### PR TITLE
[ENGG-1635] fix: hide secondary sidebar in rule editor

### DIFF
--- a/app/src/features/rules/components/RulesSidebar/RulesSidebar.tsx
+++ b/app/src/features/rules/components/RulesSidebar/RulesSidebar.tsx
@@ -1,9 +1,12 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PATHS from "config/constants/sub/paths";
 import MyRulesIcon from "assets/icons/http-rules/my-rules.svg?react";
 import TemplatesIcon from "assets/icons/http-rules/templates.svg?react";
 import SharedListIcon from "assets/icons/http-rules/shared-list.svg?react";
 import { SecondarySidebar } from "componentsV2/SecondarySidebar";
+import { useLocation } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { actions } from "store";
 
 const rulesSidebarItems = [
   {
@@ -24,5 +27,21 @@ const rulesSidebarItems = [
 ];
 
 export const RulesSidebar: React.FC = () => {
+  const location = useLocation();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (location.pathname.includes(PATHS.RULES.MY_RULES.ABSOLUTE)) {
+      // @ts-ignore
+      dispatch(actions.updateSecondarySidebarCollapse(false));
+    } else if (location.pathname.startsWith(PATHS.RULE_EDITOR.ABSOLUTE)) {
+      // @ts-ignore
+      dispatch(actions.updateSecondarySidebarCollapse(true));
+    } else {
+      // @ts-ignore
+      dispatch(actions.updateSecondarySidebarCollapse(false));
+    }
+  }, [dispatch, location]);
+
   return <SecondarySidebar items={rulesSidebarItems} />;
 };

--- a/app/src/features/rules/routes.tsx
+++ b/app/src/features/rules/routes.tsx
@@ -2,7 +2,6 @@ import { Navigate, RouteObject } from "react-router-dom";
 import TemplatesIndexPage from "components/landing/ruleTemplates";
 import PATHS from "config/constants/sub/paths";
 import { RulesContainer } from "views/containers/RulesContainer";
-// import RulesIndexView from "views/features/rules/RulesIndexView";
 import SharedListsIndexPage from "components/features/sharedLists/SharedListsIndexPage";
 import TrashIndexPage from "components/features/trash/TrashIndexPage";
 import RuleEditor from "views/features/rules/RuleEditor";
@@ -21,14 +20,6 @@ export const ruleRoutes: RouteObject[] = [
     path: PATHS.RULES.INDEX,
     element: <RulesContainer />,
     children: [
-      {
-        path: joinPaths(PATHS.RULE_EDITOR.RELATIVE, PATHS.ANY),
-        element: <RuleEditor />,
-      },
-      {
-        path: joinPaths(PATHS.RULE_EDITOR.CREATE_RULE.RELATIVE, "/:ruleType"),
-        element: <RuleEditor />,
-      },
       {
         path: PATHS.SHARED_LISTS.RELATIVE,
         element: <SharedListsIndexPage />,
@@ -79,6 +70,15 @@ export const ruleRoutes: RouteObject[] = [
       {
         path: `${PATHS.RULES.MY_RULES.RELATIVE}`,
         element: <RulesListScreen />,
+      },
+      // TODO:  VV Needs Refractoring below this VV
+      {
+        path: joinPaths(PATHS.RULE_EDITOR.RELATIVE, PATHS.ANY),
+        element: <RuleEditor />,
+      },
+      {
+        path: joinPaths(PATHS.RULE_EDITOR.CREATE_RULE.RELATIVE, "/:ruleType"),
+        element: <RuleEditor />,
       },
     ],
   },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->