### PR TITLE
fix: implicit widget not lisiting applied rules when listener is not active

### DIFF
--- a/browser-extension/common/src/custom-elements/test-rule-widget/implicit-test-rule-widget/index.ts
+++ b/browser-extension/common/src/custom-elements/test-rule-widget/implicit-test-rule-widget/index.ts
@@ -36,6 +36,7 @@ class RQImplicitTestRuleWidget extends RQTestRuleWidget {
 
   addWidgetListeners() {
     this.addEventListener("new-rule-applied", (evt: CustomEvent) => {
+      this.setAttribute("applied_listener_active", "true");
       const isRuleAlreadyApplied = this.#appliedRules.some((rule) => rule.ruleId === evt.detail.appliedRuleId);
       if (isRuleAlreadyApplied) return;
 

--- a/browser-extension/common/src/custom-elements/test-rule-widget/implicit-test-rule-widget/index.ts
+++ b/browser-extension/common/src/custom-elements/test-rule-widget/implicit-test-rule-widget/index.ts
@@ -36,7 +36,7 @@ class RQImplicitTestRuleWidget extends RQTestRuleWidget {
 
   addWidgetListeners() {
     this.addEventListener("new-rule-applied", (evt: CustomEvent) => {
-      this.setAttribute("applied_listener_active", "true");
+      this.dispatchEvent(new CustomEvent("rule_applied_listener_active"));
       const isRuleAlreadyApplied = this.#appliedRules.some((rule) => rule.ruleId === evt.detail.appliedRuleId);
       if (isRuleAlreadyApplied) return;
 

--- a/browser-extension/common/src/custom-elements/test-rule-widget/implicit-test-rule-widget/index.ts
+++ b/browser-extension/common/src/custom-elements/test-rule-widget/implicit-test-rule-widget/index.ts
@@ -36,7 +36,6 @@ class RQImplicitTestRuleWidget extends RQTestRuleWidget {
 
   addWidgetListeners() {
     this.addEventListener("new-rule-applied", (evt: CustomEvent) => {
-      this.dispatchEvent(new CustomEvent("rule_applied_listener_active"));
       const isRuleAlreadyApplied = this.#appliedRules.some((rule) => rule.ruleId === evt.detail.appliedRuleId);
       if (isRuleAlreadyApplied) return;
 
@@ -52,6 +51,8 @@ class RQImplicitTestRuleWidget extends RQTestRuleWidget {
     this.shadowRoot.getElementById("settings-button").addEventListener("click", () => {
       this.dispatchEvent(new CustomEvent("open_app_settings"));
     });
+
+    this.dispatchEvent(new CustomEvent("rule_applied_listener_active"));
   }
 
   triggerAppliedRuleClickedEvent(detail: any) {

--- a/browser-extension/mv2/src/client/js/ruleExecutionHandler.js
+++ b/browser-extension/mv2/src/client/js/ruleExecutionHandler.js
@@ -180,7 +180,7 @@ RQ.RuleExecutionHandler.notifyRuleAppliedToExplicitWidget = (ruleId) => {
   }
 };
 
-RQ.RuleExecutionHandler.notifyRuleAppliedToImplicitWidget = async (rule) => {
+RQ.RuleExecutionHandler.notifyRuleAppliedToImplicitWidget = (rule) => {
   const implicitTestRuleWidget = document.querySelector("rq-implicit-test-rule-widget");
 
   if (implicitTestRuleWidget) {
@@ -198,8 +198,8 @@ RQ.RuleExecutionHandler.notifyRuleAppliedToImplicitWidget = async (rule) => {
   }
 };
 
-RQ.RuleExecutionHandler.fetchAndStoreImplicitTestRuleWidgetConfig = async () => {
-  await chrome.storage.local.get(RQ.STORAGE_KEYS.IMPLICIT_RULE_TESTING_WIDGET_CONFIG, function (result) {
+RQ.RuleExecutionHandler.fetchAndStoreImplicitTestRuleWidgetConfig = () => {
+  chrome.storage.local.get(RQ.STORAGE_KEYS.IMPLICIT_RULE_TESTING_WIDGET_CONFIG, function (result) {
     RQ.RuleExecutionHandler.implictTestRuleWidgetConfig = result[RQ.STORAGE_KEYS.IMPLICIT_RULE_TESTING_WIDGET_CONFIG];
   });
 };

--- a/browser-extension/mv2/src/client/js/ruleExecutionHandler.js
+++ b/browser-extension/mv2/src/client/js/ruleExecutionHandler.js
@@ -127,6 +127,14 @@ RQ.RuleExecutionHandler.showImplicitTestRuleWidget = async () => {
   testRuleWidget.addEventListener("open_app_settings", () => {
     window.open(`${RQ.configs.WEB_URL}/settings/global-settings`, "_blank");
   });
+
+  testRuleWidget.addEventListener("rule_applied_listener_active", async () => {
+    const ruleIds = Array.from(RQ.RuleExecutionHandler.appliedRuleIds);
+    for (let ruleId of ruleIds) {
+      const ruleDetails = await RQ.RulesStore.getRule(ruleId);
+      RQ.RuleExecutionHandler.checkAppliedRuleAndNotifyWidget(ruleDetails);
+    }
+  });
 };
 
 RQ.RuleExecutionHandler.setWidgetInfoText = (testRuleWidget, ruleDetails) => {
@@ -176,20 +184,6 @@ RQ.RuleExecutionHandler.notifyRuleAppliedToImplicitWidget = async (rule) => {
   const implicitTestRuleWidget = document.querySelector("rq-implicit-test-rule-widget");
 
   if (implicitTestRuleWidget) {
-    if (implicitTestRuleWidget.getAttribute("applied_listener_active") === "false") {
-      const appliedRules = [];
-      const ruleIds = Array.from(RQ.RuleExecutionHandler.appliedRuleIds);
-      for (let ruleId of ruleIds) {
-        const ruleDetails = await RQ.RulesStore.getRule(ruleId);
-        appliedRules.push({
-          ruleId: ruleDetails.id,
-          ruleName: ruleDetails.name,
-          ruleType: ruleDetails.ruleType,
-        });
-      }
-      implicitTestRuleWidget.setAttribute("applied-rules", JSON.stringify(appliedRules));
-    }
-
     implicitTestRuleWidget.dispatchEvent(
       new CustomEvent("new-rule-applied", {
         detail: {


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->