### PR TITLE
[RQ-702] fix: session viewer lagging when changing start time offset

### DIFF
--- a/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
+++ b/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
@@ -103,7 +103,10 @@ const SessionDetails: React.FC = () => {
     }
 
     player.goto(startTimeOffset * 1000, true);
-  }, [player, startTimeOffset]);
+    // player should start playing from the start time offset only on the
+    // first load and not when the user changes time offset.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [player]);
 
   const getSessionPanelTabs = useMemo(() => {
     const tabItems = [

--- a/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
+++ b/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
@@ -32,6 +32,7 @@ const SessionDetails: React.FC = () => {
   const [player, setPlayer] = useState<Replayer>();
   const playerContainer = useRef<HTMLDivElement>();
   const currentTimeRef = useRef<number>(0);
+  const offsetTimeRef = useRef<number>(startTimeOffset ?? 0);
   const [playerTimeOffset, setPlayerTimeOffset] = useState<number>(0); // in seconds
   const [visibleNetworkLogsCount, setVisibleNetworkLogsCount] = useState(0);
   const [visibleConsoleLogsCount, setVisibleConsoleLogsCount] = useState(0);
@@ -102,10 +103,9 @@ const SessionDetails: React.FC = () => {
       return;
     }
 
-    player.goto(startTimeOffset * 1000, true);
     // player should start playing from the start time offset only on the
     // first load and not when the user changes time offset.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    player.goto(offsetTimeRef.current * 1000, true);
   }, [player]);
 
   const getSessionPanelTabs = useMemo(() => {

--- a/app/src/views/features/sessions/SessionViewer/SessionPropertiesPanel.tsx
+++ b/app/src/views/features/sessions/SessionViewer/SessionPropertiesPanel.tsx
@@ -2,7 +2,7 @@ import ProCard from "@ant-design/pro-card";
 import { InputNumber, Input, Tooltip } from "antd";
 import { AimOutlined } from "@ant-design/icons";
 import { RQButton } from "lib/design-system/components";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { getUserAuthDetails } from "store/selectors";
 import {
@@ -29,24 +29,27 @@ const SessionPropertiesPanel: React.FC<Props> = ({ getCurrentTimeOffset }) => {
   const isReadOnly = useSelector(getIsReadOnly);
   const sessionDescription = useSelector(getSessionRecordingDescription);
 
+  const [startOffset, setStartOffset] = useState<number>(startTimeOffset);
+
   const recordingLengthInSeconds = useMemo(() => Math.floor(attributes?.duration ?? 0 / 1000), [attributes]);
 
   const saveStartTimeOffset = useMemo(
     () =>
       debounce((value: number) => {
+        dispatch(sessionRecordingActions.setStartTimeOffset(value));
         if (recordingId) {
           updateStartTimeOffset(user?.details?.profile?.uid, recordingId, value);
         }
       }, 1000),
-    [recordingId, user]
+    [dispatch, recordingId, user?.details?.profile?.uid]
   );
 
   const onStartTimeOffsetChange = useCallback(
     (newOffset: number) => {
+      setStartOffset(newOffset);
       saveStartTimeOffset(newOffset);
-      dispatch(sessionRecordingActions.setStartTimeOffset(newOffset));
     },
-    [dispatch, saveStartTimeOffset]
+    [saveStartTimeOffset]
   );
 
   const saveDescription = useCallback(
@@ -77,7 +80,7 @@ const SessionPropertiesPanel: React.FC<Props> = ({ getCurrentTimeOffset }) => {
               addonAfter="seconds"
               min={0}
               max={recordingLengthInSeconds}
-              value={startTimeOffset}
+              value={startOffset}
               onChange={onStartTimeOffsetChange}
             />
           </div>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue --> RQ-702

## 📜 Summary of changes: 
The player would play from the offset time only on the page load and not when start offset is changed while playing the session.

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->