### PR TITLE
fix: move to persona screen if user is already logged in

### DIFF
--- a/app/src/features/onboarding/components/auth/index.tsx
+++ b/app/src/features/onboarding/components/auth/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { getUserAuthDetails } from "store/selectors";
 import { AuthForm } from "./components/Form";
 import { OnboardingAuthBanner } from "./components/Banner";
 import AUTH from "config/constants/sub/auth";
@@ -20,6 +21,7 @@ interface Props {
 
 export const OnboardingAuthScreen: React.FC<Props> = ({ isOpen }) => {
   const dispatch = useDispatch();
+  const user = useSelector(getUserAuthDetails);
   const [authMode, setAuthMode] = useState(AUTH.ACTION_LABELS.SIGN_UP);
   const [email, setEmail] = useState("");
   const [fullName, setFullName] = useState("");
@@ -44,6 +46,12 @@ export const OnboardingAuthScreen: React.FC<Props> = ({ isOpen }) => {
       trackAppOnboardingViewed(ONBOARDING_STEPS.AUTH);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (user.loggedIn) {
+      dispatch(actions.updateAppOnboardingStep(ONBOARDING_STEPS.PERSONA));
+    }
+  }, [user.loggedIn, dispatch]);
 
   return (
     <div className="onboarding-auth-screen-wrapper">

--- a/app/src/features/onboarding/components/auth/index.tsx
+++ b/app/src/features/onboarding/components/auth/index.tsx
@@ -11,7 +11,7 @@ import { updateTimeToResendEmailLogin } from "components/authentication/AuthForm
 import { actions } from "store";
 import Logger from "lib/logger";
 import { BiArrowBack } from "@react-icons/all-files/bi/BiArrowBack";
-import { trackAppOnboardingViewed } from "features/onboarding/analytics";
+import { trackAppOnboardingStepCompleted, trackAppOnboardingViewed } from "features/onboarding/analytics";
 import { m } from "framer-motion";
 import "./index.scss";
 
@@ -50,6 +50,7 @@ export const OnboardingAuthScreen: React.FC<Props> = ({ isOpen }) => {
   useEffect(() => {
     if (user.loggedIn) {
       dispatch(actions.updateAppOnboardingStep(ONBOARDING_STEPS.PERSONA));
+      trackAppOnboardingStepCompleted(ONBOARDING_STEPS.AUTH);
     }
   }, [user.loggedIn, dispatch]);
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->