### PR TITLE
chore: show install extension dialog only after api client is used

### DIFF
--- a/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/index.tsx
+++ b/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/index.tsx
@@ -9,12 +9,10 @@ import { ReactComponent as SessionIcon } from "assets/icons/session.svg";
 import { ReactComponent as MockServerIcon } from "assets/icons/mock-server.svg";
 import { PrimarySidebarLink } from "./PrimarySidebarLink";
 import { isUserUsingAndroidDebugger } from "components/features/mobileDebugger/utils/sdkUtils";
-// import { isFeatureCompatible } from "utils/CompatibilityUtils";
 import { RQBadge } from "lib/design-system/components/RQBadge";
 import { PrimarySidebarItem } from "../type";
 import InviteButton from "./InviteButton";
 import PATHS from "config/constants/sub/paths";
-import FEATURES from "config/constants/sub/features";
 //@ts-ignore
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
 import "./PrimarySidebar.css";
@@ -86,7 +84,6 @@ export const PrimarySidebar: React.FC = () => {
         title: "API client",
         path: PATHS.API_CLIENT.INDEX,
         icon: <ApiOutlined />,
-        feature: FEATURES.API_CLIENT,
         display: true,
         activeColor: "var(--api-client)",
       },
@@ -98,8 +95,6 @@ export const PrimarySidebar: React.FC = () => {
         display: isAndroidDebuggerEnabled,
       },
     ];
-
-    // return items.filter((item) => !item.feature || isFeatureCompatible(item.feature));
     return items;
   }, [appMode, isAndroidDebuggerEnabled, isSavingNetworkSession]);
 

--- a/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/index.tsx
+++ b/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/index.tsx
@@ -9,7 +9,7 @@ import { ReactComponent as SessionIcon } from "assets/icons/session.svg";
 import { ReactComponent as MockServerIcon } from "assets/icons/mock-server.svg";
 import { PrimarySidebarLink } from "./PrimarySidebarLink";
 import { isUserUsingAndroidDebugger } from "components/features/mobileDebugger/utils/sdkUtils";
-import { isFeatureCompatible } from "utils/CompatibilityUtils";
+// import { isFeatureCompatible } from "utils/CompatibilityUtils";
 import { RQBadge } from "lib/design-system/components/RQBadge";
 import { PrimarySidebarItem } from "../type";
 import InviteButton from "./InviteButton";
@@ -99,7 +99,8 @@ export const PrimarySidebar: React.FC = () => {
       },
     ];
 
-    return items.filter((item) => !item.feature || isFeatureCompatible(item.feature));
+    // return items.filter((item) => !item.feature || isFeatureCompatible(item.feature));
+    return items;
   }, [appMode, isAndroidDebuggerEnabled, isSavingNetworkSession]);
 
   return (

--- a/app/src/modules/analytics/events/features/apiClient/index.js
+++ b/app/src/modules/analytics/events/features/apiClient/index.js
@@ -52,3 +52,6 @@ export const trackRawResponseViewed = () => {
 export const trackResponseHeadersViewed = () => {
   trackEvent(API_CLIENT.RESPONSE_HEADERS_VIEWED);
 };
+
+export const trackInstallExtensionDialogShown = (params) =>
+  trackEvent(API_CLIENT.INSTALL_EXTENSION_DIALOG_SHOWN, params);

--- a/app/src/modules/analytics/events/features/constants.js
+++ b/app/src/modules/analytics/events/features/constants.js
@@ -132,6 +132,7 @@ export const API_CLIENT = {
   RESPONSE_LOADED: "api_client_response_loaded",
   RAW_RESPONSE_VIEWED: "api_client_raw_response_viewed",
   RESPONSE_HEADERS_VIEWED: "api_client_response_headers_viewed",
+  INSTALL_EXTENSION_DIALOG_SHOWN: "api_client_install_extension_dialog_shown",
 };
 
 export const REDIRECT_DESTINATION_OPTION = {

--- a/app/src/views/features/api-client/APIClientContainer.tsx
+++ b/app/src/views/features/api-client/APIClientContainer.tsx
@@ -10,10 +10,6 @@ import {
   trackNewRequestClicked,
 } from "modules/analytics/events/features/apiClient";
 import ImportRequestModal from "./ImportRequestModal";
-import { isFeatureCompatible } from "utils/CompatibilityUtils";
-import FEATURES from "config/constants/sub/features";
-import InstallExtensionCTA from "components/misc/InstallExtensionCTA";
-import { isExtensionInstalled } from "actions/ExtensionActions";
 import "./apiClientContainer.scss";
 
 interface Props {}
@@ -58,36 +54,21 @@ const APIClientContainer: React.FC<Props> = () => {
 
   return (
     <div className="api-client-container">
-      {isFeatureCompatible(FEATURES.API_CLIENT) ? (
-        <>
-          <APIClientSidebar
-            history={history}
-            onSelectionFromHistory={onSelectionFromHistory}
-            clearHistory={clearHistory}
-            onNewClick={onNewClick}
-            onImportClick={onImportClick}
-          />
-          <APIClientView apiEntry={selectedEntry} notifyApiRequestFinished={addToHistory} />
-          <ImportRequestModal
-            isOpen={isImportModalOpen}
-            handleImportRequest={handleImportRequest}
-            onClose={() => setIsImportModalOpen(false)}
-          />
-        </>
-      ) : isExtensionInstalled() ? (
-        <InstallExtensionCTA
-          heading="Get Started"
-          subHeading="You need to be on the latest version of the extension to use API Client."
-          isUpdateRequired
-          eventPage="api_client"
+      <>
+        <APIClientSidebar
+          history={history}
+          onSelectionFromHistory={onSelectionFromHistory}
+          clearHistory={clearHistory}
+          onNewClick={onNewClick}
+          onImportClick={onImportClick}
         />
-      ) : (
-        <InstallExtensionCTA
-          heading="Install Browser extension to test API end points"
-          subHeading="Test and debug API easily with Requestly API Client. Private and secure, works locally on your browser."
-          eventPage="api_client"
+        <APIClientView apiEntry={selectedEntry} notifyApiRequestFinished={addToHistory} />
+        <ImportRequestModal
+          isOpen={isImportModalOpen}
+          handleImportRequest={handleImportRequest}
+          onClose={() => setIsImportModalOpen(false)}
         />
-      )}
+      </>
     </div>
   );
 };

--- a/app/src/views/features/api-client/client-view/APIClientView.tsx
+++ b/app/src/views/features/api-client/client-view/APIClientView.tsx
@@ -180,9 +180,9 @@ const APIClientView: React.FC<Props> = ({ apiEntry, notifyApiRequestFinished }) 
     if (!isExtensionInstalled()) {
       /* SHOW INSTALL EXTENSION MODAL */
       const modalProps = {
-        heading: "Install Browser extension to use the API client",
+        heading: "Install browser Extension to use the API Client",
         subHeading:
-          "Quickly test your backend with by easily creating a request. Easy to customize the headers, body and query parameters and also analyze the response. Your requests are saved for you to reference later.",
+          "A minimalistic API Client for front-end developers to test their APIs and fast-track their web development lifecycle. Add custom Headers and Query Params to test your APIs.",
         eventPage: "api_client",
       };
       dispatch(actions.toggleActiveModal({ modalName: "extensionModal", newProps: modalProps }));

--- a/app/src/views/features/api-client/client-view/APIClientView.tsx
+++ b/app/src/views/features/api-client/client-view/APIClientView.tsx
@@ -1,5 +1,6 @@
 import { Button, Empty, Input, Select, Skeleton, Space, Spin } from "antd";
 import React, { SyntheticEvent, memo, useCallback, useEffect, useRef, useState } from "react";
+import { useDispatch } from "react-redux";
 import Split from "react-split";
 import { KeyValuePair, RQAPI, RequestContentType, RequestMethod } from "../types";
 import RequestTabs from "./request/RequestTabs";
@@ -14,14 +15,17 @@ import {
   removeEmptyKeys,
   supportsRequestBody,
 } from "../apiUtils";
+import { isExtensionInstalled } from "actions/ExtensionActions";
 import {
   trackAPIRequestCancelled,
   trackAPIRequestSent,
   trackRequestFailed,
   trackResponseLoaded,
+  trackInstallExtensionDialogShown,
 } from "modules/analytics/events/features/apiClient";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
+import { actions } from "store";
 import { getAppMode, getIsExtensionEnabled } from "store/selectors";
 import Favicon from "components/misc/Favicon";
 import { CONTENT_TYPE_HEADER, DEMO_API_URL } from "../constants";
@@ -41,6 +45,7 @@ const requestMethodOptions = Object.values(RequestMethod).map((method) => ({
 }));
 
 const APIClientView: React.FC<Props> = ({ apiEntry, notifyApiRequestFinished }) => {
+  const dispatch = useDispatch();
   const location = useLocation();
   const appMode = useSelector(getAppMode);
   const isExtensionEnabled = useSelector(getIsExtensionEnabled);
@@ -172,6 +177,19 @@ const APIClientView: React.FC<Props> = ({ apiEntry, notifyApiRequestFinished }) 
       return;
     }
 
+    if (!isExtensionInstalled()) {
+      /* SHOW INSTALL EXTENSION MODAL */
+      const modalProps = {
+        heading: "Install Browser extension to use the API client",
+        subHeading:
+          "Quickly test your backend with by easily creating a request. Easy to customize the headers, body and query parameters and also analyze the response. Your requests are saved for you to reference later.",
+        eventPage: "api_client",
+      };
+      dispatch(actions.toggleActiveModal({ modalName: "extensionModal", newProps: modalProps }));
+      trackInstallExtensionDialogShown({ src: "api_client" });
+      return;
+    }
+
     const sanitizedEntry: RQAPI.Entry = {
       ...entry,
       request: {
@@ -234,7 +252,7 @@ const APIClientView: React.FC<Props> = ({ apiEntry, notifyApiRequestFinished }) 
     });
     trackRQLastActivity(API_CLIENT.REQUEST_SENT);
     trackRQDesktopLastActivity(API_CLIENT.REQUEST_SENT);
-  }, [appMode, entry, notifyApiRequestFinished, location.pathname]);
+  }, [entry, appMode, location.pathname, dispatch, notifyApiRequestFinished]);
 
   const cancelRequest = useCallback(() => {
     abortControllerRef.current?.abort();


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->