### PR TITLE
[RQ-1327] fix: relay authorization header in case of cross origin XHR redirects

### DIFF
--- a/browser-extension/mv2/src/client/js/requestResponseRuleHandler.js
+++ b/browser-extension/mv2/src/client/js/requestResponseRuleHandler.js
@@ -555,6 +555,16 @@ RQ.RequestResponseRuleHandler.interceptAJAXRequests = function ({
     if (this.responseRule && shouldServeResponseWithoutRequest(this.responseRule)) {
       resolveXHR(this, this.responseRule.pairs[0].response.value);
     } else {
+      const redirectRuleThatMatchesURL = getMatchingRedirectRule(this.requestURL);
+      const replaceRuleThatMatchesURL = getMatchingReplaceRule(this.requestURL);
+      if (redirectRuleThatMatchesURL || replaceRuleThatMatchesURL) {
+        ignoredHeadersOnRedirect.forEach((header) => {
+          const originalHeaderValue = this.requestHeaders?.[header] || this.requestHeaders?.[header.toLowerCase()];
+          if (isExtensionEnabled() && originalHeaderValue) {
+            this.setRequestHeader(customHeaderPrefix + header, originalHeaderValue);
+          }
+        });
+      }
       send.call(this, this.requestData);
     }
   };


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue --> #1208 

## 📜 Summary of changes:

<!-- Summarize your changes -->
As mentioned [here](https://github.com/mdn/content/issues/22533#issuecomment-1458256595)
> XMLHttpRequest builds upon Fetch. It doesn’t define its own network logic. (If we added another API that could set headers it would also end up with this behavior.)

Forwards `authorization` header in case of cross-origin Requestly XHR redirects

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->