### PR TITLE
[RQ-564] fix: wrong message when header rule condition incomplete

### DIFF
--- a/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/actions/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/actions/index.js
@@ -92,14 +92,19 @@ export const validateRule = (rule, dispatch, appMode) => {
   //Headers Rule
   else if (rule.ruleType === GLOBAL_CONSTANTS.RULE_TYPES.HEADERS) {
     if (rule.version > 1) {
-      rule.pairs.forEach((pair) => {
+      rule.pairs.every((pair, index) => {
         if (pair.modifications.Request?.length === 0 && pair.modifications.Response?.length === 0) {
           output = {
             result: false,
             message: `Please add atleast one modification to the rule.`,
             error: "missing modification",
           };
+
+          if (index > 0) {
+            output.message = `One of the rule conditions is empty. Please add some header modification to the rule condition.`;
+          }
         }
+
         // Iterate over request headers
         pair.modifications.Request?.forEach((modification) => {
           //Header name shouldn't be empty
@@ -139,6 +144,12 @@ export const validateRule = (rule, dispatch, appMode) => {
             };
           }
         });
+
+        if (output?.result === false) {
+          return false;
+        } else {
+          return true;
+        }
       });
     } else {
       rule.pairs.forEach((pair) => {

--- a/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/actions/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/actions/index.js
@@ -96,13 +96,12 @@ export const validateRule = (rule, dispatch, appMode) => {
         if (pair.modifications.Request?.length === 0 && pair.modifications.Response?.length === 0) {
           output = {
             result: false,
-            message: `Please add atleast one modification to the rule.`,
+            message:
+              index > 0
+                ? `One of the rule conditions is empty. Please add some header modification to the condition.`
+                : `Please add atleast one modification to the rule.`,
             error: "missing modification",
           };
-
-          if (index > 0) {
-            output.message = `One of the rule conditions is empty. Please add some header modification to the rule condition.`;
-          }
         }
 
         // Iterate over request headers


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->
Please find the recording for the changes: https://app.requestly.io/sessions/saved/pPlEOoKkJjxTmhMj3jl8


## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [x] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->