### PR TITLE
#433 Modify API Response rule fails to intercept requests in few scenarios

### DIFF
--- a/browser-extension/mv2/src/background/background.js
+++ b/browser-extension/mv2/src/background/background.js
@@ -701,7 +701,7 @@ BG.Methods.overrideResponse = function (details) {
       {
         action: RQ.CLIENT_MESSAGES.OVERRIDE_RESPONSE,
         url: details.url,
-        ruleId: finalResponseRule.id,
+        rule: finalResponseRule,
       },
       { frameId: details.frameId }
     );

--- a/browser-extension/mv2/src/client/js/client.js
+++ b/browser-extension/mv2/src/client/js/client.js
@@ -3,25 +3,14 @@
     return;
   }
 
-  chrome.runtime.sendMessage(
-    {
-      action: RQ.EXTENSION_MESSAGES.CHECK_IF_EXTENSION_ENABLED,
-    },
-    (isExtensionEnabled) => {
-      if (!isExtensionEnabled) {
-        return;
-      }
+  RQ.ConsoleLogger.setup();
+  RQ.RuleExecutionHandler.setup();
+  RQ.ScriptRuleHandler.setup();
+  RQ.SessionRecorder.setup();
+  RQ.UserAgentRuleHandler.setup();
+  RQ.RequestResponseRuleHandler.setup();
 
-      RQ.ConsoleLogger.setup();
-      RQ.RuleExecutionHandler.setup();
-      RQ.ScriptRuleHandler.setup();
-      RQ.SessionRecorder.setup();
-      RQ.UserAgentRuleHandler.setup();
-      RQ.RequestResponseRuleHandler.setup();
-
-      chrome.runtime.sendMessage({
-        action: RQ.CLIENT_MESSAGES.NOTIFY_CONTENT_SCRIPT_LOADED,
-      });
-    }
-  );
+  chrome.runtime.sendMessage({
+    action: RQ.CLIENT_MESSAGES.NOTIFY_CONTENT_SCRIPT_LOADED,
+  });
 })();


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: [<!-- Link to Github issue -->](https://github.com/requestly/requestly/issues/433)

## 📜 Summary of changes:

- The client content script will not query the response rule from ID directly, but the data will be passed down from background script. It saves an async storage request in client.
- The client content script will not check for extension status during initialization. This check used to delay the setup of different rule handlers. It will now be checked in individual flows while execution.

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->