### PR TITLE
Add sunset warning in android debugger

### DIFF
--- a/app/src/components/features/mobileDebugger/Layout/MobileDebuggerLayout.tsx
+++ b/app/src/components/features/mobileDebugger/Layout/MobileDebuggerLayout.tsx
@@ -1,0 +1,27 @@
+import { Alert } from "antd";
+import { Outlet } from "react-router";
+
+export default function MobileDebuggerLayout() {
+  return (
+    <>
+      <Alert
+        message={
+          <p style={{ marginBottom: "0px" }}>
+            Android debugger will sunset on February 15.{" "}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://requestly.io/blog/saying-goodbye-to-the-requestly-android-debugger/"
+            >
+              Check here to know more.
+            </a>
+          </p>
+        }
+        type="warning"
+        showIcon
+        style={{ margin: "1rem 1.5rem" }}
+      />
+      <Outlet />
+    </>
+  );
+}

--- a/app/src/routes/mobileDebuggerRoutes.tsx
+++ b/app/src/routes/mobileDebuggerRoutes.tsx
@@ -6,26 +6,33 @@ import MobileDebuggerInterceptor from "components/features/mobileDebugger/featur
 import MobileDebuggerUnauthorized from "components/features/mobileDebugger/screens/unauthorized";
 import MobileDebuggerCreateApp from "components/features/mobileDebugger/screens/createApp";
 import ProtectedRoute from "components/authentication/ProtectedRoute";
+import MobileDebuggerLayout from "components/features/mobileDebugger/Layout/MobileDebuggerLayout";
 
 export const mobileDebuggerRoutes: RouteObject[] = [
   {
-    path: PATHS.MOBILE_DEBUGGER.RELATIVE,
-    element: <MobileDebuggerDashboard />,
-  },
-  {
-    path: PATHS.MOBILE_DEBUGGER.HOME.RELATIVE,
-    element: <ProtectedRoute component={MobileDebuggerHome} />,
-  },
-  {
-    path: PATHS.MOBILE_DEBUGGER.INTERCEPTOR.RELATIVE,
-    element: <ProtectedRoute component={MobileDebuggerInterceptor} />,
-  },
-  {
-    path: PATHS.MOBILE_DEBUGGER.UNAUTHORIZED.RELATIVE,
-    element: <MobileDebuggerUnauthorized />,
-  },
-  {
-    path: PATHS.MOBILE_DEBUGGER.NEW.RELATIVE,
-    element: <ProtectedRoute component={MobileDebuggerCreateApp} />,
+    path: PATHS.MOBILE_DEBUGGER.INDEX,
+    element: <MobileDebuggerLayout />,
+    children: [
+      {
+        path: PATHS.MOBILE_DEBUGGER.RELATIVE,
+        element: <MobileDebuggerDashboard />,
+      },
+      {
+        path: PATHS.MOBILE_DEBUGGER.HOME.RELATIVE,
+        element: <ProtectedRoute component={MobileDebuggerHome} />,
+      },
+      {
+        path: PATHS.MOBILE_DEBUGGER.INTERCEPTOR.RELATIVE,
+        element: <ProtectedRoute component={MobileDebuggerInterceptor} />,
+      },
+      {
+        path: PATHS.MOBILE_DEBUGGER.UNAUTHORIZED.RELATIVE,
+        element: <MobileDebuggerUnauthorized />,
+      },
+      {
+        path: PATHS.MOBILE_DEBUGGER.NEW.RELATIVE,
+        element: <ProtectedRoute component={MobileDebuggerCreateApp} />,
+      },
+    ],
   },
 ];


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->