### PR TITLE
chore: add workspace member count param in certain events

### DIFF
--- a/app/src/components/common/SharingModal/DownloadRules/index.tsx
+++ b/app/src/components/common/SharingModal/DownloadRules/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { actions } from "store";
 import { Button } from "antd";
 import fileDownload from "js-file-download";
-import { getAllRules, getAppMode, getGroupwiseRulesToPopulate } from "store/selectors";
+import { getAllRules, getAppMode, getGroupwiseRulesToPopulate, getUserAuthDetails } from "store/selectors";
 import { prepareContentToExport } from "../actions";
 import { trackRQLastActivity } from "utils/AnalyticsUtils";
 import { Rule } from "types";
@@ -11,6 +11,7 @@ import { trackRulesExportedEvent } from "modules/analytics/events/common/rules";
 import { getFormattedDate } from "utils/DateTimeUtils";
 import { toast } from "utils/Toast";
 import "./DownloadRules.css";
+import { RULES } from "modules/analytics/events/common/constants";
 
 interface DownloadRulesProps {
   selectedRules: string[];
@@ -20,6 +21,7 @@ interface DownloadRulesProps {
 export const DownloadRules: React.FC<DownloadRulesProps> = ({ selectedRules = [], toggleModal }) => {
   const dispatch = useDispatch();
   const appMode = useSelector(getAppMode);
+  const user = useSelector(getUserAuthDetails);
   const rules = useSelector(getAllRules);
   const groupwiseRulesToPopulate = useSelector(getGroupwiseRulesToPopulate);
   const [rulesToDownload, setRulesToDownload] = useState<{
@@ -42,14 +44,14 @@ export const DownloadRules: React.FC<DownloadRulesProps> = ({ selectedRules = []
     (e: unknown) => {
       const { rulesCount, fileContent } = rulesToDownload ?? {};
 
-      trackRQLastActivity("rules_exported");
-      trackRulesExportedEvent(rulesCount);
+      trackRQLastActivity(RULES.RULES_EXPORTED);
+      trackRulesExportedEvent(rulesCount, user?.details?.profile?.workspaceMemberCount || null);
       dispatch(actions.clearSelectedRules());
       fileDownload(fileContent, fileName, "application/json");
       setTimeout(() => toast.success(`${rulesCount === 1 ? "Rule" : "Rules"} downloaded successfully`), 0);
       toggleModal();
     },
-    [fileName, dispatch, toggleModal, rulesToDownload]
+    [fileName, dispatch, toggleModal, rulesToDownload, user]
   );
 
   useEffect(() => {

--- a/app/src/components/common/SharingModal/ShareLinkView.tsx
+++ b/app/src/components/common/SharingModal/ShareLinkView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
-import { getAllRules, getAppMode, getGroupwiseRulesToPopulate } from "store/selectors";
+import { getAllRules, getAppMode, getGroupwiseRulesToPopulate, getUserAuthDetails } from "store/selectors";
 import { Radio, Space, Tooltip } from "antd";
 import { RQButton, RQInput } from "lib/design-system/components";
 import { CopyValue } from "components/misc/CopyValue";
@@ -19,6 +19,7 @@ import { Rule } from "types";
 import Logger from "lib/logger";
 import { trackSharedListCreatedEvent, trackSharedListUrlCopied } from "modules/analytics/events/features/sharedList";
 import "./index.css";
+import { SHARED_LIST } from "modules/analytics/events/features/constants";
 
 interface ShareLinkProps {
   selectedRules: string[];
@@ -29,6 +30,7 @@ interface ShareLinkProps {
 
 export const ShareLinkView: React.FC<ShareLinkProps> = ({ selectedRules, source }) => {
   const appMode = useSelector(getAppMode);
+  const user = useSelector(getUserAuthDetails);
   const rules = useSelector(getAllRules);
   const groupwiseRulesToPopulate = useSelector(getGroupwiseRulesToPopulate);
   const [sharedLinkVisibility, setSharedLinkVisibility] = useState(SharedLinkVisibility.PUBLIC);
@@ -170,7 +172,7 @@ export const ShareLinkView: React.FC<ShareLinkProps> = ({ selectedRules, source 
         sharedLinkVisibility,
         sharedListRecipients
       ).then(({ sharedListId, sharedListName, sharedListData, nonRQEmails }: any) => {
-        trackRQLastActivity("sharedList_created");
+        trackRQLastActivity(SHARED_LIST.CREATED);
         if (sharedLinkVisibility === SharedLinkVisibility.PRIVATE && sharedListRecipients.length) {
           sendSharedListShareEmail({
             sharedListData: sharedListData,
@@ -200,7 +202,8 @@ export const ShareLinkView: React.FC<ShareLinkProps> = ({ selectedRules, source 
           source,
           sharedLinkVisibility,
           nonRQEmailsCount,
-          recipientsCount
+          recipientsCount,
+          user?.details?.profile?.workspaceMemberCount || null
         );
         setIsLinkGenerating(false);
       });
@@ -217,6 +220,7 @@ export const ShareLinkView: React.FC<ShareLinkProps> = ({ selectedRules, source 
     sharedListRecipients,
     sendSharedListShareEmail,
     validateSharedListName,
+    user,
   ]);
 
   useEffect(() => {

--- a/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/index.js
@@ -113,6 +113,7 @@ const CreateRuleButton = ({
                 currentlySelectedRuleData.ruleType === GLOBAL_CONSTANTS.RULE_TYPES.RESPONSE
                   ? getAllResponseBodyTypes(currentlySelectedRuleData)
                   : null,
+              workspaceMemberCount: user?.details?.profile?.workspaceMemberCount || null,
             });
           } else if (MODE === APP_CONSTANTS.RULE_EDITOR_CONFIG.MODES.EDIT) {
             trackRuleEditedEvent(
@@ -121,7 +122,8 @@ const CreateRuleButton = ({
               currentlySelectedRuleData.ruleType === GLOBAL_CONSTANTS.RULE_TYPES.REDIRECT
                 ? getAllRedirectDestinationTypes(currentlySelectedRuleData)
                 : null,
-              analyticEventRuleCreatedSource
+              analyticEventRuleCreatedSource,
+              user?.details?.profile?.workspaceMemberCount || null
             );
           }
           ruleModifiedAnalytics(user);

--- a/app/src/components/features/rules/RulesListContainer/index.js
+++ b/app/src/components/features/rules/RulesListContainer/index.js
@@ -37,6 +37,7 @@ import { redirectToCreateNewRule } from "utils/RedirectionUtils";
 import FeatureLimiterBanner from "components/common/FeatureLimiterBanner/featureLimiterBanner";
 import { useFeatureIsOn } from "@growthbook/growthbook-react";
 import "./RulesListContainer.css";
+import { SHARED_LIST } from "modules/analytics/events/features/constants";
 
 const { PATHS } = APP_CONSTANTS;
 
@@ -168,7 +169,7 @@ const RulesListContainer = ({ isTableLoading = false }) => {
     const newSelectedRules = getSelectedRules(rulesSelection);
     setSelectedRules(newSelectedRules);
     toggleSharingModal(newSelectedRules);
-    trackRQLastActivity("sharedList_created");
+    trackRQLastActivity(SHARED_LIST.CREATED);
   };
 
   const handleImportRulesOnClick = (e) => {

--- a/app/src/modules/analytics/events/common/rules/index.js
+++ b/app/src/modules/analytics/events/common/rules/index.js
@@ -1,9 +1,17 @@
 import { trackEvent } from "modules/analytics";
 import { RULES } from "../constants";
 
-export const trackRuleCreatedEvent = ({ rule_type, description, destination_types, source, body_types }) => {
+export const trackRuleCreatedEvent = ({
+  rule_type,
+  description,
+  destination_types,
+  source,
+  body_types,
+  workspaceMemberCount,
+}) => {
   const params = {
     rule_type,
+    workspace_member_count: workspaceMemberCount,
   };
   if (description) params.description = description;
   if (destination_types) params.destination_types = destination_types;
@@ -13,9 +21,10 @@ export const trackRuleCreatedEvent = ({ rule_type, description, destination_type
   trackEvent(RULES.RULE_CREATED, params);
 };
 
-export const trackRuleEditedEvent = (rule_type, description, destination_types, source) => {
+export const trackRuleEditedEvent = (rule_type, description, destination_types, source, workspaceMemberCount) => {
   const params = {
     rule_type,
+    workspace_member_count: workspaceMemberCount,
   };
   if (description) params.description = description;
   if (destination_types) params.destination_types = destination_types;
@@ -73,9 +82,10 @@ export const trackRuleExportedEvent = (count, rule_type) => {
   trackEvent(RULES.RULE_EXPORTED, params);
 };
 
-export const trackRulesExportedEvent = (count) => {
+export const trackRulesExportedEvent = (count, workspaceMemberCount) => {
   const params = {
     count,
+    workspace_member_count: workspaceMemberCount,
   };
   trackEvent(RULES.RULES_EXPORTED, params);
 };
@@ -100,8 +110,8 @@ export const trackRulesUngrouped = () => {
   trackEvent(RULES.RULES_UNGROUPED, params);
 };
 
-export const trackRuleExecuted = (type, count, month, year) => {
-  const params = { type, count, month, year };
+export const trackRuleExecuted = (type, count, month, year, executorIsCreator = null) => {
+  const params = { type, count, month, year, executor_is_creator: executorIsCreator };
   trackEvent(RULES.RULE_EXECUTED, params);
 };
 

--- a/app/src/modules/analytics/events/features/sharedList/index.js
+++ b/app/src/modules/analytics/events/features/sharedList/index.js
@@ -10,7 +10,8 @@ export const trackSharedListCreatedEvent = (
   source,
   access_type,
   non_rq_users,
-  num_users_notified
+  num_users_notified,
+  workspaceMemberCount
 ) => {
   const params = {
     id,
@@ -18,6 +19,7 @@ export const trackSharedListCreatedEvent = (
     num_rules,
     source,
     access_type,
+    workspace_member_count: workspaceMemberCount,
   };
 
   if (!isNull(num_users_notified)) params.num_users_notified = num_users_notified;


### PR DESCRIPTION
do not set `executor_is_creator`

<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->