### PR TITLE
fix: symlink instead of making copy of network session

### DIFF
--- a/app/src/views/features/sessions/SessionsIndexPageContainer/NetworkSessions/actions.ts
+++ b/app/src/views/features/sessions/SessionsIndexPageContainer/NetworkSessions/actions.ts
@@ -29,8 +29,9 @@ function ipcRequest(channel: string, requestData: any, timeout = 10_000): any {
   });
 }
 
-export async function saveNetworkSession(name: string, har: Har): Promise<string> {
-  return ipcRequest("save-network-session", { name, har })
+export async function saveNetworkSession(name: string, har: Har, filePath?: string): Promise<string> {
+  const payload = { name, har, originalFilePath: filePath };
+  return ipcRequest("save-network-session", payload)
     .then((id: string) => {
       return id;
     })


### PR DESCRIPTION
currently network sessions are saved locally as copies of the originally uploaded har.
This does not make sense if Requestly is meant to act as a har client that should reflect changes from the original har as well