### PR TITLE
fix: refresh button clipping in execution logs

### DIFF
--- a/app/src/components/features/rules/RuleEditorSplitPane/ExecutionLogs.js
+++ b/app/src/components/features/rules/RuleEditorSplitPane/ExecutionLogs.js
@@ -97,7 +97,7 @@ const ExecutionLogs = () => {
     <>
       <Skeleton loading={isLoading}>
         <Row align="middle" justify="space-between" style={{ paddingBottom: "6px" }}>
-          <Col span={2} xxl={{ pull: 0 }} lg={{ pull: 1 }} sm={{ pull: 2 }}>
+          <Col span={2}>
             <Button onClick={handleRefreshBtnOnClick} type="default" icon={<SyncOutlined />}>
               Refresh
             </Button>


### PR DESCRIPTION
Before:
<img width="434" alt="refresh-before" src="https://github.com/requestly/requestly/assets/57226514/9812d47e-9af0-4b68-afeb-729e63bd993e">

After:
<img width="479" alt="refresh-after" src="https://github.com/requestly/requestly/assets/57226514/ed33d846-8a20-4e31-9194-c4a91d21cef7">
