### PR TITLE
fix: add response body to exported logs

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.js
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.js
@@ -333,14 +333,8 @@ const CurrentTrafficTable = ({
     [filterLog]
   );
 
-  /* HACKY WAY TO GET ALL LOG RESPONSES FROM REDUX FOR EXPORT */
   const allResponses = useSelector(getAllResponses);
-  const allResponsesRef = useRef(allResponses);
-  useEffect(() => {
-    allResponsesRef.current = allResponses;
-  }, [allResponses]);
-
-  const getResponseById = (id) => allResponsesRef.current[id];
+  const getResponseById = useCallback((id) => allResponses[id], [allResponses]);
 
   const getFilteredLogsWithResponses = useCallback(
     (logs) => {
@@ -353,7 +347,7 @@ const CurrentTrafficTable = ({
         };
       });
     },
-    [getFilteredLogs]
+    [getFilteredLogs, getResponseById]
   );
 
   const renderLogs = useMemo(

--- a/app/src/store/features/desktop-traffic-table/selectors.ts
+++ b/app/src/store/features/desktop-traffic-table/selectors.ts
@@ -7,8 +7,12 @@ const selectors = logsAdapter.getSelectors((state: any) => state[storeKey]["logs
 
 export const getAllLogs = selectors.selectAll;
 
-export const getLogResponseById = (id: string) => (state: any) => {
-  return state[storeKey]["responses"][id];
+export const getAllResponses = (state: RootState) => {
+  return state[storeKey]["responses"];
+};
+
+export const getLogResponseById = (id: string) => (state: RootState) => {
+  return getAllResponses(state)[id];
 };
 
 export const getAllFilters = (state: RootState) => {


### PR DESCRIPTION
Fixes - https://github.com/requestly/requestly/issues/1252

Creates a dummy reference to the `DESKTOP_TRAFFIC_TABLE.responses` state stored in redux. Had to take this approach because `useSelector` cannot be used inside a callback function.