### PR TITLE
RQ-641 Show extension context invalidation notice in App

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -21,6 +21,7 @@ import RuleExecutionsSyncer from "hooks/RuleExecutionsSyncer";
 import FeatureUsageEvent from "hooks/FeatureUsageEvent";
 import ActiveWorkspace from "hooks/ActiveWorkspace";
 import AuthHandler from "hooks/AuthHandler";
+import ExtensionContextInvalidationNotice from "components/misc/ExtensionContextInvalidationNotice";
 
 const { PATHS } = APP_CONSTANTS;
 
@@ -57,6 +58,7 @@ const App = () => {
 
   return (
     <>
+      <ExtensionContextInvalidationNotice />
       <AuthHandler />
       <PreLoadRemover />
       <AppModeInitializer />

--- a/app/src/actions/FirebaseActions.js
+++ b/app/src/actions/FirebaseActions.js
@@ -126,7 +126,7 @@ export async function signUp(name, email, password, refCode, source) {
       })
         .then(() => {
           const functions = getFunctions();
-          const addUserToCRM = httpsCallable(functions, "addUserToCRM");
+          const addUserToCRM = httpsCallable(functions, "internal-addUserToCRM");
           addUserToCRM({});
           const authData = getAuthData(result.user);
           const database = getDatabase();

--- a/app/src/actions/FirebaseActions.js
+++ b/app/src/actions/FirebaseActions.js
@@ -126,7 +126,7 @@ export async function signUp(name, email, password, refCode, source) {
       })
         .then(() => {
           const functions = getFunctions();
-          const addUserToCRM = httpsCallable(functions, "internal-addUserToCRM");
+          const addUserToCRM = httpsCallable(functions, "addUserToCRM");
           addUserToCRM({});
           const authData = getAuthData(result.user);
           const database = getDatabase();

--- a/app/src/components/misc/ExtensionContextInvalidationNotice/extensionContextInvalidationNotice.scss
+++ b/app/src/components/misc/ExtensionContextInvalidationNotice/extensionContextInvalidationNotice.scss
@@ -1,0 +1,13 @@
+#extension-context-invalidation-notice {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  height: 48px;
+  width: 100vw;
+  background: #3700b3;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+}

--- a/app/src/components/misc/ExtensionContextInvalidationNotice/index.tsx
+++ b/app/src/components/misc/ExtensionContextInvalidationNotice/index.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from "react";
+import { Typography } from "antd";
+import { trackExtensionContextInvalidated } from "modules/analytics/events/misc/extensionContextInvalidation";
+import "./extensionContextInvalidationNotice.scss";
+
+const ExtensionContextInvalidationNotice: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    window.addEventListener("message", (event) => {
+      if (event.data?.event === "requestly:extensionUpdated") {
+        setVisible(true);
+        trackExtensionContextInvalidated(event.data.oldVersion, event.data.newVersion);
+      }
+    });
+  }, []);
+
+  return visible ? (
+    <div id="extension-context-invalidation-notice">
+      <Typography.Text>
+        The browser extension was updated in the background. Please save your work and&nbsp;
+      </Typography.Text>
+      <Typography.Link onClick={() => window.location.reload()}>Reload</Typography.Link>
+      <Typography.Text>&nbsp;the page to avoid errors.</Typography.Text>
+    </div>
+  ) : null;
+};
+
+export default ExtensionContextInvalidationNotice;

--- a/app/src/components/misc/ExtensionContextInvalidationNotice/index.tsx
+++ b/app/src/components/misc/ExtensionContextInvalidationNotice/index.tsx
@@ -1,18 +1,22 @@
 import React, { useEffect, useState } from "react";
 import { Typography } from "antd";
 import { trackExtensionContextInvalidated } from "modules/analytics/events/misc/extensionContextInvalidation";
+import PageScriptMessageHandler from "config/PageScriptMessageHandler";
+// @ts-ignore
+import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
 import "./extensionContextInvalidationNotice.scss";
 
 const ExtensionContextInvalidationNotice: React.FC = () => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    window.addEventListener("message", (event) => {
-      if (event.data?.event === "requestly:extensionUpdated") {
+    PageScriptMessageHandler.addMessageListener(
+      GLOBAL_CONSTANTS.EXTENSION_MESSAGES.NOTIFY_EXTENSION_UPDATED,
+      ({ oldVersion, newVersion }: { oldVersion: string; newVersion: string }) => {
         setVisible(true);
-        trackExtensionContextInvalidated(event.data.oldVersion, event.data.newVersion);
+        trackExtensionContextInvalidated(oldVersion, newVersion);
       }
-    });
+    );
   }, []);
 
   return visible ? (

--- a/app/src/config/PageScriptMessageHandler.js
+++ b/app/src/config/PageScriptMessageHandler.js
@@ -6,10 +6,8 @@ const PageScriptMessageHandler = {
   requestId: 1,
 
   constants: {
-    CONTENT_SCRIPT: "content_script",
-    PAGE_SCRIPT: "page_script",
+    SOURCE: "page_script",
     DOMAIN: window.location.origin,
-    SOURCE_FIELD: "source",
   },
 
   addMessageListener: function (messageAction, listener) {
@@ -18,10 +16,6 @@ const PageScriptMessageHandler = {
 
   removeMessageListener: function (messageName) {
     delete this.messageListeners[messageName];
-  },
-
-  getSource: function () {
-    return this.constants.PAGE_SCRIPT;
   },
 
   registerCallback: function (message, callback) {
@@ -51,7 +45,7 @@ const PageScriptMessageHandler = {
 
     this.registerCallback(message, callback);
 
-    message[this.constants.SOURCE_FIELD] = this.getSource();
+    message.source = this.constants.SOURCE;
     window.postMessage(message, this.constants.DOMAIN);
   },
 
@@ -62,7 +56,7 @@ const PageScriptMessageHandler = {
       response: response,
     };
 
-    message[this.constants.SOURCE_FIELD] = this.constants.PAGE_SCRIPT;
+    message.source = this.constants.SOURCE;
     window.postMessage(message, this.constants.DOMAIN);
   },
 
@@ -73,13 +67,10 @@ const PageScriptMessageHandler = {
       return;
     }
 
-    if (event && event.data && event.data.source === this.constants.CONTENT_SCRIPT) {
+    if (event?.data?.source !== this.constants.SOURCE) {
       Logger.log("Received message:", event.data);
 
-      if (
-        event.data.requestId &&
-        this.eventCallbackMap.hasOwnProperty(`${event.data.action}_${event.data.requestId}`)
-      ) {
+      if (event.data.requestId && this.eventCallbackMap[`${event.data.action}_${event.data.requestId}`]) {
         this.invokeCallback(event.data);
       } else {
         this.messageHandler(event.data);

--- a/app/src/modules/analytics/events/misc/constants.js
+++ b/app/src/modules/analytics/events/misc/constants.js
@@ -19,6 +19,8 @@ export const UNINSTALLATION = {
   EXTENSION_UNINSTALLED: "extension_uninstalled",
 };
 
+export const EXTENSION_CONTEXT_INVALIDATED = "extension_context_invalidated";
+
 export const ORGANIZATION = {
   VIEW_MORE_USERS_CLICKED: "organization_view_more_users_clicked",
   PAGE_VIEWED: "organization_my_org_page_viewed",

--- a/app/src/modules/analytics/events/misc/extensionContextInvalidation.ts
+++ b/app/src/modules/analytics/events/misc/extensionContextInvalidation.ts
@@ -1,0 +1,6 @@
+import { trackEvent } from "modules/analytics";
+import { EXTENSION_CONTEXT_INVALIDATED } from "./constants";
+
+export const trackExtensionContextInvalidated = (oldVersion: string, newVersion: string) => {
+  trackEvent(EXTENSION_CONTEXT_INVALIDATED, { oldVersion, newVersion });
+};

--- a/browser-extension/mv2/src/background/background.js
+++ b/browser-extension/mv2/src/background/background.js
@@ -874,6 +874,18 @@ BG.Methods.handleExtensionInstalledOrUpdated = function (details) {
     if (shouldOpenUpdatesPage) {
       chrome.tabs.create({ url: RQ.CONSTANTS.UPDATES_PAGE_URL });
     }
+
+    BG.Methods.getAppTabs().then((tabs) => {
+      tabs.forEach((tab) => {
+        chrome.tabs.executeScript(tab.id, {
+          code: `window.postMessage({
+            event: "requestly:extensionUpdated",
+            oldVersion: "${details.previousVersion}",
+            newVersion: "${chrome.runtime.getManifest().version}"
+          }, "*")`,
+        });
+      });
+    });
   }
 
   Logger.log("Requestly: " + details.reason);

--- a/browser-extension/mv2/src/background/background.js
+++ b/browser-extension/mv2/src/background/background.js
@@ -879,7 +879,7 @@ BG.Methods.handleExtensionInstalledOrUpdated = function (details) {
       tabs.forEach((tab) => {
         chrome.tabs.executeScript(tab.id, {
           code: `window.postMessage({
-            event: "requestly:extensionUpdated",
+            action: "${RQ.EXTENSION_MESSAGES.NOTIFY_EXTENSION_UPDATED}",
             oldVersion: "${details.previousVersion}",
             newVersion: "${chrome.runtime.getManifest().version}"
           }, "*")`,

--- a/common/constants.js
+++ b/common/constants.js
@@ -144,6 +144,7 @@ CONSTANTS.EXTENSION_MESSAGES = {
   NOTIFY_APP_LOADED: "notifyAppLoaded",
   NOTIFY_RECORD_UPDATED: "notifyRecordUpdated",
   START_RECORDING_ON_URL: "startRecordingOnUrl",
+  NOTIFY_EXTENSION_UPDATED: "notifyExtensionUpdated",
 };
 
 CONSTANTS.HEADERS_TARGET = {


### PR DESCRIPTION

<img width="1512" alt="image" src="https://github.com/requestly/requestly/assets/6367566/fa2143d7-7207-41f6-9cc7-53a740d174b5">


## 📜 Summary of changes:

On extension update, background will notify all App tabs and App will show a sticky message on top.

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->