### PR TITLE
[RQ-712] fix: current time greater than the video duration

### DIFF
--- a/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
+++ b/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
@@ -129,6 +129,13 @@ const SessionDetails: React.FC<SessionDetailsProps> = ({ isInsideIframe = false 
       return;
     }
 
+    // no rrweb listener on the player works when focus is shifted from the tab
+    // The player keeps playing even when the tab is not in focus.
+    // so we add a listener on the window to pause the player when the tab is blurred
+    window.addEventListener("blur", () => {
+      player.pause();
+    });
+
     // player should start playing from the start time offset only on the
     // first load and not when the user changes time offset.
     player.goto(offsetTimeRef.current * 1000, true);

--- a/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
+++ b/app/src/views/features/sessions/SessionViewer/SessionDetails.tsx
@@ -68,6 +68,10 @@ const SessionDetails: React.FC<SessionDetailsProps> = ({ isInsideIframe = false 
     return Math.floor((currentTimeRef.current - startTime) / 1000);
   }, [startTime]);
 
+  const onBlurListener = useCallback(() => {
+    player?.pause();
+  }, [player]);
+
   useEffect(() => {
     if (!isAppOpenedInIframe()) return;
 
@@ -111,10 +115,11 @@ const SessionDetails: React.FC<SessionDetailsProps> = ({ isInsideIframe = false 
   // destroy player on unmount
   useEffect(
     () => () => {
+      window.removeEventListener("blur", onBlurListener);
       // @ts-ignore
       player?.$destroy();
     },
-    [player]
+    [onBlurListener, player]
   );
 
   useEffect(() => {
@@ -132,14 +137,12 @@ const SessionDetails: React.FC<SessionDetailsProps> = ({ isInsideIframe = false 
     // no rrweb listener on the player works when focus is shifted from the tab
     // The player keeps playing even when the tab is not in focus.
     // so we add a listener on the window to pause the player when the tab is blurred
-    window.addEventListener("blur", () => {
-      player.pause();
-    });
+    window.addEventListener("blur", onBlurListener);
 
     // player should start playing from the start time offset only on the
     // first load and not when the user changes time offset.
     player.goto(offsetTimeRef.current * 1000, true);
-  }, [player]);
+  }, [onBlurListener, player]);
 
   const getSessionPanelTabs = useMemo(() => {
     const tabItems = [


### PR DESCRIPTION
Closes issue: <!-- Link to Github issue --> RQ-712

## 📜 Summary of changes:

- `rrweb` listeners do not work when the focus is changed to another tab. Hence, the player keeps on playing.
- For fixing, this PR pauses the player `onBlur`.
<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->