### PR TITLE
chore: wrap compress/decompress in try-catch

### DIFF
--- a/app/src/utils/Compression.js
+++ b/app/src/utils/Compression.js
@@ -8,19 +8,19 @@ function decompressString(compressedString) {
     const uncompressed = pako.inflate(compressed, { to: "string" });
     return uncompressed;
   } catch (error) {
-    console.debug("Error decompressing string", error, compressedString);
-    return compressedString;
+    console.log("[DEBUG] Error decompressing string", error, compressedString);
+    throw compressedString;
   }
 }
 
 function compressString(uncompressedString) {
   try {
-    const compressed = pako.deflate(uncompressedString, { to: "string" });
+    const compressed = pako.deflate(uncompressedString);
     const base64Compressed = Buffer.from(compressed).toString("base64");
     return base64Compressed;
   } catch (error) {
-    console.debug("Error compressing string", error, uncompressedString);
-    return uncompressedString;
+    console.log("[DEBUG] Error compressing string", error, uncompressedString);
+    throw uncompressedString;
   }
 }
 

--- a/app/src/utils/Compression.js
+++ b/app/src/utils/Compression.js
@@ -9,7 +9,7 @@ function decompressString(compressedString) {
     return uncompressed;
   } catch (error) {
     console.log("[DEBUG] Error decompressing string", error, compressedString);
-    throw compressedString;
+    throw error;
   }
 }
 
@@ -20,7 +20,7 @@ function compressString(uncompressedString) {
     return base64Compressed;
   } catch (error) {
     console.log("[DEBUG] Error compressing string", error, uncompressedString);
-    throw uncompressedString;
+    throw error;
   }
 }
 

--- a/app/src/utils/Compression.js
+++ b/app/src/utils/Compression.js
@@ -26,6 +26,7 @@ function compressString(uncompressedString) {
 
 function decompressRecord(record) {
   const decompressedRecord = { ...record };
+  console.log("[DEBUG] Decompressing Record", record?.id);
   if (isRule(record)) {
     switch (record.ruleType) {
       case RuleType.RESPONSE:

--- a/app/src/utils/Compression.js
+++ b/app/src/utils/Compression.js
@@ -3,15 +3,25 @@ import pako from "pako";
 import { RuleType } from "types";
 
 function decompressString(compressedString) {
-  const compressed = Buffer.from(compressedString, "base64");
-  const uncompressed = pako.inflate(compressed, { to: "string" });
-  return uncompressed;
+  try {
+    const compressed = Buffer.from(compressedString, "base64");
+    const uncompressed = pako.inflate(compressed, { to: "string" });
+    return uncompressed;
+  } catch (error) {
+    console.debug("Error decompressing string", error, compressedString);
+    return compressedString;
+  }
 }
 
 function compressString(uncompressedString) {
-  const compressed = pako.deflate(uncompressedString, { to: "string" });
-  const base64Compressed = Buffer.from(compressed).toString("base64");
-  return base64Compressed;
+  try {
+    const compressed = pako.deflate(uncompressedString, { to: "string" });
+    const base64Compressed = Buffer.from(compressed).toString("base64");
+    return base64Compressed;
+  } catch (error) {
+    console.debug("Error compressing string", error, uncompressedString);
+    return uncompressedString;
+  }
 }
 
 function decompressRecord(record) {


### PR DESCRIPTION
Observed a case where syncing completely stops if the console shows the error `incorrect header check` from the compression logic. 

Couldn't consistently reproduce but this should stop the error from halting the complete syncing flow and making the app unusable