### PR TITLE
[RQ-684]: reorder persona recommendation screen

### DIFF
--- a/app/src/components/features/rules/GettingStarted/PersonaRecommendation/FeatureCard/FeatureCard.css
+++ b/app/src/components/features/rules/GettingStarted/PersonaRecommendation/FeatureCard/FeatureCard.css
@@ -20,6 +20,10 @@
   margin-bottom: 6px;
 }
 
+.feature-title-container .rq-badge {
+  margin-left: -7px;
+}
+
 .feature-title-container .right-chevron svg {
   flex-shrink: 0;
   width: 15px;

--- a/app/src/components/features/rules/GettingStarted/PersonaRecommendation/FeatureCard/index.tsx
+++ b/app/src/components/features/rules/GettingStarted/PersonaRecommendation/FeatureCard/index.tsx
@@ -3,12 +3,12 @@ import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { actions } from "store";
 import { Feature } from "../types";
+import { RQBadge } from "lib/design-system/components/RQBadge";
 import { ReactComponent as RightChevron } from "assets/icons/chevron-right.svg";
 import { trackPersonaRecommendationSelected } from "modules/analytics/events/misc/personaSurvey";
 import "./FeatureCard.css";
 
-export const FeatureCard: React.FC<Feature> = ({ id, icon, title, subTitle, link }) => {
-  const Icon = icon;
+export const FeatureCard: React.FC<Feature> = ({ id, icon: Icon, title, subTitle, link, tag = "" }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
@@ -28,6 +28,7 @@ export const FeatureCard: React.FC<Feature> = ({ id, icon, title, subTitle, link
         <div className="feature-title-wrapper">
           <span className="feature-icon">{<Icon />}</span>
           <span className="feature-title">{title}</span>
+          {!!tag && <RQBadge badgeText={tag} />}
         </div>
         <span className="right-chevron">
           <RightChevron />

--- a/app/src/components/features/rules/GettingStarted/PersonaRecommendation/personaRecommendationData.tsx
+++ b/app/src/components/features/rules/GettingStarted/PersonaRecommendation/personaRecommendationData.tsx
@@ -5,6 +5,7 @@ import PATHS from "config/constants/sub/paths";
 import { Document, PaperUpload, Video } from "react-iconly";
 import { FeatureSection } from "./types";
 import { ApiOutlined } from "@ant-design/icons";
+import { FeatureReleaseTag } from "./types";
 
 const { RULE_TYPES } = GLOBAL_CONSTANTS;
 const { RULE_TYPES_CONFIG } = APP_CONSTANTS;
@@ -56,6 +57,41 @@ export const personaRecommendationData: FeatureSection[] = [
     ],
   },
   {
+    section: "Page HTML",
+    features: [
+      {
+        id: "record_session",
+        title: "Record a session",
+        icon: () => (
+          <span className="remix-icon">
+            <Video set="curved" />
+          </span>
+        ),
+        subTitle: "Record your browsing sessions along with network and console logs",
+        link: PATHS.SESSIONS.ABSOLUTE,
+        tag: FeatureReleaseTag.NEW,
+      },
+      {
+        id: "inject_script",
+        title: "Inject script",
+        icon: RULE_TYPES_CONFIG[RULE_TYPES.SCRIPT].ICON,
+        subTitle: RULE_TYPES_CONFIG[RULE_TYPES.SCRIPT].DESCRIPTION,
+        link: `${PATHS.RULE_EDITOR.CREATE_RULE.ABSOLUTE}/${RULE_TYPES.SCRIPT}`,
+      },
+      {
+        id: "host_js_css",
+        title: "Host JS/CSS",
+        icon: () => (
+          <span className="remix-icon">
+            <PaperUpload set="curved" />
+          </span>
+        ),
+        subTitle: "Host your JS/CSS/HTML files and use them anywhere for debugging",
+        link: PATHS.FILE_SERVER_V2.ABSOLUTE,
+      },
+    ],
+  },
+  {
     section: "API's",
     features: [
       {
@@ -90,40 +126,6 @@ export const personaRecommendationData: FeatureSection[] = [
         icon: () => <ApiOutlined />,
         subTitle: "Test responses quickly using API Client",
         link: PATHS.API_CLIENT.ABSOLUTE,
-      },
-    ],
-  },
-  {
-    section: "Page HTML",
-    features: [
-      {
-        id: "inject_script",
-        title: "Inject script",
-        icon: RULE_TYPES_CONFIG[RULE_TYPES.SCRIPT].ICON,
-        subTitle: RULE_TYPES_CONFIG[RULE_TYPES.SCRIPT].DESCRIPTION,
-        link: `${PATHS.RULE_EDITOR.CREATE_RULE.ABSOLUTE}/${RULE_TYPES.SCRIPT}`,
-      },
-      {
-        id: "replay_session",
-        title: "Replay session",
-        icon: () => (
-          <span className="remix-icon">
-            <Video set="curved" />
-          </span>
-        ),
-        subTitle: "Record your browsing sessions along with network and console logs",
-        link: PATHS.SESSIONS.ABSOLUTE,
-      },
-      {
-        id: "host_js_css",
-        title: "Host JS/CSS",
-        icon: () => (
-          <span className="remix-icon">
-            <PaperUpload set="curved" />
-          </span>
-        ),
-        subTitle: "Host your JS/CSS/HTML files and use them anywhere for debugging",
-        link: PATHS.FILE_SERVER_V2.ABSOLUTE,
       },
     ],
   },

--- a/app/src/components/features/rules/GettingStarted/PersonaRecommendation/types.ts
+++ b/app/src/components/features/rules/GettingStarted/PersonaRecommendation/types.ts
@@ -1,5 +1,10 @@
 import React from "react";
 
+export enum FeatureReleaseTag {
+  NEW = "NEW",
+  BETA = "BETA",
+}
+
 export type Feature = {
   id: string;
   icon: React.FC;
@@ -7,6 +12,7 @@ export type Feature = {
   subTitle: string;
   link?: string;
   disabled?: boolean;
+  tag?: FeatureReleaseTag;
 };
 
 export type FeatureSection = {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:
- Updated "Page HTML" as 3rd category on the page. 
- Within "Page HTML" added Replay Session in the first spot and changed the copy to "Record a session"
- Added a "NEW" tag like we have on header in Desktop app.

<img width="1440" alt="Screenshot 2023-08-01 at 1 00 11 PM" src="https://github.com/requestly/requestly/assets/61556757/e513021c-188f-412b-bc5a-93636ef9272c">

<!-- Summarize your changes -->

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [x] Verified UI in browser.
- [x] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->