### PR TITLE
fix: oneTap prompt gets shown even when loggedIn

### DIFF
--- a/app/src/components/features/rules/GettingStarted/WorkspaceOnboarding/OnboardingSteps/OnboardingAuthForm/index.tsx
+++ b/app/src/components/features/rules/GettingStarted/WorkspaceOnboarding/OnboardingSteps/OnboardingAuthForm/index.tsx
@@ -10,7 +10,7 @@ interface FormProps {
 }
 
 export const OnboardingAuthForm: React.FC<FormProps> = ({ callback }) => {
-  const { isNewUser, loggedInUsingOneTap } = useGoogleOneTapLogin();
+  const { isNewUser, isLoggedInUsingOneTapPrompt: loggedInUsingOneTap } = useGoogleOneTapLogin();
   const [authMode, setAuthMode] = useState(APP_CONSTANTS.AUTH.ACTION_LABELS.SIGN_UP);
 
   useEffect(() => {

--- a/app/src/features/rules/screens/rulesList/components/RulesList/components/GettingStarted/WorkspaceOnboarding/OnboardingSteps/OnboardingAuthForm/index.tsx
+++ b/app/src/features/rules/screens/rulesList/components/RulesList/components/GettingStarted/WorkspaceOnboarding/OnboardingSteps/OnboardingAuthForm/index.tsx
@@ -10,7 +10,7 @@ interface FormProps {
 }
 
 export const OnboardingAuthForm: React.FC<FormProps> = ({ callback }) => {
-  const { isNewUser, loggedInUsingOneTap } = useGoogleOneTapLogin();
+  const { isNewUser, isLoggedInUsingOneTapPrompt } = useGoogleOneTapLogin();
   const [authMode, setAuthMode] = useState(APP_CONSTANTS.AUTH.ACTION_LABELS.SIGN_UP);
 
   useEffect(() => {
@@ -18,10 +18,10 @@ export const OnboardingAuthForm: React.FC<FormProps> = ({ callback }) => {
   }, []);
 
   useEffect(() => {
-    if (loggedInUsingOneTap) {
+    if (isLoggedInUsingOneTapPrompt) {
       callback.onSignInSuccess(null, isNewUser);
     }
-  }, [callback, isNewUser, loggedInUsingOneTap]);
+  }, [callback, isNewUser, isLoggedInUsingOneTapPrompt]);
   return (
     <>
       <AuthForm

--- a/app/src/hooks/useGoogleOneTapLogin.ts
+++ b/app/src/hooks/useGoogleOneTapLogin.ts
@@ -40,7 +40,7 @@ export const useGoogleOneTapLogin = () => {
   const [isNewUser, setIsNewUser] = useState<boolean>(false);
   const [oneTapScriptInitialized, setOneTapScriptInitialized] = useState<boolean>(false);
   const [oneTapPromptShown, setOneTapPromptShown] = useState<boolean>(false);
-  const [loggedInUsingOneTap, setIsLoggedInUsingOneTap] = useState<boolean>(false);
+  const [isLoggedInUsingOneTapPrompt, setIsLoggedInUsingOneTapPrompt] = useState<boolean>(false);
   const scriptStatus = useScript(googleSignInScriptURL);
   const user = useSelector(getUserAuthDetails);
   const appMode = useSelector(getAppMode);
@@ -55,7 +55,7 @@ export const useGoogleOneTapLogin = () => {
   const handleSignIn = async (credential: CredentialResponse) => {
     handleOnetapSignIn(credential).then((res) => {
       setIsNewUser(res.is_new_user);
-      setIsLoggedInUsingOneTap(true);
+      setIsLoggedInUsingOneTapPrompt(true);
     });
   };
 
@@ -88,15 +88,15 @@ export const useGoogleOneTapLogin = () => {
   useEffect(() => {
     if (!user?.loggedIn) {
       setIsNewUser(false);
-      setIsLoggedInUsingOneTap(false);
+      setIsLoggedInUsingOneTapPrompt(false);
     }
   }, [user?.loggedIn]);
 
   return {
-    initializeOnetap: () => listener,
+    initializeOneTap: () => listener,
     promptOneTap,
     shouldShowOneTapPrompt,
     isNewUser,
-    loggedInUsingOneTap,
+    isLoggedInUsingOneTapPrompt,
   };
 };

--- a/app/src/hooks/useGoogleOneTapLogin.ts
+++ b/app/src/hooks/useGoogleOneTapLogin.ts
@@ -25,7 +25,7 @@ interface CredentialResponse {
   client_id: string;
 }
 
-export const shouldShowOneTapPrompt = () => {
+const shouldShowOneTapPrompt = () => {
   if (
     window.location.href.includes(PATHS.AUTH.DEKSTOP_SIGN_IN.RELATIVE) ||
     window.location.href.includes(PATHS.AUTH.EMAIL_ACTION.RELATIVE) ||
@@ -39,7 +39,7 @@ export const shouldShowOneTapPrompt = () => {
 export const useGoogleOneTapLogin = () => {
   const [isNewUser, setIsNewUser] = useState<boolean>(false);
   const [oneTapScriptInitialized, setOneTapScriptInitialized] = useState<boolean>(false);
-  const [onetapPromptShown, setShownOnetapPromptShown] = useState<boolean>(false);
+  const [oneTapPromptShown, setOneTapPromptShown] = useState<boolean>(false);
   const [loggedInUsingOneTap, setIsLoggedInUsingOneTap] = useState<boolean>(false);
   const scriptStatus = useScript(googleSignInScriptURL);
   const user = useSelector(getUserAuthDetails);
@@ -47,10 +47,10 @@ export const useGoogleOneTapLogin = () => {
   const userLoginHasChanged = useHasChanged(user?.loggedIn);
 
   useEffect(() => {
-    if (userLoginHasChanged && !user?.loggedIn && onetapPromptShown) {
-      setShownOnetapPromptShown(false);
+    if (userLoginHasChanged && !user?.loggedIn && oneTapPromptShown) {
+      setOneTapPromptShown(false);
     }
-  }, [userLoginHasChanged, user?.loggedIn, onetapPromptShown]);
+  }, [userLoginHasChanged, user?.loggedIn, oneTapPromptShown]);
 
   const handleSignIn = async (credential: CredentialResponse) => {
     handleOnetapSignIn(credential).then((res) => {
@@ -79,11 +79,11 @@ export const useGoogleOneTapLogin = () => {
   }, [scriptStatus, config, oneTapScriptInitialized]);
 
   const promptOneTap = useCallback(() => {
-    if (oneTapScriptInitialized && window.google && !onetapPromptShown) {
+    if (oneTapScriptInitialized && window.google && !oneTapPromptShown) {
       window.google.accounts.id.prompt();
-      setShownOnetapPromptShown(true);
+      setOneTapPromptShown(true);
     }
-  }, [oneTapScriptInitialized, onetapPromptShown]);
+  }, [oneTapScriptInitialized, oneTapPromptShown]);
 
   useEffect(() => {
     if (!user?.loggedIn) {
@@ -95,6 +95,7 @@ export const useGoogleOneTapLogin = () => {
   return {
     initializeOnetap: () => listener,
     promptOneTap,
+    shouldShowOneTapPrompt,
     isNewUser,
     loggedInUsingOneTap,
   };

--- a/app/src/hooks/useGoogleOneTapLogin.ts
+++ b/app/src/hooks/useGoogleOneTapLogin.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useScript } from "./useScript";
 import { useSelector } from "react-redux";
 import { getUserAuthDetails, getAppMode } from "store/selectors";
@@ -6,6 +6,8 @@ import { handleOnetapSignIn } from "actions/FirebaseActions";
 import { isAppOpenedInIframe } from "utils/AppUtils";
 //@ts-ignore
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
+import PATHS from "config/constants/sub/paths";
+import { useHasChanged } from "./useHasChanged";
 
 //google signIn client libary for fetching user cred
 const googleSignInScriptURL: string = "https://accounts.google.com/gsi/client";
@@ -23,12 +25,32 @@ interface CredentialResponse {
   client_id: string;
 }
 
+export const shouldShowOneTapPrompt = () => {
+  if (
+    window.location.href.includes(PATHS.AUTH.DEKSTOP_SIGN_IN.RELATIVE) ||
+    window.location.href.includes(PATHS.AUTH.EMAIL_ACTION.RELATIVE) ||
+    window.location.href.includes(PATHS.AUTH.EMAIL_LINK_SIGNIN.RELATIVE)
+  ) {
+    return false;
+  }
+  return true;
+};
+
 export const useGoogleOneTapLogin = () => {
   const [isNewUser, setIsNewUser] = useState<boolean>(false);
+  const [oneTapScriptInitialized, setOneTapScriptInitialized] = useState<boolean>(false);
+  const [onetapPromptShown, setShownOnetapPromptShown] = useState<boolean>(false);
   const [loggedInUsingOneTap, setIsLoggedInUsingOneTap] = useState<boolean>(false);
-  const script = useScript(googleSignInScriptURL);
+  const scriptStatus = useScript(googleSignInScriptURL);
   const user = useSelector(getUserAuthDetails);
   const appMode = useSelector(getAppMode);
+  const userLoginHasChanged = useHasChanged(user?.loggedIn);
+
+  useEffect(() => {
+    if (userLoginHasChanged && !user?.loggedIn && onetapPromptShown) {
+      setShownOnetapPromptShown(false);
+    }
+  }, [userLoginHasChanged, user?.loggedIn, onetapPromptShown]);
 
   const handleSignIn = async (credential: CredentialResponse) => {
     handleOnetapSignIn(credential).then((res) => {
@@ -50,11 +72,18 @@ export const useGoogleOneTapLogin = () => {
   }, [user?.loggedIn, appMode]);
 
   const listener = useEffect(() => {
-    if (script === "ready" && !config.disabled && window.google) {
+    if (scriptStatus === "ready" && !config.disabled && window.google && !oneTapScriptInitialized) {
       window.google.accounts.id.initialize({ ...config });
-      window.google.accounts.id.prompt();
+      setOneTapScriptInitialized(true);
     }
-  }, [script, config]);
+  }, [scriptStatus, config, oneTapScriptInitialized]);
+
+  const promptOneTap = useCallback(() => {
+    if (oneTapScriptInitialized && window.google && !onetapPromptShown) {
+      window.google.accounts.id.prompt();
+      setShownOnetapPromptShown(true);
+    }
+  }, [oneTapScriptInitialized, onetapPromptShown]);
 
   useEffect(() => {
     if (!user?.loggedIn) {
@@ -64,7 +93,8 @@ export const useGoogleOneTapLogin = () => {
   }, [user?.loggedIn]);
 
   return {
-    promptOneTapOnLoad: () => listener,
+    initializeOnetap: () => listener,
+    promptOneTap,
     isNewUser,
     loggedInUsingOneTap,
   };

--- a/app/src/layouts/DashboardLayout/index.jsx
+++ b/app/src/layouts/DashboardLayout/index.jsx
@@ -7,7 +7,7 @@ import Footer from "../../components/sections/Footer";
 import DashboardContent from "./DashboardContent";
 import { Sidebar } from "./Sidebar";
 import MenuHeader from "./MenuHeader";
-import { shouldShowOneTapPrompt, useGoogleOneTapLogin } from "hooks/useGoogleOneTapLogin";
+import { useGoogleOneTapLogin } from "hooks/useGoogleOneTapLogin";
 import { removeElement } from "utils/domUtils";
 import { isAppOpenedInIframe } from "utils/AppUtils";
 import { AppNotificationBanner } from "../../componentsV2/AppNotificationBanner";
@@ -21,11 +21,11 @@ const DashboardLayout = () => {
   const dispatch = useDispatch();
   const location = useLocation();
   const { pathname } = location;
-  const { initializeOnetap, promptOneTap } = useGoogleOneTapLogin();
+  const { initializeOneTap, promptOneTap, shouldShowOneTapPrompt } = useGoogleOneTapLogin();
   const user = useSelector(getUserAuthDetails);
   const isPlanExpiredBannerClosed = useSelector(getIsPlanExpiredBannerClosed);
 
-  initializeOnetap();
+  initializeOneTap();
 
   if (shouldShowOneTapPrompt()) {
     promptOneTap();

--- a/app/src/layouts/DashboardLayout/index.jsx
+++ b/app/src/layouts/DashboardLayout/index.jsx
@@ -7,7 +7,7 @@ import Footer from "../../components/sections/Footer";
 import DashboardContent from "./DashboardContent";
 import { Sidebar } from "./Sidebar";
 import MenuHeader from "./MenuHeader";
-import { useGoogleOneTapLogin } from "hooks/useGoogleOneTapLogin";
+import { shouldShowOneTapPrompt, useGoogleOneTapLogin } from "hooks/useGoogleOneTapLogin";
 import { removeElement } from "utils/domUtils";
 import { isAppOpenedInIframe } from "utils/AppUtils";
 import { AppNotificationBanner } from "../../componentsV2/AppNotificationBanner";
@@ -21,11 +21,15 @@ const DashboardLayout = () => {
   const dispatch = useDispatch();
   const location = useLocation();
   const { pathname } = location;
-  const { promptOneTapOnLoad } = useGoogleOneTapLogin();
+  const { initializeOnetap, promptOneTap } = useGoogleOneTapLogin();
   const user = useSelector(getUserAuthDetails);
   const isPlanExpiredBannerClosed = useSelector(getIsPlanExpiredBannerClosed);
 
-  promptOneTapOnLoad();
+  initializeOnetap();
+
+  if (shouldShowOneTapPrompt()) {
+    promptOneTap();
+  }
 
   const isSidebarVisible = useMemo(
     () => !(isPricingPage(pathname) || isGoodbyePage(pathname) || isInvitePage(pathname) || isSettingsPage(pathname)),


### PR DESCRIPTION
Also removes the prompt from 
- [X] Desktop sign helper route
- [X] Email action routes

Builds on top of https://github.com/requestly/requestly/pull/1625 so fixes have been tested on FedCM enabled OneTap