### PR TITLE
[RQ-769] Fix: confirmation shown twice on discarding draft session

### DIFF
--- a/app/src/views/features/sessions/SessionViewer/DraftSessionViewer.tsx
+++ b/app/src/views/features/sessions/SessionViewer/DraftSessionViewer.tsx
@@ -150,6 +150,9 @@ const DraftSessionViewer: React.FC = () => {
         trackDraftSessionDiscarded();
         navigate(PATHS.SESSIONS.ABSOLUTE);
       },
+      onCancel() {
+        setIsDiscardSessionClicked(false);
+      },
     });
   };
 

--- a/app/src/views/features/sessions/SessionViewer/DraftSessionViewer.tsx
+++ b/app/src/views/features/sessions/SessionViewer/DraftSessionViewer.tsx
@@ -41,6 +41,7 @@ const DraftSessionViewer: React.FC = () => {
   const [loadingError, setLoadingError] = useState<string>();
   const [isSavePopupVisible, setIsSavePopupVisible] = useState(false);
   const [isSaveSessionClicked, setIsSaveSessionClicked] = useState(false);
+  const [isDiscardSessionClicked, setIsDiscardSessionClicked] = useState(false);
 
   const generateDraftSessionTitle = useCallback((url: string) => {
     const hostname = new URL(url).hostname.split(".").slice(0, -1).join(".");
@@ -77,7 +78,7 @@ const DraftSessionViewer: React.FC = () => {
   }, []);
 
   unstable_usePrompt({
-    when: !isSaveSessionClicked,
+    when: !isSaveSessionClicked && !isDiscardSessionClicked,
     message: "Exiting without saving will discard the draft.\nAre you sure you want to exit?",
   });
 
@@ -138,6 +139,7 @@ const DraftSessionViewer: React.FC = () => {
   }, [dispatch, tabId, user?.details?.profile?.email, generateDraftSessionTitle]);
 
   const confirmDiscard = () => {
+    setIsDiscardSessionClicked(true);
     Modal.confirm({
       title: "Confirm Discard",
       icon: <ExclamationCircleOutlined />,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->