### PR TITLE
[RQ-973] fix: cache position of draggable widgets

### DIFF
--- a/browser-extension/common/src/custom-elements/abstract-classes/draggable-widget.ts
+++ b/browser-extension/common/src/custom-elements/abstract-classes/draggable-widget.ts
@@ -1,3 +1,7 @@
+enum RQDraggableWidgetEvent {
+  MOVED = "moved",
+}
+
 export abstract class RQDraggableWidget extends HTMLElement {
   #isDragging: boolean;
   #defaultPosition;
@@ -83,5 +87,7 @@ export abstract class RQDraggableWidget extends HTMLElement {
     this.style.top = getCSSPostionValue(position.top);
     this.style.bottom = getCSSPostionValue(position.bottom);
     this.style.right = getCSSPostionValue(position.right);
+
+    this.dispatchEvent(new CustomEvent(RQDraggableWidgetEvent.MOVED, { detail: position }));
   }
 }

--- a/browser-extension/common/src/custom-elements/session-recording-widget/index.ts
+++ b/browser-extension/common/src/custom-elements/session-recording-widget/index.ts
@@ -6,7 +6,6 @@ import { RQDraggableWidget } from "../abstract-classes/draggable-widget";
 enum RQSessionRecordingWidgetEvent {
   STOP_RECORDING = "stop",
   DISCARD_RECORDING = "discard",
-  MOVED = "moved",
 }
 
 const TAG_NAME = "rq-session-recording-widget";


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->