### PR TITLE
fix: don't mark as unsaved changes on start of rule creation

### DIFF
--- a/app/src/components/features/rules/RuleBuilder/Body/actions/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Body/actions/index.js
@@ -1,7 +1,7 @@
 //Actions
 import { setCurrentlySelectedRule } from "../../actions";
 
-export const onChangeHandler = (currentlySelectedRuleData, dispatch, event) => {
+export const onChangeHandler = (currentlySelectedRuleData, dispatch, event, warnForUnsavedChanges = true) => {
   const input = event.target;
 
   setCurrentlySelectedRule(
@@ -10,6 +10,6 @@ export const onChangeHandler = (currentlySelectedRuleData, dispatch, event) => {
       ...currentlySelectedRuleData,
       [input.name]: input.type === "checkbox" ? input.checked : input.value,
     },
-    true
+    warnForUnsavedChanges
   );
 };

--- a/app/src/components/features/rules/RuleBuilder/Body/index.js
+++ b/app/src/components/features/rules/RuleBuilder/Body/index.js
@@ -25,9 +25,9 @@ const Body = ({ mode, showDocs, currentlySelectedRuleConfig }) => {
   const getEventObject = (name, value) => ({ target: { name, value } });
 
   const handleRuleNameChange = useCallback(
-    (name) => {
+    (name, warnForUnsavedChanges = true) => {
       const event = getEventObject("name", name);
-      onChangeHandler(currentlySelectedRuleData, dispatch, event);
+      onChangeHandler(currentlySelectedRuleData, dispatch, event, warnForUnsavedChanges);
     },
     [dispatch, currentlySelectedRuleData]
   );

--- a/app/src/lib/design-system/components/RQEditorTitle/index.tsx
+++ b/app/src/lib/design-system/components/RQEditorTitle/index.tsx
@@ -14,7 +14,7 @@ interface TitleProps {
   description: string;
   namePlaceholder: string;
   descriptionPlaceholder: string;
-  nameChangeCallback: (name: string) => void;
+  nameChangeCallback: (name: string, warnForUnsavedChanges?: boolean) => void;
   descriptionChangeCallback: (desc: string) => void;
   errors?: ValidationErrors;
   mode?: "create" | "edit";
@@ -59,7 +59,7 @@ export const RQEditorTitle: React.FC<TitleProps> = ({
   useEffect(() => {
     if (!defaultName || mode === "edit") return;
 
-    nameChangeCallback(defaultName);
+    nameChangeCallback(defaultName, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, defaultName]);
 

--- a/app/src/utils/helpers/appDetails/UserProvider.ts
+++ b/app/src/utils/helpers/appDetails/UserProvider.ts
@@ -1,5 +1,5 @@
 import { getDomainFromEmail, isCompanyEmail } from "utils/FormattingHelper";
-
+/* was created for integrations but no longer used */
 export type User = {
   id: string;
   email?: string;


### PR DESCRIPTION
- ignore the extra comment string added
- Was happening because we set the default name of the rule

<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->