### PR TITLE
[RQ-909] fix: stop recording widget not visible when recording from launch URL

### DIFF
--- a/browser-extension/mv2/src/background/background.js
+++ b/browser-extension/mv2/src/background/background.js
@@ -1346,7 +1346,11 @@ BG.Methods.startRecordingExplicitly = (tabId, showWidget = true) => {
 
 BG.Methods.launchUrlAndStartRecording = (url) => {
   BG.Methods.launchUrl(url).then((tab) => {
-    window.tabService.setData(tab.id, BG.TAB_SERVICE_DATA.SESSION_RECORDING, { notify: true, explicit: true });
+    window.tabService.setData(tab.id, BG.TAB_SERVICE_DATA.SESSION_RECORDING, {
+      notify: true,
+      explicit: true,
+      showWidget: true,
+    });
   });
 };
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->