### PR TITLE
[ENGG-1721] chore(fix): contentTable local storage state override

### DIFF
--- a/app/src/componentsV2/ContentList/components/ContentListTable/ContentListTable.tsx
+++ b/app/src/componentsV2/ContentList/components/ContentListTable/ContentListTable.tsx
@@ -19,6 +19,8 @@ export interface ContentListTableProps<DataType> extends TableProps<DataType> {
   onRecordSelection?: (selectedRows: DataType[]) => void;
 }
 
+const EXPANDED_ROWS_LOCAL_STORAGE_KEY = "content-list-table-expanded-rows";
+
 const ContentListTable = <DataType extends { [key: string]: any }>({
   id,
   columns,
@@ -48,7 +50,6 @@ const ContentListTable = <DataType extends { [key: string]: any }>({
       }
       setExpandedRowsKeys(Array.from(updatedExpandedRowKeys));
 
-      const EXPANDED_ROWS_LOCAL_STORAGE_KEY = "content-list-table-expanded-rows";
       const expandedRows = JSON.parse(localStorage.getItem(EXPANDED_ROWS_LOCAL_STORAGE_KEY) || null) ?? {};
 
       localStorage.setItem(
@@ -63,7 +64,7 @@ const ContentListTable = <DataType extends { [key: string]: any }>({
   );
 
   useEffect(() => {
-    const expandedRowsData = localStorage.getItem("content-list-table-expanded-rows");
+    const expandedRowsData = localStorage.getItem(EXPANDED_ROWS_LOCAL_STORAGE_KEY);
     const currentListTableExpandedRows = expandedRowsData ? JSON.parse(expandedRowsData)[id] : [];
     if (currentListTableExpandedRows) {
       setExpandedRowsKeys(currentListTableExpandedRows);

--- a/app/src/componentsV2/ContentList/components/ContentListTable/ContentListTable.tsx
+++ b/app/src/componentsV2/ContentList/components/ContentListTable/ContentListTable.tsx
@@ -47,9 +47,14 @@ const ContentListTable = <DataType extends { [key: string]: any }>({
         updatedExpandedRowKeys.delete(record[rowKey]);
       }
       setExpandedRowsKeys(Array.from(updatedExpandedRowKeys));
+
+      const EXPANDED_ROWS_LOCAL_STORAGE_KEY = "content-list-table-expanded-rows";
+      const expandedRows = JSON.parse(localStorage.getItem(EXPANDED_ROWS_LOCAL_STORAGE_KEY) || null) ?? {};
+
       localStorage.setItem(
-        "content-list-table-expanded-rows",
+        EXPANDED_ROWS_LOCAL_STORAGE_KEY,
         JSON.stringify({
+          ...expandedRows,
           [id]: Array.from(updatedExpandedRowKeys),
         })
       );


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->