### PR TITLE
fix (old table): deleteGroup should also delete group record from local storage

### DIFF
--- a/app/src/components/features/rules/RulesListContainer/RulesTable/index.js
+++ b/app/src/components/features/rules/RulesListContainer/RulesTable/index.js
@@ -345,7 +345,7 @@ const RulesTable = ({
       setGroupToEmpty(groupData.id);
       event.stopPropagation();
 
-      deleteGroup(appMode, groupData.id, groupwiseRulesToPopulate)
+      deleteGroup(appMode, groupData.id, groupwiseRulesToPopulate, true)
         .then(async (args) => {
           if (args && args.err) {
             if (args.err === "ungroup-rules-first") {


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->