### PR TITLE
feat: compress pair values of certain rule types

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -54,6 +54,7 @@
         "md5": "^2.3.0",
         "moment": "^2.29.1",
         "monaco-editor": "^0.41.0",
+        "pako": "^2.1.0",
         "posthog-js": "^1.71.0",
         "prettier": "^2.8.1",
         "react": "^18.2.0",
@@ -97,6 +98,7 @@
         "yargs-parser": "^21.1.1"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@requestly-ui/resource-table": "^0.1.7",
         "@requestly/web-sdk": "0.14.2",
         "@types/chrome": "^0.0.217",
@@ -1054,10 +1056,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
       "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2377,6 +2386,18 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       },
@@ -6582,12 +6603,12 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -6595,7 +6616,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -6734,6 +6755,12 @@
       "dependencies": {
         "pako": "~1.0.5"
       }
+    },
+    "node_modules/browserify-zlib/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "node_modules/browserslist": {
       "version": "4.23.0",
@@ -7170,9 +7197,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8529,16 +8556,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -12675,10 +12702,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -13401,9 +13427,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -18709,10 +18735,16 @@
       }
     },
     "@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      }
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -19588,6 +19620,12 @@
         "semver": "^6.3.1"
       },
       "dependencies": {
+        "@babel/plugin-proposal-private-property-in-object": {
+          "version": "7.21.0-placeholder-for-preset-env.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+          "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+          "dev": true
+        },
         "semver": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -22655,12 +22693,12 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "requires": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -22668,7 +22706,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -22798,6 +22836,14 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+          "dev": true
+        }
       }
     },
     "browserslist": {
@@ -23110,9 +23156,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -24163,16 +24209,16 @@
       }
     },
     "express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -26986,10 +27032,9 @@
       }
     },
     "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -27521,9 +27566,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -84,6 +84,7 @@
     "md5": "^2.3.0",
     "moment": "^2.29.1",
     "monaco-editor": "^0.41.0",
+    "pako": "^2.1.0",
     "posthog-js": "^1.71.0",
     "prettier": "^2.8.1",
     "react": "^18.2.0",
@@ -127,6 +128,7 @@
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@requestly-ui/resource-table": "^0.1.7",
     "@requestly/web-sdk": "0.14.2",
     "@types/chrome": "^0.0.217",

--- a/app/src/config/constants/sub/features.js
+++ b/app/src/config/constants/sub/features.js
@@ -75,4 +75,6 @@ FEATURES.SESSION_RECORDING = "session_recording";
 FEATURES.SAVED_NETWORK_LOGS = "saved_network_logs";
 FEATURES.DESKTOP_SESSIONS = "all_desktop_session_features";
 
+FEATURES.COMPRESS_RULE_PAIRS = "compress_rule_pairs";
+
 export default FEATURES;

--- a/app/src/hooks/DbListenerInit/syncingNodeListener.ts
+++ b/app/src/hooks/DbListenerInit/syncingNodeListener.ts
@@ -26,6 +26,7 @@ import APP_CONSTANTS from "config/constants";
 import { SyncType } from "utils/syncing/SyncUtils";
 // @ts-ignore
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
+import { decompressRecords } from "../../utils/Compression";
 
 type NodeRef = DatabaseReference;
 type Snapshot = DataSnapshot;
@@ -231,7 +232,7 @@ export const resetSyncThrottle = () => {
  *
  * @param {Object} params - The parameters for the function.
  * @param {Function} params.dispatch - Dispatch function to manage the state.
- * @param {Array} params.latestFirebaseRecords - Most recent records fetched from Firebase.
+ * @param {Record<string, any>} params.latestFirebaseRecords - Most recent records fetched from Firebase.
  * @param {string} params.uid - User ID.
  * @param {string} params.team_id - Team ID.
  * @param {('EXTENSION' | 'DESKTOP')}  params.appMode - Current mode of the app.
@@ -248,7 +249,7 @@ export const invokeSyncingIfRequired = async ({
   isSyncEnabled,
 }: {
   dispatch: Function;
-  latestFirebaseRecords?: any[];
+  latestFirebaseRecords?: Record<string, any>;
   uid?: string;
   team_id?: string;
   appMode?: "EXTENSION" | "DESKTOP";
@@ -376,7 +377,7 @@ const syncingNodeListener = (
         onValue(syncNodeRef, async (snap: Snapshot) => {
           await invokeSyncingIfRequired({
             dispatch,
-            latestFirebaseRecords: snap.val(),
+            latestFirebaseRecords: decompressRecords(snap.val()),
             uid,
             team_id,
             appMode,
@@ -392,7 +393,7 @@ const syncingNodeListener = (
         onValue(syncNodeRef, async (snap: Snapshot) => {
           await callInvokeSyncingIfRequiredIfNotCalledRecently({
             dispatch,
-            latestFirebaseRecords: snap.val(),
+            latestFirebaseRecords: decompressRecords(snap.val()),
             uid,
             team_id,
             appMode,

--- a/app/src/utils/Compression.js
+++ b/app/src/utils/Compression.js
@@ -42,7 +42,7 @@ function decompressRecord(record) {
         });
         break;
 
-      case "Script":
+      case RuleType.SCRIPT:
         record.pairs.forEach((pair, idx) => {
           pair.scripts.forEach((script, sidx) => {
             if (script.type === "code" && script.isCompressed) {
@@ -92,7 +92,7 @@ function compressRecord(record) {
         });
         break;
 
-      case "Script":
+      case RuleType.SCRIPT:
         record.pairs.forEach((pair, idx) => {
           pair.scripts.forEach((script, sidx) => {
             if (script.type === "code") {

--- a/app/src/utils/Compression.js
+++ b/app/src/utils/Compression.js
@@ -14,12 +14,6 @@ function compressString(uncompressedString) {
   return base64Compressed;
 }
 
-function shouldDecompressRecord(recordId) {
-  // trying to keep it as efficient as possible by working with ID instead of whole object
-  const recordType = recordId.split("_")[0];
-  return recordType && ["Response", "Request", "Script"].includes(recordType);
-}
-
 function decompressRecord(record) {
   const decompressedRecord = { ...record };
   if (isRule(record)) {
@@ -54,7 +48,7 @@ function decompressRecord(record) {
         });
         break;
       default:
-        console.log("This rule type should not need decompression");
+        break;
     }
   }
   return decompressedRecord;
@@ -63,11 +57,7 @@ function decompressRecord(record) {
 export function decompressRecords(recordsMap) {
   const decompressedRecordsMap = {};
   for (const recordId in recordsMap) {
-    if (shouldDecompressRecord(recordId)) {
-      decompressedRecordsMap[recordId] = decompressRecord(recordsMap[recordId]);
-    } else {
-      decompressedRecordsMap[recordId] = recordsMap[recordId];
-    }
+    decompressedRecordsMap[recordId] = decompressRecord(recordsMap[recordId]);
   }
   return decompressedRecordsMap;
 }
@@ -103,7 +93,7 @@ function compressRecord(record) {
         });
         break;
       default:
-        console.log("This rule type should not need compression");
+        break;
     }
   }
   return compressedRecord;

--- a/app/src/utils/Compression.js
+++ b/app/src/utils/Compression.js
@@ -1,0 +1,118 @@
+import { isRule } from "features/rules";
+import pako from "pako";
+import { RuleType } from "types";
+
+function decompressString(compressedString) {
+  const compressed = Buffer.from(compressedString, "base64");
+  const uncompressed = pako.inflate(compressed, { to: "string" });
+  return uncompressed;
+}
+
+function compressString(uncompressedString) {
+  const compressed = pako.deflate(uncompressedString, { to: "string" });
+  const base64Compressed = Buffer.from(compressed).toString("base64");
+  return base64Compressed;
+}
+
+function shouldDecompressRecord(recordId) {
+  // trying to keep it as efficient as possible by working with ID instead of whole object
+  const recordType = recordId.split("_")[0];
+  return recordType && ["Response", "Request", "Script"].includes(recordType);
+}
+
+function decompressRecord(record) {
+  const decompressedRecord = { ...record };
+  if (isRule(record)) {
+    switch (record.ruleType) {
+      case RuleType.RESPONSE:
+        record.pairs.forEach((pair, idx) => {
+          if (pair.isCompressed) {
+            const decompressedVal = decompressString(pair?.response?.value ?? "");
+            decompressedRecord.pairs[idx].response.value = decompressedVal;
+          }
+        });
+        break;
+
+      case RuleType.REQUEST:
+        record.pairs.forEach((pair, idx) => {
+          if (pair.isCompressed) {
+            const decompressedVal = decompressString(pair?.request?.value ?? "");
+            decompressedRecord.pairs[idx].request.value = decompressedVal;
+          }
+        });
+        break;
+
+      case "Script":
+        record.pairs.forEach((pair, idx) => {
+          pair.scripts.forEach((script, sidx) => {
+            if (script.type === "code" && script.isCompressed) {
+              const ScriptValue = script?.value;
+              const compressedValue = decompressString(ScriptValue ?? "");
+              decompressedRecord.pairs[idx].scripts[sidx].value = compressedValue;
+            }
+          });
+        });
+        break;
+      default:
+        console.log("This rule type should not need decompression");
+    }
+  }
+  return decompressedRecord;
+}
+
+export function decompressRecords(recordsMap) {
+  const decompressedRecordsMap = {};
+  for (const recordId in recordsMap) {
+    if (shouldDecompressRecord(recordId)) {
+      decompressedRecordsMap[recordId] = decompressRecord(recordsMap[recordId]);
+    } else {
+      decompressedRecordsMap[recordId] = recordsMap[recordId];
+    }
+  }
+  return decompressedRecordsMap;
+}
+
+function compressRecord(record) {
+  const compressedRecord = { ...record };
+  if (isRule(record)) {
+    switch (record.ruleType) {
+      case RuleType.RESPONSE:
+        record.pairs.forEach((pair, idx) => {
+          const compressedVal = compressString(pair?.response?.value ?? "");
+          compressedRecord.pairs[idx].response.value = compressedVal;
+          compressedRecord.pairs[idx].isCompressed = true;
+        });
+        break;
+
+      case RuleType.REQUEST:
+        record.pairs.forEach((pair, idx) => {
+          const compressedVal = compressString(pair?.request?.value ?? "");
+          compressedRecord.pairs[idx].request.value = compressedVal;
+          compressedRecord.pairs[idx].isCompressed = true;
+        });
+        break;
+
+      case "Script":
+        record.pairs.forEach((pair, idx) => {
+          pair.scripts.forEach((script, sidx) => {
+            if (script.type === "code") {
+              compressedRecord.pairs[idx].scripts[sidx].value = compressString(script?.value ?? "");
+              compressedRecord.pairs[idx].scripts[sidx].isCompressed = true;
+            }
+          });
+        });
+        break;
+      default:
+        console.log("This rule type should not need compression");
+    }
+  }
+  return compressedRecord;
+}
+
+export function compressRecords(recordsMap) {
+  const compressedRecordsMap = {};
+  for (const recordId in recordsMap) {
+    compressedRecordsMap[recordId] = compressRecord(recordsMap[recordId]);
+  }
+  return compressedRecordsMap;
+}


### PR DESCRIPTION
compresses the pair value for 
1. Response rule
2. Request rule
3. Script rule that are of code type

in transit (to and from firebase) and storage. 
Syncing still works on the complete (uncompressed) records