### PR TITLE
RQ-36 add sign in option in persona survey

### DIFF
--- a/app/src/components/misc/PersonaSurvey/index.css
+++ b/app/src/components/misc/PersonaSurvey/index.css
@@ -72,6 +72,3 @@
   display: flex;
   justify-content: center;
 }
-span.underline {
-  text-decoration: underline;
-}

--- a/app/src/components/misc/PersonaSurvey/index.css
+++ b/app/src/components/misc/PersonaSurvey/index.css
@@ -1,17 +1,30 @@
 .survey-modal .ant-modal-body .rq-modal-content {
   padding: 40px 20px;
 }
-.survey-modal .skip-recommendation {
+.survey-modal .skip-recommendation-wrapper {
   display: flex;
   justify-content: flex-end;
-  cursor: pointer;
+  align-items: center;
   margin-top: -30px;
   margin-left: 10px;
-  color: var(--white);
   width: 100%;
+  color: var(--text-gray);
 }
-.survey-modal .skip-recommendation:hover {
-  color: inherit;
+
+.survey-modal .skip-recommendation-btn {
+  color: var(--white);
+  padding: 5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.survey-modal .skip-recommendation-btn.persona-login-btn {
+  text-decoration: underline;
+}
+.survey-modal .skip-recommendation-btn.persona-login-btn:hover {
+  text-decoration: underline;
+}
+.survey-modal .skip-recommendation-btn:hover {
+  color: var(--white);
 }
 .survey-modal .survey-modal-border-radius {
   border-radius: var(--border-radius-md);
@@ -58,4 +71,7 @@
 .survey-modal .survey-subtitle-wrapper {
   display: flex;
   justify-content: center;
+}
+span.underline {
+  text-decoration: underline;
 }

--- a/app/src/components/misc/PersonaSurvey/index.tsx
+++ b/app/src/components/misc/PersonaSurvey/index.tsx
@@ -17,6 +17,8 @@ import {
 } from "modules/analytics/events/misc/personaSurvey";
 //@ts-ignore
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
+import APP_CONSTANTS from "config/constants";
+import { AUTH } from "modules/analytics/events/common/constants";
 import { actions } from "store";
 import "./index.css";
 
@@ -38,22 +40,63 @@ export const PersonaSurveyModal: React.FC<PersonaModalProps> = ({
   const currentPage = userPersona.page;
   const persona = userPersona.persona;
 
+  const SkippableButton = () => {
+    switch (currentPage) {
+      case surveyConfig.length - 1:
+        return (
+          <div className="skip-recommendation-wrapper">
+            <RQButton
+              type="link"
+              onClick={() => {
+                toggle();
+                dispatch(actions.updateIsPersonaSurveyCompleted(true));
+                trackPersonaRecommendationSkipped();
+              }}
+              className="white skip-recommendation-btn"
+            >
+              Skip
+            </RQButton>
+          </div>
+        );
+
+      case 0:
+        return (
+          <div className="skip-recommendation-wrapper">
+            Existing user?
+            <RQButton
+              className="skip-recommendation-btn persona-login-btn"
+              type="link"
+              onClick={() => {
+                dispatch(
+                  actions.toggleActiveModal({
+                    modalName: "authModal",
+                    newProps: {
+                      callback: () => {
+                        toggle();
+                        dispatch(actions.updateIsPersonaSurveyCompleted(true));
+                        trackPersonaRecommendationSkipped();
+                      },
+                      authMode: APP_CONSTANTS.AUTH.ACTION_LABELS.LOG_IN,
+                      eventSource: AUTH.SOURCE.PERSONA_SURVEY,
+                    },
+                  })
+                );
+              }}
+            >
+              Sign in
+            </RQButton>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
   const renderPageHeader = (page: PageConfig) => {
     return (
       <>
-        {currentPage === surveyConfig.length - 1 && (
-          <RQButton
-            type="link"
-            onClick={() => {
-              toggle();
-              dispatch(actions.updateIsPersonaSurveyCompleted(true));
-              trackPersonaRecommendationSkipped();
-            }}
-            className="white skip-recommendation"
-          >
-            Skip
-          </RQButton>
-        )}
+        <SkippableButton />
         <div className="text-center white text-bold survey-title">
           {page.title}
         </div>

--- a/app/src/components/misc/PersonaSurvey/index.tsx
+++ b/app/src/components/misc/PersonaSurvey/index.tsx
@@ -14,6 +14,7 @@ import { PageConfig } from "./types";
 import {
   trackPersonaSurveyViewed,
   trackPersonaRecommendationSkipped,
+  trackPersonaSurveySignInClicked,
 } from "modules/analytics/events/misc/personaSurvey";
 //@ts-ignore
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
@@ -42,6 +43,35 @@ export const PersonaSurveyModal: React.FC<PersonaModalProps> = ({
 
   const SkippableButton = () => {
     switch (currentPage) {
+      case 0:
+        return (
+          <div className="skip-recommendation-wrapper">
+            Existing user?
+            <RQButton
+              className="skip-recommendation-btn persona-login-btn"
+              type="link"
+              onClick={() => {
+                trackPersonaSurveySignInClicked();
+                dispatch(
+                  actions.toggleActiveModal({
+                    modalName: "authModal",
+                    newProps: {
+                      callback: () => {
+                        toggle();
+                        dispatch(actions.updateIsPersonaSurveyCompleted(true));
+                      },
+                      authMode: APP_CONSTANTS.AUTH.ACTION_LABELS.LOG_IN,
+                      eventSource: AUTH.SOURCE.PERSONA_SURVEY,
+                    },
+                  })
+                );
+              }}
+            >
+              Sign in
+            </RQButton>
+          </div>
+        );
+
       case surveyConfig.length - 1:
         return (
           <div className="skip-recommendation-wrapper">
@@ -55,35 +85,6 @@ export const PersonaSurveyModal: React.FC<PersonaModalProps> = ({
               className="white skip-recommendation-btn"
             >
               Skip
-            </RQButton>
-          </div>
-        );
-
-      case 0:
-        return (
-          <div className="skip-recommendation-wrapper">
-            Existing user?
-            <RQButton
-              className="skip-recommendation-btn persona-login-btn"
-              type="link"
-              onClick={() => {
-                dispatch(
-                  actions.toggleActiveModal({
-                    modalName: "authModal",
-                    newProps: {
-                      callback: () => {
-                        toggle();
-                        dispatch(actions.updateIsPersonaSurveyCompleted(true));
-                        trackPersonaRecommendationSkipped();
-                      },
-                      authMode: APP_CONSTANTS.AUTH.ACTION_LABELS.LOG_IN,
-                      eventSource: AUTH.SOURCE.PERSONA_SURVEY,
-                    },
-                  })
-                );
-              }}
-            >
-              Sign in
             </RQButton>
           </div>
         );

--- a/app/src/modules/analytics/events/misc/constants.js
+++ b/app/src/modules/analytics/events/misc/constants.js
@@ -79,4 +79,5 @@ export const PERSONA_SURVEY = {
   PERSONA_QUESTIONNAIRE_STARTED: "persona_questionnaire_started",
   PERSONA_RECOMMENDATION_SELECTED: "persona_recommendation_selected",
   PERSONA_RECOMMENDATION_SKIPPED: "persona_recommendation_skipped",
+  PERSONA_SURVEY_SIGN_IN_CLICKED: "persona_survey_sign_in_clicked",
 };

--- a/app/src/modules/analytics/events/misc/personaSurvey.ts
+++ b/app/src/modules/analytics/events/misc/personaSurvey.ts
@@ -32,3 +32,7 @@ export const trackPersonaRecommendationSkipped = () => {
 export const trackPersonaQuestionnaireStarted = () => {
   trackEvent(PERSONA_SURVEY.PERSONA_QUESTIONNAIRE_STARTED);
 };
+
+export const trackPersonaSurveySignInClicked = () => {
+  trackEvent(PERSONA_SURVEY.PERSONA_SURVEY_SIGN_IN_CLICKED);
+};


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:
Added a sign in option, after clicking on this , if the user logs in then the persona survey will not show up again
<img width="808" alt="Screenshot 2023-03-13 at 6 12 41 PM" src="https://user-images.githubusercontent.com/53986600/224705123-2828ab6a-b800-425c-9494-a0537bc8661e.png">

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->