### PR TITLE
RQ-686 Bug: Extension icon does not show session recording state on Browser back

### DIFF
--- a/browser-extension/mv2/src/client/js/client.js
+++ b/browser-extension/mv2/src/client/js/client.js
@@ -17,4 +17,17 @@
       isIframe: window.top !== window,
     },
   });
+
+  window.addEventListener("pageshow", (event) => {
+    if (event.persisted) {
+      chrome.runtime.sendMessage({
+        action: RQ.CLIENT_MESSAGES.NOTIFY_PAGE_LOADED_FROM_CACHE,
+        payload: {
+          isIframe: window.top !== window,
+          hasExecutedRules: RQ.RuleExecutionHandler.hasExecutedRules(),
+          isRecordingSession: RQ.SessionRecorder.isRecording,
+        },
+      });
+    }
+  });
 })();

--- a/browser-extension/mv2/src/client/js/ruleExecutionHandler.js
+++ b/browser-extension/mv2/src/client/js/ruleExecutionHandler.js
@@ -54,3 +54,7 @@ RQ.RuleExecutionHandler.syncCachedAppliedRules = (appliedRuleDetails, isConsoleL
     });
   });
 };
+
+RQ.RuleExecutionHandler.hasExecutedRules = () => {
+  return RQ.RuleExecutionHandler.appliedRuleIds.size > 0;
+};

--- a/browser-extension/mv2/src/shared/constants.js
+++ b/browser-extension/mv2/src/shared/constants.js
@@ -43,5 +43,6 @@ RQ.CLIENT_MESSAGES = {
   IS_EXPLICIT_RECORDING_SESSION: "isExplicitRecordingSession",
   SYNC_APPLIED_RULES: "syncAppliedRules",
   NOTIFY_CONTENT_SCRIPT_LOADED: "notifyContentScriptLoaded",
+  NOTIFY_PAGE_LOADED_FROM_CACHE: "notifyPageLoadedFromCache",
   NOTIFY_RECORD_UPDATED_IN_POPUP: "notifyRecordUpdatedInPopup",
 };


### PR DESCRIPTION
## 📜 Summary of changes:

Because of pages being loaded from browser's BF cache, the content script has stale context and does not reload. In this PR, the content script notifies extension's background script to update extension icon and reload session data whenever page is loaded from cache.

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->