### PR TITLE
[RQ-1134] fix: rule editor scroll stops after tour is shown

### DIFF
--- a/app/src/components/features/rules/RuleBuilder/Body/RuleBuilderBody.css
+++ b/app/src/components/features/rules/RuleBuilder/Body/RuleBuilderBody.css
@@ -5,7 +5,7 @@
 .ant-row.rule-builder-body {
   height: 80vh;
   padding-bottom: 4rem;
-  overflow: auto;
+  overflow: auto !important;
 }
 
 .rule-builder-body > .ant-col {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->