### PR TITLE
revert (revert) and fix side effects of recent changes in storage service wrapper

### DIFF
--- a/app/src/actions/TeamWorkspaceActions.js
+++ b/app/src/actions/TeamWorkspaceActions.js
@@ -34,6 +34,8 @@ export const switchWorkspace = async (
   const { teamId, teamName, teamMembersCount } = newWorkspaceDetails;
   let needToMergeRecords = false;
 
+  await StorageService(appMode).waitForAllTransactions();
+
   if (teamId !== null) {
     // We are switching to a given workspace, not clearing the workspace (switching to private)
     const { isSyncEnabled, isWorkspaceMode } = currentSyncingState;
@@ -54,7 +56,6 @@ export const switchWorkspace = async (
   trackWorkspaceSwitched(source);
   dispatch(actions.updateIsRulesListLoading(true));
 
-  setLoader?.();
   if (window.unsubscribeSyncingNodeRef.current && isArray(window.unsubscribeSyncingNodeRef.current)) {
     window.unsubscribeSyncingNodeRef.current.forEach((removeFirebaseListener) => {
       removeFirebaseListener && removeFirebaseListener();
@@ -77,6 +78,7 @@ export const switchWorkspace = async (
   resetSyncDebounce();
 
   // Don't clear when appMode is Extension but user has not installed it!
+  /* CAN BE REPLACED WITH isLocalStoragePresent */
   if (appMode === GLOBAL_CONSTANTS.APP_MODES.EXTENSION && !isExtensionInstalled()) skipStorageClearing = true;
 
   if (!skipStorageClearing) {

--- a/app/src/components/features/rules/RulesListContainer/RulesTable/index.js
+++ b/app/src/components/features/rules/RulesListContainer/RulesTable/index.js
@@ -449,7 +449,7 @@ const RulesTable = ({
     Logger.log("Writing storage in RulesTable changeRuleStatus");
     StorageService(appMode)
       .saveRuleOrGroup(updatedRule, { silentUpdate: true })
-      .then((rule) => {
+      .then(() => {
         //Push Notify
         newStatus === GLOBAL_CONSTANTS.RULE_STATUS.ACTIVE
           ? toast.success(`Rule is now ${newStatus.toLowerCase()}`)
@@ -465,7 +465,8 @@ const RulesTable = ({
           trackRuleToggled(rule.ruleType, "rules_list", newStatus);
         }
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error(err);
         dispatch(actions.updateRecord(rule));
       });
   };

--- a/app/src/features/rules/components/RulesList/components/RulesTable/hooks/useRuleTableActions.tsx
+++ b/app/src/features/rules/components/RulesList/components/RulesTable/hooks/useRuleTableActions.tsx
@@ -133,7 +133,7 @@ const useRuleTableActions = () => {
 
     return StorageService(appMode)
       .saveRuleOrGroup(updatedRule, { silentUpdate: true })
-      .then((rule) => {
+      .then(() => {
         console.log("Rule updated in Storage Service");
       })
       .catch(() => {

--- a/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/TeamSettings/index.js
+++ b/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/TeamSettings/index.js
@@ -46,11 +46,10 @@ const TeamSettings = ({ teamId, isTeamAdmin, isTeamArchived, teamOwnerId }) => {
 
   const handleSwitchToPrivateWorkspace = async () => {
     setIsTeamSwitchModalActive(true);
-    await clearCurrentlyActiveWorkspace(dispatch, appMode);
-    setTimeout(() => {
+    return clearCurrentlyActiveWorkspace(dispatch, appMode).then(() => {
       setIsTeamSwitchModalActive(false);
       showSwitchWorkspaceSuccessToast();
-    }, 2 * 1000);
+    });
   };
 
   const deleteTeam = async () => {

--- a/app/src/hooks/ActiveWorkspace.js
+++ b/app/src/hooks/ActiveWorkspace.js
@@ -67,7 +67,7 @@ const ActiveWorkspace = () => {
   useEffect(() => {
     window.currentlyActiveWorkspaceTeamId = currentlyActiveWorkspace.id;
     window.workspaceMembersCount = currentlyActiveWorkspace?.membersCount ?? null;
-    window.keySetDonecurrentlyActiveWorkspaceTeamId = true;
+    window.keySetDonecurrentlyActiveWorkspaceTeamId = true; // NOT USED ANYWHERE
     window.workspaceCleanupDone = false;
   }, [currentlyActiveWorkspace.id, currentlyActiveWorkspace?.membersCount]);
 };

--- a/app/src/hooks/DbListenerInit/DBListeners.js
+++ b/app/src/hooks/DbListenerInit/DBListeners.js
@@ -34,6 +34,7 @@ const DBListeners = () => {
     if (unsubscribeUserNodeRef.current) unsubscribeUserNodeRef.current(); // Unsubscribe existing user node listener before creating a new one
     if (user?.loggedIn) {
       unsubscribeUserNodeRef.current = userNodeListener(dispatch, user?.details?.profile.uid, appMode);
+      /* CAN BE MOVED TO SEPARATE USE EFFECT AND SHOULD HAVE AN UNSUBSCRIBER TOO, will be useful when actually implementing premium */
       userSubscriptionDocListener(dispatch, user?.details?.profile.uid);
     }
   }, [dispatch, user?.details?.profile.uid, user?.loggedIn, appMode]);
@@ -83,7 +84,7 @@ const DBListeners = () => {
   ]);
 
   // Listens to teams available to the user
-  // Also listens to changes to the currently active workspace
+  // Also listens to changes to the currently active workspace /* TODO: THIS SHOULD BE DONE IN A SEPARATE USEEFFECT */
   useEffect(() => {
     if (unsubscribeAvailableTeams.current) unsubscribeAvailableTeams.current(); // Unsubscribe any existing listener
     if (user?.loggedIn && user?.details?.profile?.uid) {

--- a/app/src/hooks/DbListenerInit/syncingNodeListener.ts
+++ b/app/src/hooks/DbListenerInit/syncingNodeListener.ts
@@ -89,12 +89,13 @@ export const mergeRecordsAndSaveToFirebase = async (
 ): Promise<Record<string, any>[]> => {
   // Fetch all local records based on the current application mode
   const localRecords: Record<string, any>[] = await getAllLocalRecords(appMode);
-  console.log("[DEBUG] mergeRecordsAndSaveToFirebase", { localRecords });
-  console.log("[DEBUG] mergeRecordsAndSaveToFirebase", { recordsOnFirebase });
+  // todo @nsr: remove, just tracking count for now
+  console.log("[DEBUG] mergeRecordsAndSaveToFirebase - length of local", localRecords?.length ?? 0);
+  console.log("[DEBUG] mergeRecordsAndSaveToFirebase - length of recordsOnFirebase", recordsOnFirebase?.length ?? 0);
 
   // Merge the records from Firebase with the local records
   const mergedRecords: Record<string, any>[] = mergeRecords(recordsOnFirebase, localRecords);
-  console.log("[DEBUG] mergeRecordsAndSaveToFirebase", { mergedRecords });
+  console.log("[DEBUG] mergeRecordsAndSaveToFirebase - length of merged", mergedRecords?.length ?? 0);
 
   // Format the merged records into an object where the keys are the record IDs
   const formattedObject: Record<string, any> = mergedRecords.reduce(
@@ -127,6 +128,9 @@ const resolveLocalConflictsAndSaveToFirebase = async (
 ): Promise<any[]> => {
   const localRecords: any[] = await getAllLocalRecords(appMode, false);
   const resolvedRecords: any[] = handleLocalConflicts(recordsOnFirebase, localRecords);
+
+  console.log("[DEBUG] resolveLocalConflictsAndSaveToFirebase - length of local", localRecords?.length ?? 0);
+  console.log("[DEBUG] resolveLocalConflictsAndSaveToFirebase - length of resolved", resolvedRecords?.length ?? 0);
 
   // Write to firebase
   const formattedObject: { [key: string]: any } = {};
@@ -272,8 +276,9 @@ export const invokeSyncingIfRequired = async ({
     dispatch(actions.updateIsRulesListLoading(false));
     return;
   }
+  // this does not make sense!!! Why not just call doSyncDebounced here????
   if (Date.now() - window.syncDebounceTimerStart > waitPeriod) {
-    console.log("DEBUG", "doSyncDebounced");
+    console.log("[DEBUG] invokeSyncingIfRequired - debouncedDosync");
     doSyncDebounced(uid, appMode, dispatch, updatedFirebaseRecords, syncTarget, team_id);
   } else {
     resetSyncDebounce();

--- a/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/index.jsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/index.jsx
@@ -317,14 +317,14 @@ const WorkspaceSelector = () => {
 
   const handleSwitchToPrivateWorkspace = async () => {
     setIsModalOpen(true);
-    await clearCurrentlyActiveWorkspace(dispatch, appMode);
-    setTimeout(() => {
+    return clearCurrentlyActiveWorkspace(dispatch, appMode).then(() => {
       setIsModalOpen(false);
       showSwitchWorkspaceSuccessToast();
-    }, 2 * 1000);
+    });
   };
 
   const handleWorkspaceSwitch = async (team) => {
+    setIsModalOpen(true);
     switchWorkspace(
       {
         teamId: team.id,
@@ -337,15 +337,12 @@ const WorkspaceSelector = () => {
         isWorkspaceMode,
       },
       appMode,
-      () => {
-        setIsModalOpen(true);
-        setTimeout(() => {
-          if (!isModalOpen) showSwitchWorkspaceSuccessToast(team.name);
-          setIsModalOpen(false);
-        }, 2 * 1000);
-      },
+      undefined,
       "workspaces_dropdown"
-    );
+    ).then(() => {
+      if (!isModalOpen) showSwitchWorkspaceSuccessToast(team.name);
+      setIsModalOpen(false);
+    });
   };
 
   const unauthenticatedUserMenu = (

--- a/app/src/utils/StorageServiceWrapper.js
+++ b/app/src/utils/StorageServiceWrapper.js
@@ -90,7 +90,7 @@ class StorageServiceWrapper {
 
   async saveRecord(object) {
     await this.StorageHelper.saveStorageObject(object); // writes to Extension or Desktop storage
-    return Object.values(object)[0];
+    return Object.values(object)[0]; // why???
   }
 
   /**

--- a/app/src/utils/syncing/syncDataUtils.js
+++ b/app/src/utils/syncing/syncDataUtils.js
@@ -68,7 +68,7 @@ const preventWorkspaceSyncWrite = async (key, latestRules, objectId, uid, remote
   const localRecords = myLocalRecords || rulesFlatObjectToObjectIdArray(await getAllLocalRecords(appMode));
   // First, if user has defined a personal rule config and it's key, write it in required db node
   if (typeof localRecords?.[objectId]?.[key] !== "undefined" || key === "isFavourite") {
-    //@sagarsoni7 todo handle: localRecords doesn't contain empty groups. So they won't get updated.
+    //@sagarsoni7 todo handle: localRecords doesn't contain empty groups. So they won't get updated. // @nsr: not hanlded, but is an enhancement, no breaking logic I guess
     const teamUserRuleConfigPath = getTeamUserRuleConfigPath(objectId);
     if (!teamUserRuleConfigPath) return;
     updateValueAsPromise(teamUserRuleConfigPath, {
@@ -93,8 +93,7 @@ const preventWorkspaceSyncWrite = async (key, latestRules, objectId, uid, remote
 };
 
 export const updateUserSyncRecords = async (uid, records, appMode, options) => {
-  const targetWorkspaceId =
-    typeof options.workspaceId !== "undefined" ? options.workspaceId : window.currentlyActiveWorkspaceTeamId;
+  const targetWorkspaceId = options.workspaceId ?? window.currentlyActiveWorkspaceTeamId;
   const isSameWorkspaceOperation = targetWorkspaceId === window.currentlyActiveWorkspaceTeamId;
 
   const latestRules = _.cloneDeep(records); // Does not contain all rules, only contains rules that has been updated.
@@ -102,7 +101,7 @@ export const updateUserSyncRecords = async (uid, records, appMode, options) => {
   // Check if it's team syncing. We might not want to write some props like "isFavourite" to this node. Instead, we can write it to userConfig node
   if (isSameWorkspaceOperation && window.currentlyActiveWorkspaceTeamId) {
     const syncRuleStatus = localStorage.getItem("syncRuleStatus") === "true" || false;
-    // Get current values from db and use them xD
+    // Get current values from db and use them xD // @sagar, what's so funny?
     const allRemoteRecords = (await getValueAsPromise(getRecordsSyncPath())) || {};
     const remoteRecords = {};
     Object.keys(allRemoteRecords).forEach((key) => {
@@ -281,6 +280,7 @@ export const getAllLocalRecords = async (appMode, _sanitizeRules = true) => {
 };
 
 export const saveRecords = (records, appMode) => {
+  // not being used anywhere
   Logger.log("Writing storage in saveRecords");
   return StorageService(appMode).saveMultipleRulesOrGroups(records);
 };


### PR DESCRIPTION
Some parts of the app was expecting the `saveRuleOrGroup` method to also return the saved value.
The fix was only to stop expecting a result to be passed into the following `then`. The callback does not need to be updated since the original `rule` still exists in an outer scope.

The [first commit](https://github.com/requestly/requestly/commit/e891ce5e86b8c5576b0d6286a85e8c178b50e725) just brings back changes from the [original fix](https://github.com/requestly/requestly/pull/1415) (which [was recently reverted](https://github.com/requestly/requestly/pull/1431) because of a severe issue that was introduced, which made it impossible to toggle rules)


<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->