### PR TITLE
fix: button colors in the signup popover

### DIFF
--- a/app/src/components/features/mocksV2/MockList/GettingStartedWithMocks/index.tsx
+++ b/app/src/components/features/mocksV2/MockList/GettingStartedWithMocks/index.tsx
@@ -1,10 +1,10 @@
+import { Col, Row } from "antd";
+import { AuthConfirmationPopover } from "components/hoc/auth/AuthConfirmationPopover";
+import { RQButton } from "lib/design-system/components";
 import React from "react";
 import { useSelector } from "react-redux";
-import { Row, Col } from "antd";
-import { RQButton } from "lib/design-system/components";
-import { MockType } from "../../types";
 import { getUserAuthDetails } from "store/selectors";
-import { AuthConfirmationPopover } from "components/hoc/auth/AuthConfirmationPopover";
+import { MockType } from "../../types";
 
 import { AiOutlineCloudUpload, AiOutlineQuestionCircle } from "react-icons/ai";
 import { FiArrowUpRight } from "react-icons/fi";

--- a/app/src/components/hoc/auth/AuthConfirmationPopover/index.js
+++ b/app/src/components/hoc/auth/AuthConfirmationPopover/index.js
@@ -1,14 +1,14 @@
-import { useRef } from "react";
-import { actions } from "store";
-import { useSelector, useDispatch } from "react-redux";
-import { getUserAuthDetails } from "store/selectors";
 import { Popconfirm } from "antd";
 import APP_CONSTANTS from "config/constants";
 import {
-  trackPopoverForAuthShown,
-  trackPopoverForAuthContinued,
   trackPopoverForAuthCancelled,
+  trackPopoverForAuthContinued,
+  trackPopoverForAuthShown,
 } from "modules/analytics/events/common/auth/authPopover";
+import { useRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { actions } from "store";
+import { getUserAuthDetails } from "store/selectors";
 
 import "./popover.scss";
 
@@ -52,6 +52,7 @@ export const AuthConfirmationPopover = ({
     <Popconfirm
       title={title}
       okText={okText}
+      okButtonProps={{ type: "primary" }}
       cancelText={cancelText}
       icon={null}
       disabled={user?.details?.isLoggedIn || disabled}

--- a/app/src/components/hoc/auth/AuthConfirmationPopover/popover.scss
+++ b/app/src/components/hoc/auth/AuthConfirmationPopover/popover.scss
@@ -10,16 +10,14 @@
   & .ant-popover-buttons {
     text-align: left;
   }
-  & .ant-btn-default,
-  & .ant-btn-primary {
+  & .ant-btn-default {
     border: 0;
     background: var(--hover-color);
     color: var(--white);
     padding: 2px 6px;
   }
-  & .ant-btn-default:hover,
-  & .ant-btn-primary:hover {
-    background: var(--primary);
+  & .ant-btn-default:hover {
+    background: var(--hover-color);
     color: var(--white);
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: https://github.com/requestly/requestly/issues/625

## 📜 Summary of changes:

- I had to add the prop called `okButtonProps` and set its value to `{{ type: "primary" }}`. This is a prop of the `Popconfirm` component that lives inside the `AuthConfirmationPopover`.
- I also adjusted the `popover.scss` file. I had to change a couple of styles there.
- Additional changes are coming from my prettier configuration (sorted imports).

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [x] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->