### PR TITLE
RQLY-1268: fix: rules created from templates get overriden when reusing the same template

### DIFF
--- a/app/src/components/landing/ruleTemplates/RulePreviewModal/index.js
+++ b/app/src/components/landing/ruleTemplates/RulePreviewModal/index.js
@@ -11,6 +11,7 @@ import { isExtensionInstalled } from "actions/ExtensionActions";
 import { actions } from "store";
 import { trackTemplateImportCompleted } from "modules/analytics/events/features/templates";
 import { snakeCase } from "lodash";
+import { generateObjectId } from "utils/FormattingHelper";
 
 const RulePreviewModal = ({ rule, isOpen, toggle }) => {
   const navigate = useNavigate();
@@ -36,16 +37,18 @@ const RulePreviewModal = ({ rule, isOpen, toggle }) => {
     }
     const lastModifiedBy = Date.now();
     const modificationDate = Date.now();
-    ruleObj.appMode = appMode;
-    saveRule(ruleObj.appMode, dispatch, {
+    const ruleToSave = {
       ...ruleObj.ruleDefinition,
+      id: `${ruleObj.ruleDefinition.ruleType}_${generateObjectId()}`,
       createdBy,
       currentOwner,
       lastModifiedBy,
       modificationDate,
-    }).then(() => {
-      trackTemplateImportCompleted(snakeCase(ruleObj.ruleDefinition.name));
-      redirectToRuleEditor(navigate, ruleObj.ruleDefinition.id);
+    };
+
+    saveRule(appMode, dispatch, ruleToSave).then(() => {
+      trackTemplateImportCompleted(snakeCase(ruleToSave.name));
+      redirectToRuleEditor(navigate, ruleToSave.id);
     });
   };
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [x] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->