### PR TITLE
bugfix-reduced the 'created by' column width

### DIFF
--- a/app/src/components/features/rules/RulesListContainer/RulesTable/index.js
+++ b/app/src/components/features/rules/RulesListContainer/RulesTable/index.js
@@ -912,6 +912,7 @@ const RulesTable = ({
     columns.splice(3, 0, {
       title: "Created by",
       align: "center",
+      width: "120px",
       responsive: ["lg"],
       dataIndex: "createdBy",
       valueType: "date",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: #691 
## 📜 Summary of changes:
 - Reduced the width of the 'created by' column on the rules table to inactive the horizontal scroll bar.
<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [x] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->
- The change works best for the screen size over 1436px ~ 1440px. If the size is less than 1436px, the horizontal scroll bar will be active.

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->