### PR TITLE
[ENGG-1708] fix: shared list viewer breaks when clicking on group

### DIFF
--- a/app/src/features/rules/screens/sharedListViewer/components/SharedListViewerList/hooks/useSharedListViewerColumns.tsx
+++ b/app/src/features/rules/screens/sharedListViewer/components/SharedListViewerList/hooks/useSharedListViewerColumns.tsx
@@ -19,7 +19,11 @@ export const useSharedListViewerColumns = ({ handleViewSharedListRule }: Props) 
       render: (_: any, record: RuleTableRecord) => (
         <div
           className={`shared-list-viewer-record-name ${isRule(record) ? "shared-list-viewer-rule-name" : ""}`}
-          onClick={() => handleViewSharedListRule(record)}
+          onClick={() => {
+            if (isRule(record)) {
+              handleViewSharedListRule(record);
+            }
+          }}
         >
           {record.name}
         </div>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->