### PR TITLE
RQ-1223: show install extension popup on save rule click if extension not installed

### DIFF
--- a/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Header/ActionButtons/CreateRuleButton/index.js
@@ -32,6 +32,8 @@ import { ResponseRuleResourceType } from "types/rules";
 import { runMinorFixesOnRule } from "utils/rules/misc";
 import { PremiumFeature } from "features/pricing";
 import { FeatureLimitType } from "hooks/featureLimiter/types";
+import { isExtensionInstalled } from "actions/ExtensionActions";
+import { actions } from "store";
 import "../RuleEditorActionButtons.css";
 
 const getEventParams = (rule) => {
@@ -112,6 +114,11 @@ const CreateRuleButton = ({
   const currentActionText = MODE === APP_CONSTANTS.RULE_EDITOR_CONFIG.MODES.EDIT ? "Save" : "Create";
 
   const handleBtnOnClick = async () => {
+    if (!isExtensionInstalled()) {
+      dispatch(actions.toggleActiveModal({ modalName: "extensionModal", newValue: true }));
+      return;
+    }
+
     const createdBy = currentlySelectedRuleData?.createdBy || user?.details?.profile?.uid || null;
     const currentOwner = user?.details?.profile?.uid || null;
     const lastModifiedBy = user?.details?.profile?.uid || null;


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->