### PR TITLE
[RQ-653] fix: prevent rrweb inputs from getting focus

### DIFF
--- a/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
+++ b/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
@@ -66,6 +66,7 @@ const SessionDetails: React.FC = () => {
             width: playerContainer.current.clientWidth,
             height: 400,
             autoPlay: true,
+            triggerFocus: false,
           },
         })
       );

--- a/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
+++ b/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
@@ -66,6 +66,9 @@ const SessionDetails: React.FC = () => {
             width: playerContainer.current.clientWidth,
             height: 400,
             autoPlay: true,
+            // prevents elements inside rrweb-player to steal focus
+            // The elements inside the player were stealing the focus from the inputs in the session viewer pages
+            // The drawback is that it doesn't allow the focus styles to be applied: https://github.com/rrweb-io/rrweb/issues/876
             triggerFocus: false,
           },
         })


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->