### PR TITLE
remove the curl button from request log pane and shift the close button to the right in RequestlogPane

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/FixedRequestLogPane.js
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/FixedRequestLogPane.js
@@ -27,19 +27,15 @@ const Header = (props) => {
   return (
     <Row className="request-log-pane-header" align="middle" wrap={false}>
       <Space>
-        <div style={{ display: "flex", marginLeft: "4px", cursor: "pointer" }}>
-          <CloseOutlined onClick={props.handleClosePane} style={{ alignSelf: "center", margin: "0" }} />
-        </div>
         <Badge count={props.method} style={{ backgroundColor: "grey" }} />
         <Badge overflowCount={699} count={props.statusCode} style={{ backgroundColor: "#87d068" }} />
         <Text ellipsis={{ tooltip: props.url }} className="request-log-pane-url">
           {props.url}
         </Text>
+        <div style={{ display: "flex", marginLeft: "auto", cursor: "pointer" }}>
+          <CloseOutlined onClick={props.handleClosePane} style={{ alignSelf: "center", margin: "0" }} />
+        </div>
       </Space>
-
-      <Col className="ml-auto">
-        <CopyCurlButton requestShellCurl={props.requestShellCurl} />
-      </Col>
     </Row>
   );
 };

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/FixedRequestLogPane.js
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/FixedRequestLogPane.js
@@ -32,10 +32,12 @@ const Header = (props) => {
         <Text ellipsis={{ tooltip: props.url }} className="request-log-pane-url">
           {props.url}
         </Text>
-        <div style={{ display: "flex", marginLeft: "auto", cursor: "pointer" }}>
+      </Space>
+      <Col className="ml-auto">
+        <div style={{ display: "flex", marginLeft: "15px", cursor: "pointer" }}>
           <CloseOutlined onClick={props.handleClosePane} style={{ alignSelf: "center", margin: "0" }} />
         </div>
-      </Space>
+      </Col>
     </Row>
   );
 };


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->
@tarunsamanta2k20 
Closes issue: <!-- Link to Github issue -->
#623 
#626
## 📜 Summary of changes:
1. Remove 'Copy cURL' button from top left of the Request pane in Traffic Table.
2. bug: Close button should be on the top right of the request pane in the traffic inspector

 
![image](https://github.com/requestly/requestly/assets/55488549/2531c8c7-b7fa-40fc-b529-4fff2e3e273a)

<!-- Summarize your changes -->

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [x] Verified UI in browser.
- [x] For UI changes, added/updated analytics events (if applicable).
- [x] For changes in extension's code, manually tested in Chrome and Firefox.
- [x] For changes in extension's code, both MV2 and MV3 are covered.
- [x] Added/updated unit tests for this change.
- [x] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->