### PR TITLE
[RQ-821] fix: need to double click on session recording on-page widget sometimes

### DIFF
--- a/browser-extension/common/src/custom-elements/abstract-classes/draggable-widget.ts
+++ b/browser-extension/common/src/custom-elements/abstract-classes/draggable-widget.ts
@@ -37,6 +37,13 @@ export abstract class RQDraggableWidget extends HTMLElement {
       };
 
       const onMouseUp = () => {
+        // Fallback incase click event is not triggered. Timeout because we need to stopPropogation in case isDragging=true. Else it will propogate it and cause weird behaviour
+        // This happens when mousedown and mouseup doesn't happen on the same element
+        // Similar to this https://melkornemesis.medium.com/handling-javascript-mouseup-event-outside-element-b0a34090bb56
+        setTimeout(() => {
+          this.#isDragging = false;
+        }, 100);
+
         document.removeEventListener("mousemove", onMouseMove);
         document.removeEventListener("mouseup", onMouseUp);
       };


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->