### PR TITLE
[RQ-643] fix: autofixer not working properly in case of bad regex

### DIFF
--- a/app/src/components/common/TestURLModal/index.tsx
+++ b/app/src/components/common/TestURLModal/index.tsx
@@ -4,7 +4,7 @@ import { RQButton, RQModal } from "lib/design-system/components";
 import { SourceConditionInput } from "../SourceUrl";
 import { Typography, Divider, Row, Input } from "antd";
 import { CheckCircleOutlined, InfoCircleOutlined, CloseCircleOutlined } from "@ant-design/icons";
-import { isRegexFormat } from "utils/rules/misc";
+import { isValidRegex } from "utils/rules/misc";
 import { isValidUrl } from "utils/FormattingHelper";
 import { isEqual } from "lodash";
 import { SourceOperator } from "types";
@@ -57,7 +57,7 @@ export const TestURLModal: React.FC<ModalProps> = ({ isOpen, source, analyticsCo
   }, [matchedGroups, updatedSource.operator]);
 
   const renderResult = useCallback(() => {
-    if (updatedSource.operator === SourceOperator.MATCHES && !isRegexFormat(updatedSource.value)) {
+    if (updatedSource.operator === SourceOperator.MATCHES && !isValidRegex(updatedSource.value)) {
       return (
         <>
           <CloseCircleOutlined className="danger" />


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

For RegEx matching rule, I noticed that upon save, the pattern string was auto-added the trailing ‘/’.
E.g.
Input > /test/ig
After save > /test/ig/


## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->