### PR TITLE
fix: Share CTA Typo fixed from "Copy Text" to "Copy Link"

### DIFF
--- a/app/src/components/features/sharedLists/CreateSharedListModal/index.js
+++ b/app/src/components/features/sharedLists/CreateSharedListModal/index.js
@@ -176,7 +176,7 @@ const CreateSharedListModal = (props) => {
   };
 
   const renderPostConfirmationFooter = () => {
-    return isSharedListCreated ? <CopyButton copyText={sharedListURL} type="primary" title={"Copy Text"} /> : null;
+    return isSharedListCreated ? <CopyButton copyText={sharedListURL} type="primary" title={"Copy Link"} /> : null;
   };
 
   const handleVisibilityChange = (e) => {


### PR DESCRIPTION
Closes issue: https://github.com/requestly/requestly/issues/624

## 📜 Summary of changes: Fixed the Typo of the CTA share button content from "Copy Text" to "Copy Link".

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
