### PR TITLE
RQ-718 Fix: Disabling automatic recording keeps recording existing tabs even on page reload/navigation

### DIFF
--- a/browser-extension/mv2/src/background/background.js
+++ b/browser-extension/mv2/src/background/background.js
@@ -1172,8 +1172,16 @@ BG.Methods.handleSessionRecordingOnClientPageLoad = async (tab, payload) => {
     const sessionRecordingConfig = await BG.Methods.getSessionRecordingConfig(payload.url);
 
     if (sessionRecordingConfig) {
-      sessionRecordingData = { config: sessionRecordingConfig };
+      sessionRecordingData = { config: sessionRecordingConfig, url: payload.url };
       window.tabService.setData(tab.id, BG.TAB_SERVICE_DATA.SESSION_RECORDING, sessionRecordingData);
+    }
+  } else if (!sessionRecordingData.explicit) {
+    // stop recording if config was changed to turn off auto-recording for the session URL
+    const sessionRecordingConfig = await BG.Methods.getSessionRecordingConfig(sessionRecordingData.url);
+
+    if (!sessionRecordingConfig) {
+      BG.Methods.stopRecording(tab.id);
+      return;
     }
   }
 


### PR DESCRIPTION
## 📜 Summary of changes:

- Cache the starting page URL when session recording started
- On page navigation/reload in same tab, check if above URL still satisfies the config

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->