### PR TITLE
chore: add event param executor_is_creator

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -17,7 +17,7 @@ import LocalUserAttributesHelperComponent from "hooks/LocalUserAttributesHelperC
 import PreLoadRemover from "hooks/PreLoadRemover";
 import AppModeInitializer from "hooks/AppModeInitializer";
 import DBListeners from "hooks/DbListenerInit/DBListeners";
-import RuleExecutionsSyncer from "hooks/RuleExecutionsSyncer";
+// import RuleExecutionsSyncer from "hooks/RuleExecutionsSyncer";
 import FeatureUsageEvent from "hooks/FeatureUsageEvent";
 import ActiveWorkspace from "hooks/ActiveWorkspace";
 import AuthHandler from "hooks/AuthHandler";
@@ -65,7 +65,7 @@ const App = () => {
       <PreLoadRemover />
       <AppModeInitializer />
       <DBListeners />
-      <RuleExecutionsSyncer />
+      {/* <RuleExecutionsSyncer /> */}
       <ActiveWorkspace />
       <ThirdPartyIntegrationsHandler />
 

--- a/app/src/modules/analytics/events/extension.ts
+++ b/app/src/modules/analytics/events/extension.ts
@@ -26,9 +26,9 @@ const sendEventsBatch = (eventBatch: EventBatch): void => {
 
       if (ruleCreator && currentUserId) {
         const isExecutorCreator = currentUserId === ruleCreator;
-        delete event.eventParams["rule_creator"];
         event.eventParams["is_executor_creator"] = isExecutorCreator;
       }
+      delete event.eventParams["rule_creator"];
     }
 
     trackEvent(event.eventName, event.eventParams, eventConfig);

--- a/app/src/modules/analytics/events/extension.ts
+++ b/app/src/modules/analytics/events/extension.ts
@@ -1,10 +1,11 @@
 import { trackEvent } from "..";
 // @ts-ignore
 import { CONSTANTS } from "@requestly/requestly-core";
+import { RULES } from "./common/constants";
 
 interface Event {
   eventName: string;
-  eventParams: object;
+  eventParams: Record<string, any>;
   eventTs: number;
 }
 
@@ -17,6 +18,19 @@ interface EventBatch {
 const sendEventsBatch = (eventBatch: EventBatch): void => {
   eventBatch.events.forEach((event) => {
     const eventConfig = { time: event.eventTs };
+
+    /* ADDING EXTRA INFO FOR RULE EXECUTION EVENTS */
+    if (event.eventName === RULES.RULE_EXECUTED) {
+      const currentUserId = window.uid;
+      const ruleCreator = event.eventParams?.["rule_creator"];
+
+      if (ruleCreator && currentUserId) {
+        const isExecutorCreator = currentUserId === ruleCreator;
+        delete event.eventParams["rule_creator"];
+        event.eventParams["is_executor_creator"] = isExecutorCreator;
+      }
+    }
+
     trackEvent(event.eventName, event.eventParams, eventConfig);
   });
 };

--- a/browser-extension/mv2/src/client/js/ruleExecutionHandler.js
+++ b/browser-extension/mv2/src/client/js/ruleExecutionHandler.js
@@ -7,6 +7,7 @@ RQ.RuleExecutionHandler.sendRuleExecutionEvent = (rule) => {
     rule_type: rule.ruleType,
     rule_id: rule.id,
     platform: "extension",
+    rule_creator: rule.createdBy,
   };
   RQ.ClientUtils.sendExecutionEventToBackground(eventName, eventParams);
 };


### PR DESCRIPTION
- Starts sending `rule_creator` in `rule_executed` event
- removes the old implementation for sending `rule_executed` events (adding unnecessary noise)
- adds event param `executor_is_creator`