### PR TITLE
[RQ-1220] added exception when rule saving fails

### DIFF
--- a/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/index.js
@@ -191,6 +191,9 @@ const CreateRuleButton = ({
           if (!isRuleEditorModal) {
             redirectToRuleEditor(navigate, currentlySelectedRuleData.id, MODE);
           }
+        })
+        .catch(() => {
+          toast.error("Error in saving rule. Please contact support.");
         });
     } else {
       toast.warn(ruleValidation.message);

--- a/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/actions/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/actions/index.js
@@ -5,10 +5,11 @@ import { StorageService } from "../../../../../../../init";
 import { generateObjectCreationDate } from "utils/DateTimeUtils";
 import { parseExtensionRules } from "modules/extension/ruleParser";
 import { isExtensionManifestVersion3 } from "actions/ExtensionActions";
-import { trackRuleEditorClosed } from "modules/analytics/events/common/rules";
+import { trackErrorInRuleCreation, trackRuleEditorClosed } from "modules/analytics/events/common/rules";
 import { snakeCase } from "lodash";
 import Logger from "lib/logger";
-import { toast } from "utils/Toast";
+import * as Sentry from "@sentry/react";
+import { detectUnsettledPromise } from "utils/FunctionUtils";
 
 export const saveRule = async (appMode, ruleObject, callback) => {
   //Set the modification date of rule
@@ -23,12 +24,13 @@ export const saveRule = async (appMode, ruleObject, callback) => {
 
   //Save the rule
   Logger.log("Writing to storage in saveRule");
-  await StorageService(appMode).saveRuleOrGroup(ruleToSave);
-  //Fetch the group related to that rule
-  Logger.log("Reading storage in saveRule");
-  return StorageService(appMode)
-    .getRecord(ruleToSave.groupId)
-    .then((result_1) => {
+  const ruleSavePromises = [
+    detectUnsettledPromise(StorageService(appMode).saveRuleOrGroup(ruleToSave), 3000),
+    detectUnsettledPromise(StorageService(appMode).getRecord(ruleToSave.groupId), 3000),
+  ];
+
+  return Promise.all(ruleSavePromises)
+    .then(([_, result_1]) => {
       //Set the modification date of group
       if (result_1 && result_1.objectType === "group") {
         const groupToSave = {
@@ -52,7 +54,10 @@ export const saveRule = async (appMode, ruleObject, callback) => {
       exit();
     })
     .catch(() => {
-      toast.error("Error in saving rule. Please contact support.");
+      Logger.log("Error in saving rule");
+      trackErrorInRuleCreation("save_rule_error", ruleToSave.ruleType);
+      Sentry.captureException(new Error("Extension: Error in saving rule", "fatal"));
+      throw new Error("Error in saving rule");
     });
 };
 

--- a/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/actions/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/actions/index.js
@@ -53,8 +53,8 @@ export const saveRule = async (appMode, ruleObject, callback) => {
       //Continue exit
       exit();
     })
-    .catch(() => {
-      Logger.log("Error in saving rule");
+    .catch((e) => {
+      Logger.log("Error in saving rule:", e);
       trackErrorInRuleCreation("save_rule_error", ruleToSave.ruleType);
       Sentry.captureException(new Error("Extension: Error in saving rule", "fatal"));
       throw new Error("Error in saving rule");

--- a/app/src/components/features/rules/RuleBuilder/actions/utils.js
+++ b/app/src/components/features/rules/RuleBuilder/actions/utils.js
@@ -38,8 +38,8 @@ export const createResponseRule = (appMode, source_url, response_body) => {
 
   let rule = generate_blank_rule_format(rule_type);
   rule.pairs.push(createResponseRulePair(source_url, response_body));
-  saveRule(appMode, rule).catch(() => {
-    Logger.log("Error in create rule: createResponseRule");
+  saveRule(appMode, rule).catch((e) => {
+    Logger.log("createResponseRule:Error in create rule:", e);
   });
   return rule;
 };
@@ -63,8 +63,8 @@ export const updateResponseRule = (appMode, rule_id, source_url, response_body) 
 
   let rule = generate_blank_rule_format(rule_type, rule_id);
   rule.pairs.push(createResponseRulePair(source_url, response_body));
-  saveRule(appMode, rule).catch(() => {
-    Logger.log("Error in saving rule: updateResponseRule");
+  saveRule(appMode, rule).catch((e) => {
+    Logger.log("updateResponseRule: Error in saving rule:", e);
   });
 };
 

--- a/app/src/components/features/rules/RuleBuilder/actions/utils.js
+++ b/app/src/components/features/rules/RuleBuilder/actions/utils.js
@@ -8,6 +8,7 @@ import { generateObjectId } from "../../../../../utils/FormattingHelper";
 import APP_CONSTANTS from "config/constants";
 import { saveRule } from "../Header/ActionButtons/actions";
 import { generateObjectCreationDate } from "utils/DateTimeUtils";
+import Logger from "lib/logger";
 
 const { RULE_TYPES_CONFIG } = APP_CONSTANTS;
 
@@ -37,7 +38,9 @@ export const createResponseRule = (appMode, source_url, response_body) => {
 
   let rule = generate_blank_rule_format(rule_type);
   rule.pairs.push(createResponseRulePair(source_url, response_body));
-  saveRule(appMode, rule);
+  saveRule(appMode, rule).catch(() => {
+    Logger.log("Error in create rule: createResponseRule");
+  });
   return rule;
 };
 
@@ -60,7 +63,9 @@ export const updateResponseRule = (appMode, rule_id, source_url, response_body) 
 
   let rule = generate_blank_rule_format(rule_type, rule_id);
   rule.pairs.push(createResponseRulePair(source_url, response_body));
-  saveRule(appMode, rule);
+  saveRule(appMode, rule).catch(() => {
+    Logger.log("Error in saving rule: updateResponseRule");
+  });
 };
 
 export const getRuleLevelInitialConfigs = (ruleType) => {

--- a/app/src/components/landing/ruleTemplates/RulePreviewModal/index.js
+++ b/app/src/components/landing/ruleTemplates/RulePreviewModal/index.js
@@ -52,13 +52,15 @@ const RulePreviewModal = ({ rule, isOpen, toggle, source }) => {
 
     //triggering started event here for home screen because started event is triggered from templates list page.g
     if (source === AUTH.SOURCE.HOME_SCREEN) trackTemplateImportStarted(snakeCase(ruleToSave.name), source);
-    saveRule(appMode, ruleToSave).then(() => {
-      trackTemplateImportCompleted(snakeCase(ruleToSave.name), source);
-      redirectToRuleEditor(navigate, ruleToSave.id, "templates");
-    }).catch(() => {
-      Logger.log("Error in saving rule: saveRuleTemplate");
-      toast.error("Error in saving rule. Please contact support.");
-    });
+    saveRule(appMode, ruleToSave)
+      .then(() => {
+        trackTemplateImportCompleted(snakeCase(ruleToSave.name), source);
+        redirectToRuleEditor(navigate, ruleToSave.id, "templates");
+      })
+      .catch((e) => {
+        Logger.log("saveRuleTemplate Error in saving rule:", e);
+        toast.error("Error in saving rule. Please contact support.");
+      });
   };
 
   return (

--- a/app/src/components/landing/ruleTemplates/RulePreviewModal/index.js
+++ b/app/src/components/landing/ruleTemplates/RulePreviewModal/index.js
@@ -14,6 +14,8 @@ import { snakeCase } from "lodash";
 import { generateObjectId } from "utils/FormattingHelper";
 import { AUTH } from "modules/analytics/events/common/constants";
 import "./index.css";
+import Logger from "lib/logger";
+import { toast } from "utils/Toast";
 
 const RulePreviewModal = ({ rule, isOpen, toggle, source }) => {
   const navigate = useNavigate();
@@ -53,6 +55,9 @@ const RulePreviewModal = ({ rule, isOpen, toggle, source }) => {
     saveRule(appMode, ruleToSave).then(() => {
       trackTemplateImportCompleted(snakeCase(ruleToSave.name), source);
       redirectToRuleEditor(navigate, ruleToSave.id, "templates");
+    }).catch(() => {
+      Logger.log("Error in saving rule: saveRuleTemplate");
+      toast.error("Error in saving rule. Please contact support.");
     });
   };
 

--- a/app/src/components/misc/CodeEditor/index.tsx
+++ b/app/src/components/misc/CodeEditor/index.tsx
@@ -11,7 +11,6 @@ function FallbackToTrackInfiniteLoading() {
 
     const timeout_5 = setTimeout(() => {
       Sentry.captureMessage("CodeEditor lazy loaded for 5s", "fatal");
-      console.log("!!!debug", "5s timout");
     }, 5000);
     return () => {
       clearTimeout(timeout_10);

--- a/app/src/utils/FunctionUtils.ts
+++ b/app/src/utils/FunctionUtils.ts
@@ -20,3 +20,26 @@ export const retryOrFailSilently = (
   };
   functionToRetry();
 };
+
+export const detectUnsettledPromise = async (promise: Promise<any>, timeoutMillis: number) => {
+  let isResolved = false;
+  let isRejected = false;
+
+  const timeoutPromise = new Promise((_, reject) => {
+    setTimeout(() => {
+      if (!isResolved && !isRejected) {
+        reject(new Error("Promise did not settle within the specified timeout."));
+      }
+    }, timeoutMillis);
+  });
+
+  return Promise.race([promise, timeoutPromise])
+    .then((result) => {
+      isResolved = true;
+      return result;
+    })
+    .catch((error) => {
+      isRejected = true;
+      throw error;
+    });
+};


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:
- The saveRule Promise neither resolves nor rejects in the extension when extension is not available or context invalidated.
- addded a function in UI which rejects the promise on timeout of 3s if unsettled
- show toast to user that rule saving has failed
- logged the exceptions


<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->