### PR TITLE
chore: show connect app modal on start if user has never connected any traffic source

### DIFF
--- a/app/src/components/mode-specific/desktop/MySources/Sources/index.js
+++ b/app/src/components/mode-specific/desktop/MySources/Sources/index.js
@@ -108,6 +108,7 @@ const Sources = ({ isOpen, toggle, ...props }) => {
                 value: true,
               })
             );
+            dispatch(actions.updateHasConnectedApp(true));
             trackAppConnectedEvent(getAppName(appId), getAppCount() + 1, getAppType(appId));
             toggle();
 

--- a/app/src/hooks/AppModeInitializer.js
+++ b/app/src/hooks/AppModeInitializer.js
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { actions } from "../store";
 // UTILS
-import { getAppMode, getDesktopSpecificDetails, getUserAuthDetails } from "../store/selectors";
+import { getAppMode, getDesktopSpecificDetails, getHasConnectedApp, getUserAuthDetails } from "../store/selectors";
 // CONSTANTS
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
 // ACTIONS
@@ -46,7 +46,8 @@ const AppModeInitializer = () => {
   const appMode = useSelector(getAppMode);
   const user = useSelector(getUserAuthDetails);
   const currentlyActiveWorkspace = useSelector(getCurrentlyActiveWorkspace);
-  const { appsList, isBackgroundProcessActive } = useSelector(getDesktopSpecificDetails);
+  const { appsList, isBackgroundProcessActive, isProxyServerRunning } = useSelector(getDesktopSpecificDetails);
+  const hasConnectedAppBefore = useSelector(getHasConnectedApp);
 
   const appsListRef = useRef(null);
   const hasMessageHandlersBeenSet = useRef(false);
@@ -143,6 +144,12 @@ const AppModeInitializer = () => {
       trackDesktopAppStartedEvent();
     }
   }, [appMode]);
+
+  useEffect(() => {
+    if (isProxyServerRunning && appMode === GLOBAL_CONSTANTS.APP_MODES.DESKTOP && !hasConnectedAppBefore) {
+      dispatch(actions.toggleActiveModal({ modalName: "connectedAppsModal" }));
+    }
+  }, [appMode, dispatch, hasConnectedAppBefore, isProxyServerRunning]);
 
   // Set app mode to "DESKTOP" if required. Default is "EXTENSION"
   useEffect(() => {

--- a/app/src/store/features/appModeSpecificActions.js
+++ b/app/src/store/features/appModeSpecificActions.js
@@ -30,5 +30,5 @@ export const updateDesktopSpecificAppProperty = (prevState, action) => {
 };
 
 export const updateHasConnectedApp = (prevState, action) => {
-  prevState.hasConnectedApp = action.payload;
+  prevState.misc.persist.hasConnectedApp = action.payload;
 };

--- a/app/src/store/features/appModeSpecificActions.js
+++ b/app/src/store/features/appModeSpecificActions.js
@@ -28,3 +28,7 @@ export const updateDesktopSpecificAppProperty = (prevState, action) => {
 
   prevState.desktopSpecificDetails.appsList[appId][property] = value;
 };
+
+export const updateHasConnectedApp = (prevState, action) => {
+  prevState.hasConnectedApp = action.payload;
+};

--- a/app/src/store/index.js
+++ b/app/src/store/index.js
@@ -40,6 +40,7 @@ const globalReducer = getReducerWithLocalStorageSync("root", globalSlice.reducer
   "appTheme",
   // "rules",
   // "desktopSpecificDetails.appsList",
+  "hasConnectedApp",
   "userPersona",
   "country",
   "mobileDebugger",

--- a/app/src/store/initial-state/index.js
+++ b/app/src/store/initial-state/index.js
@@ -10,8 +10,6 @@ const INITIAL_STATE = {
     details: null,
   },
 
-  hasConnectedApp: false,
-
   userPersona: {
     page: 0,
     persona: "",
@@ -162,6 +160,8 @@ const INITIAL_STATE = {
       isConnectedAppsTourCompleted: false,
       isNetworkSessionTooltipShown: false,
       isRuleEditorTourCompleted: false,
+
+      hasConnectedApp: false,
     },
     nonPersist: {
       networkSessionSaveInProgress: false,

--- a/app/src/store/initial-state/index.js
+++ b/app/src/store/initial-state/index.js
@@ -10,6 +10,8 @@ const INITIAL_STATE = {
     details: null,
   },
 
+  hasConnectedApp: false,
+
   userPersona: {
     page: 0,
     persona: "",

--- a/app/src/store/selectors.js
+++ b/app/src/store/selectors.js
@@ -162,6 +162,10 @@ export const getActiveModals = (state) => {
   return getGlobalState(state)["activeModals"];
 };
 
+export const getHasConnectedApp = (state) => {
+  return getGlobalState(state)["hasConnectedApp"];
+};
+
 export const getMarketplaceRuleStatus = (state) => {
   return getGlobalState(state)["marketplace"]["ruleStatus"];
 };

--- a/app/src/store/selectors.js
+++ b/app/src/store/selectors.js
@@ -163,7 +163,7 @@ export const getActiveModals = (state) => {
 };
 
 export const getHasConnectedApp = (state) => {
-  return getGlobalState(state)["hasConnectedApp"];
+  return getGlobalState(state).misc?.persist?.hasConnectedApp;
 };
 
 export const getMarketplaceRuleStatus = (state) => {


### PR DESCRIPTION
Adds a persistent `hasConnectedApp` key to the global slice.

The modal is shown once the proxy has started.



https://github.com/requestly/requestly/assets/57226514/2bc9cda6-b67e-4e12-9434-080c989bec0d

