### PR TITLE
fix: watch replay button for disabled state tooltip

### DIFF
--- a/browser-extension/common/src/popup/components/Popup/popup.css
+++ b/browser-extension/common/src/popup/components/Popup/popup.css
@@ -277,12 +277,12 @@
   box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.48);
 }
 
-.action-btn-tooltip.ant-tooltip {
+.ant-tooltip.action-btn-tooltip {
   margin-top: 3px;
   box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.48);
 }
 
-.action-btn-tooltip.action-btn-tooltip .ant-tooltip-inner {
+.ant-tooltip.action-btn-tooltip .ant-tooltip-inner {
   max-width: 232px;
   padding: 8px 12px;
   border-radius: var(--border-radius-sm);

--- a/browser-extension/common/src/popup/components/SessionRecording/SessionRecordingView.tsx
+++ b/browser-extension/common/src/popup/components/SessionRecording/SessionRecordingView.tsx
@@ -6,6 +6,7 @@ import SettingIcon from "../../../../resources/icons/setting.svg";
 import PlayRecordingIcon from "../../../../resources/icons/playRecording.svg";
 import StopRecordingIcon from "../../../../resources/icons/stopRecording.svg";
 import ReplayLastFiveMinuteIcon from "../../../../resources/icons/replayLastFiveMinute.svg";
+import InfoIcon from "../../../../resources/icons/info.svg";
 import ShieldIcon from "../../../../resources/icons/shield.svg";
 import config from "../../../config";
 import { EVENT, sendEvent } from "../../events";
@@ -15,6 +16,8 @@ const SessionRecordingView: React.FC = () => {
   const [currentTabId, setCurrentTabId] = useState<number>();
   const [isRecordingSession, setIsRecordingSession] = useState<boolean>();
   const [isManualMode, setIsManualMode] = useState<boolean>();
+  const isRecordingInManualMode = isRecordingSession && isManualMode;
+  const isRecordingInAutoMode = isRecordingSession && !isManualMode;
 
   const startRecordingOnClick = useCallback(() => {
     sendEvent(EVENT.START_RECORDING_CLICKED, { type: "manual" });
@@ -70,20 +73,29 @@ const SessionRecordingView: React.FC = () => {
     }
   }, [currentTabId]);
 
-  const isRecordingInManualMode = isRecordingSession && isManualMode;
-  const isRecordingInAutoMode = isRecordingSession && !isManualMode;
+  const handleConfigureBtnClick = useCallback(() => {
+    sendEvent(EVENT.SESSION_RECORDINGS_CONFIG_OPENED);
+    window.open(`${config.WEB_URL}/sessions/settings?source=popup`, "_blank");
+  }, []);
+
+  const watchReplayBtnTooltipContent =
+    isRecordingInManualMode || !isRecordingSession ? (
+      <div className="watch-replay-btn-tooltip-content">
+        <InfoIcon />
+        <div>
+          <span>Auto recording is disabled. Please enable it in session replay settings.</span>{" "}
+          <button onClick={handleConfigureBtnClick}>Enable now</button>
+        </div>
+      </div>
+    ) : (
+      <>Instantly play last 5 min auto recorded session for this tab.</>
+    );
 
   return (
     <div className="session-view-content">
       <Row align="middle" justify="space-between">
         <div className="title">Record session for sharing & debugging</div>
-        <div
-          className="configure-btn"
-          onClick={() => {
-            sendEvent(EVENT.SESSION_RECORDINGS_CONFIG_OPENED);
-            window.open(`${config.WEB_URL}/sessions/settings?source=popup`, "_blank");
-          }}
-        >
+        <div className="configure-btn" onClick={handleConfigureBtnClick}>
           <SettingIcon /> Configure
         </div>
       </Row>
@@ -108,17 +120,19 @@ const SessionRecordingView: React.FC = () => {
         <Tooltip
           placement="top"
           color="#000000"
-          title="Instantly play last 5 min auto recorded session for this tab."
-          overlayClassName="action-btn-tooltip"
+          title={watchReplayBtnTooltipContent}
+          overlayClassName="action-btn-tooltip watch-replay-btn"
         >
-          <PrimaryActionButton
-            block
-            icon={<ReplayLastFiveMinuteIcon />}
-            disabled={isRecordingInManualMode || !isRecordingSession}
-            onClick={viewRecordingOnClick}
-          >
-            Watch last 5 min replay
-          </PrimaryActionButton>
+          <span>
+            <PrimaryActionButton
+              block
+              icon={<ReplayLastFiveMinuteIcon />}
+              disabled={isRecordingInManualMode || !isRecordingSession}
+              onClick={viewRecordingOnClick}
+            >
+              Watch last 5 min replay
+            </PrimaryActionButton>
+          </span>
         </Tooltip>
       </Row>
       <div className="session-replay-security-msg">

--- a/browser-extension/common/src/popup/components/SessionRecording/SessionRecordingView.tsx
+++ b/browser-extension/common/src/popup/components/SessionRecording/SessionRecordingView.tsx
@@ -83,8 +83,8 @@ const SessionRecordingView: React.FC = () => {
       <div className="watch-replay-btn-tooltip-content">
         <InfoIcon />
         <div>
-          <span>Auto recording is disabled. Please enable it in session replay settings.</span>{" "}
-          <button onClick={handleConfigureBtnClick}>Enable now</button>
+          <span>Auto recording is disabled for this page. Please Enable it in session replay settings.</span>{" "}
+          <button onClick={handleConfigureBtnClick}>Enable now.</button>
         </div>
       </div>
     ) : (

--- a/browser-extension/common/src/popup/components/SessionRecording/sessionRecordingView.css
+++ b/browser-extension/common/src/popup/components/SessionRecording/sessionRecordingView.css
@@ -48,7 +48,7 @@
 
 /* tooltip */
 .ant-tooltip.action-btn-tooltip.watch-replay-btn .ant-tooltip-inner {
-  max-width: 235px;
+  max-width: 239px;
 }
 
 .ant-tooltip .watch-replay-btn-tooltip-content {

--- a/browser-extension/common/src/popup/components/SessionRecording/sessionRecordingView.css
+++ b/browser-extension/common/src/popup/components/SessionRecording/sessionRecordingView.css
@@ -45,3 +45,34 @@
   line-height: 16px;
   letter-spacing: 0.4px;
 }
+
+/* tooltip */
+.ant-tooltip.action-btn-tooltip.watch-replay-btn .ant-tooltip-inner {
+  max-width: 235px;
+}
+
+.ant-tooltip .watch-replay-btn-tooltip-content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ant-tooltip .watch-replay-btn-tooltip-content svg {
+  flex-shrink: 0;
+  align-self: flex-start;
+  width: 20px;
+  height: 20px;
+}
+
+.ant-tooltip .watch-replay-btn-tooltip-content button {
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  border: none;
+  text-decoration: underline;
+  background-color: transparent;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: 0.25px;
+}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->