### PR TITLE
fix: don't show as unsaved changes for first render of script rule

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/CustomScriptRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/CustomScriptRow/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable default-case */
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Row, Col, Input, Tooltip, Typography, Menu, Dropdown, Popconfirm, Button } from "antd";
 import { actions } from "store";
@@ -28,6 +28,7 @@ const CustomScriptRow = ({
 }) => {
   const dispatch = useDispatch();
 
+  const isFirstRender = useRef(true); // to maintain a state for unsaved changes
   const [isCodeTypePopupVisible, setIsCodeTypePopupVisible] = useState(false);
   const [isSourceTypePopupVisible, setIsSourceTypePopupVisible] = useState(false);
   const [codeTypeSelection, setCodeTypeSelection] = useState(GLOBAL_CONSTANTS.SCRIPT_CODE_TYPES.JS);
@@ -186,6 +187,12 @@ const CustomScriptRow = ({
 
   const handleEditorUpdate = useCallback(
     (value) => {
+      const shouldTriggerUnsavedChanges = !isFirstRender.current;
+
+      if (isFirstRender.current) {
+        isFirstRender.current = false;
+      }
+
       if (script.type === GLOBAL_CONSTANTS.SCRIPT_TYPES.URL) {
         /* THIS IS TEMPORARY REPRESENTATION OF SCRIPT ATTRIBUTE */
         dispatch(
@@ -194,13 +201,14 @@ const CustomScriptRow = ({
             updates: {
               [`scripts[${scriptIndex}].wrapperElement`]: value,
             },
+            triggerUnsavedChangesIndication: shouldTriggerUnsavedChanges,
           })
         );
       } else {
         dispatch(
           actions.updateRulePairAtGivenPath({
             pairIndex,
-            triggerUnsavedChangesIndication: !isCodeFormatted,
+            triggerUnsavedChangesIndication: !isCodeFormatted && shouldTriggerUnsavedChanges,
             updates: {
               [`scripts[${scriptIndex}].value`]: value,
             },

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/CustomScriptRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/CustomScriptRow/index.js
@@ -186,13 +186,7 @@ const CustomScriptRow = ({
   };
 
   const handleEditorUpdate = useCallback(
-    (value) => {
-      const shouldTriggerUnsavedChanges = !isFirstRender.current;
-
-      if (isFirstRender.current) {
-        isFirstRender.current = false;
-      }
-
+    (value, triggerUnsavedChanges = true) => {
       if (script.type === GLOBAL_CONSTANTS.SCRIPT_TYPES.URL) {
         /* THIS IS TEMPORARY REPRESENTATION OF SCRIPT ATTRIBUTE */
         dispatch(
@@ -201,14 +195,14 @@ const CustomScriptRow = ({
             updates: {
               [`scripts[${scriptIndex}].wrapperElement`]: value,
             },
-            triggerUnsavedChangesIndication: shouldTriggerUnsavedChanges,
+            triggerUnsavedChangesIndication: triggerUnsavedChanges,
           })
         );
       } else {
         dispatch(
           actions.updateRulePairAtGivenPath({
             pairIndex,
-            triggerUnsavedChangesIndication: !isCodeFormatted && shouldTriggerUnsavedChanges,
+            triggerUnsavedChangesIndication: !isCodeFormatted && triggerUnsavedChanges,
             updates: {
               [`scripts[${scriptIndex}].value`]: value,
             },
@@ -221,7 +215,12 @@ const CustomScriptRow = ({
 
   useEffect(() => {
     if (initialCodeEditorValue !== null) {
-      handleEditorUpdate(initialCodeEditorValue);
+      const shouldTriggerUnsavedChanges = !isFirstRender.current;
+      if (isFirstRender.current) {
+        isFirstRender.current = false;
+      }
+
+      handleEditorUpdate(initialCodeEditorValue, shouldTriggerUnsavedChanges);
     }
   }, [initialCodeEditorValue, handleEditorUpdate]);
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->