### PR TITLE
chore: return original record if compression / decompression fails

### DIFF
--- a/app/src/utils/Compression.js
+++ b/app/src/utils/Compression.js
@@ -26,43 +26,47 @@ function compressString(uncompressedString) {
 
 function decompressRecord(record) {
   const decompressedRecord = { ...record };
-  console.log("[DEBUG] Decompressing Record", record?.id);
   if (isRule(record)) {
-    switch (record.ruleType) {
-      case RuleType.RESPONSE:
-        record.pairs.forEach((pair, idx) => {
-          if (pair.isCompressed) {
-            const decompressedVal = decompressString(pair?.response?.value ?? "");
-            decompressedRecord.pairs[idx].response.value = decompressedVal;
-            decompressedRecord.pairs[idx].isCompressed = false;
-          }
-        });
-        break;
-
-      case RuleType.REQUEST:
-        record.pairs.forEach((pair, idx) => {
-          if (pair.isCompressed) {
-            const decompressedVal = decompressString(pair?.request?.value ?? "");
-            decompressedRecord.pairs[idx].request.value = decompressedVal;
-            decompressedRecord.pairs[idx].isCompressed = false;
-          }
-        });
-        break;
-
-      case RuleType.SCRIPT:
-        record.pairs.forEach((pair, idx) => {
-          pair.scripts.forEach((script, sidx) => {
-            if (script.type === "code" && script.isCompressed) {
-              const ScriptValue = script?.value;
-              const decompressedVal = decompressString(ScriptValue ?? "");
-              decompressedRecord.pairs[idx].scripts[sidx].value = decompressedVal;
-              decompressedRecord.pairs[idx].scripts[sidx].isCompressed = false;
+    try {
+      switch (record.ruleType) {
+        case RuleType.RESPONSE:
+          record.pairs.forEach((pair, idx) => {
+            if (pair.isCompressed) {
+              const decompressedVal = decompressString(pair?.response?.value ?? "");
+              decompressedRecord.pairs[idx].response.value = decompressedVal;
+              decompressedRecord.pairs[idx].isCompressed = false;
             }
           });
-        });
-        break;
-      default:
-        break;
+          break;
+
+        case RuleType.REQUEST:
+          record.pairs.forEach((pair, idx) => {
+            if (pair.isCompressed) {
+              const decompressedVal = decompressString(pair?.request?.value ?? "");
+              decompressedRecord.pairs[idx].request.value = decompressedVal;
+              decompressedRecord.pairs[idx].isCompressed = false;
+            }
+          });
+          break;
+
+        case RuleType.SCRIPT:
+          record.pairs.forEach((pair, idx) => {
+            pair.scripts.forEach((script, sidx) => {
+              if (script.type === "code" && script.isCompressed) {
+                const ScriptValue = script?.value;
+                const decompressedVal = decompressString(ScriptValue ?? "");
+                decompressedRecord.pairs[idx].scripts[sidx].value = decompressedVal;
+                decompressedRecord.pairs[idx].scripts[sidx].isCompressed = false;
+              }
+            });
+          });
+          break;
+        default:
+          break;
+      }
+    } catch (error) {
+      console.log("[DEBUG] Error decompressing record", error, record);
+      return record;
     }
   }
   return decompressedRecord;
@@ -79,37 +83,42 @@ export function decompressRecords(recordsMap) {
 function compressRecord(record) {
   const compressedRecord = { ...record };
   if (isRule(record)) {
-    switch (record.ruleType) {
-      case RuleType.RESPONSE:
-        record.pairs.forEach((pair, idx) => {
-          if (compressedRecord.pairs[idx].isCompressed) return;
-          const compressedVal = compressString(pair?.response?.value ?? "");
-          compressedRecord.pairs[idx].response.value = compressedVal;
-          compressedRecord.pairs[idx].isCompressed = true;
-        });
-        break;
-
-      case RuleType.REQUEST:
-        record.pairs.forEach((pair, idx) => {
-          if (compressedRecord.pairs[idx].isCompressed) return;
-          const compressedVal = compressString(pair?.request?.value ?? "");
-          compressedRecord.pairs[idx].request.value = compressedVal;
-          compressedRecord.pairs[idx].isCompressed = true;
-        });
-        break;
-
-      case RuleType.SCRIPT:
-        record.pairs.forEach((pair, idx) => {
-          pair.scripts.forEach((script, sidx) => {
-            if (script.type === "code" && !script.isCompressed) {
-              compressedRecord.pairs[idx].scripts[sidx].value = compressString(script?.value ?? "");
-              compressedRecord.pairs[idx].scripts[sidx].isCompressed = true;
-            }
+    try {
+      switch (record.ruleType) {
+        case RuleType.RESPONSE:
+          record.pairs.forEach((pair, idx) => {
+            if (compressedRecord.pairs[idx].isCompressed) return;
+            const compressedVal = compressString(pair?.response?.value ?? "");
+            compressedRecord.pairs[idx].response.value = compressedVal;
+            compressedRecord.pairs[idx].isCompressed = true;
           });
-        });
-        break;
-      default:
-        break;
+          break;
+
+        case RuleType.REQUEST:
+          record.pairs.forEach((pair, idx) => {
+            if (compressedRecord.pairs[idx].isCompressed) return;
+            const compressedVal = compressString(pair?.request?.value ?? "");
+            compressedRecord.pairs[idx].request.value = compressedVal;
+            compressedRecord.pairs[idx].isCompressed = true;
+          });
+          break;
+
+        case RuleType.SCRIPT:
+          record.pairs.forEach((pair, idx) => {
+            pair.scripts.forEach((script, sidx) => {
+              if (script.type === "code" && !script.isCompressed) {
+                compressedRecord.pairs[idx].scripts[sidx].value = compressString(script?.value ?? "");
+                compressedRecord.pairs[idx].scripts[sidx].isCompressed = true;
+              }
+            });
+          });
+          break;
+        default:
+          break;
+      }
+    } catch (error) {
+      console.log("[DEBUG] Error compressing record", error, record);
+      return record;
     }
   }
   return compressedRecord;


### PR DESCRIPTION
improves [this](https://github.com/requestly/requestly/pull/1555) to also return the original (faulty) record in case of compression/decompression failure