### PR TITLE
chore: add event for session onboarding start

### DIFF
--- a/app/src/modules/analytics/events/features/constants.js
+++ b/app/src/modules/analytics/events/features/constants.js
@@ -22,7 +22,8 @@ export const SESSION_RECORDING = {
   session_recording_panel_sample_session_clicked: "session_recording_panel_sample_session_clicked",
 
   ONBAORDING: {
-    youtube_link_clicked: "session_onboarding_youtube_link_clicked",
+    onboarding_page_viewed: "session_onboarding_page_viewed",
+    sample_session_viewed: "sample_session_viewed",
     start_recording_clicked: "start_recording_btn_clicked",
     invalid_recording_url: "invalid_recording_url_entered",
     navigate_to_target_website: "navigated_to_recording_target",

--- a/app/src/modules/analytics/events/features/sessionRecording/index.js
+++ b/app/src/modules/analytics/events/features/sessionRecording/index.js
@@ -91,7 +91,8 @@ export const trackSampleSessionClicked = (log_type) => {
 };
 
 /* ONBOARDING */
-export const trackOnboardingYTVideoClicked = () => trackEvent(SESSION_RECORDING.ONBAORDING.youtube_link_clicked);
+export const trackOnboardingPageViewed = () => trackEvent(SESSION_RECORDING.ONBAORDING.onboarding_page_viewed);
+export const trackOnboardingSampleSessionViewed = () => trackEvent(SESSION_RECORDING.ONBAORDING.sample_session_viewed);
 export const trackStartRecordingWithURLClicked = () => trackEvent(SESSION_RECORDING.ONBAORDING.start_recording_clicked);
 export const trackOnboardingToSettingsNavigate = () => trackEvent(SESSION_RECORDING.ONBAORDING.navigated_to_settings);
 export const trackStartRecordingOnExternalTarget = (url) => {

--- a/app/src/views/features/sessions/SessionsIndexPageContainer/SessionsIndexPage/OnboardingView.tsx
+++ b/app/src/views/features/sessions/SessionsIndexPageContainer/SessionsIndexPage/OnboardingView.tsx
@@ -1,7 +1,7 @@
 import { CheckOutlined, SettingOutlined, YoutubeFilled } from "@ant-design/icons";
 import { BsShieldCheck } from "react-icons/bs";
 import { Button, Divider, Input, Row, Col, Typography, InputRef } from "antd";
-import React, { useState, useCallback, useRef } from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import { actions } from "store";
 import HarImportModal from "components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/HarImportModal";
 import { redirectToNetworkSession } from "utils/RedirectionUtils";
@@ -13,7 +13,8 @@ import { getUserAuthDetails } from "store/selectors";
 import {
   trackInstallExtensionDialogShown,
   trackOnboardingToSettingsNavigate,
-  trackOnboardingYTVideoClicked,
+  trackOnboardingSampleSessionViewed,
+  trackOnboardingPageViewed,
   trackStartRecordingOnExternalTarget,
   trackStartRecordingWithURLClicked,
   trackTriedRecordingForInvalidURL,
@@ -193,6 +194,10 @@ const SessionOnboardingView: React.FC<SessionOnboardProps> = ({ redirectToSettin
   const inputRef = useRef<InputRef>();
   const dispatch = useDispatch();
 
+  useEffect(() => {
+    trackOnboardingPageViewed();
+  }, []);
+
   const openInstallExtensionModal = useCallback(() => {
     const modalProps = {
       heading: "Install Browser extension to record sessions for faster debugging and bug reporting",
@@ -285,7 +290,7 @@ const SessionOnboardingView: React.FC<SessionOnboardProps> = ({ redirectToSettin
           <Row justify="end">
             <img src={StartSessionRecordingGif} alt="How to start session recording" className="demo-video" />
           </Row>
-          <Row onClick={trackOnboardingYTVideoClicked}>
+          <Row onClick={trackOnboardingSampleSessionViewed}>
             <a
               href="https://app.requestly.io/sessions/saved/24wBYgAaKlgqCOflTTJj"
               target="__blank"


### PR DESCRIPTION
adds `session_onboarding_page_viewed` for when session onboarding starts
rename sample recording viewed event to `sample_session_viewed`