### PR TITLE
chore: add documentation link in header

### DIFF
--- a/app/src/layouts/DashboardLayout/MenuHeader/index.js
+++ b/app/src/layouts/DashboardLayout/MenuHeader/index.js
@@ -7,14 +7,15 @@ import HeaderText from "./HeaderText";
 // import LINKS from "config/constants/sub/links";
 import RulesSyncToggle from "../../../components/sections/Navbars/NavbarRightContent/RulesSyncToggle";
 import { isPricingPage, isGoodbyePage, isInvitePage } from "utils/PathUtils";
-import { NotificationOutlined, SlackOutlined } from "@ant-design/icons";
-import { redirectToSettings, redirectToProductUpdates } from "utils/RedirectionUtils";
+import { NotificationOutlined, ReadOutlined, SlackOutlined } from "@ant-design/icons";
+import { redirectToSettings, redirectToProductUpdates, redirectToUrl } from "utils/RedirectionUtils";
 import { RQBreadcrumb } from "lib/design-system/components";
 import GitHubButton from "react-github-btn";
 import { useMediaQuery } from "react-responsive";
 import { ReactComponent as Settings } from "assets/icons/settings.svg";
 import { trackHeaderClicked } from "modules/analytics/events/common/onboarding/header";
 import "./MenuHeader.css";
+import LINKS from "config/constants/sub/links";
 
 const { Header } = Layout;
 
@@ -175,6 +176,21 @@ const MenuHeader = ({ setVisible, setCollapsed }) => {
                       <Button type="text" className="header-icon-btn" icon={<QuestionCircleOutlined />} />
                     </Dropdown>
                   </Col> */}
+
+                  {/* documentation */}
+                  <Col className="hidden-on-small-screen">
+                    <Tooltip title={<span className="text-gray text-sm">Documentation</span>}>
+                      <Button
+                        type="text"
+                        className="header-icon-btn"
+                        icon={<ReadOutlined />}
+                        onClick={() => {
+                          trackHeaderClicked("documentation");
+                          redirectToUrl(LINKS.REQUESTLY_DOCS, true);
+                        }}
+                      />
+                    </Tooltip>
+                  </Col>
 
                   {/* product updates */}
                   <Col className="hidden-on-small-screen">


### PR DESCRIPTION
<img width="263" alt="Screenshot 2023-05-31 at 10 34 32 AM" src="https://github.com/requestly/requestly/assets/57226514/765fba9a-925c-4aaa-8ff0-ae6a1df1fe0a">
