### PR TITLE
[ENGG-1778] fix: rq_request_initiator_origin() not being handled on OPTIONS request

### DIFF
--- a/browser-extension/common/src/types.ts
+++ b/browser-extension/common/src/types.ts
@@ -59,7 +59,7 @@ export interface UrlSource {
 
 export interface RuleSourceFilter {
   pageDomains: string[];
-  requestMethod: HttpRequestMethod;
+  requestMethod: HttpRequestMethod[];
   resourceType: ResourceType[];
 }
 

--- a/browser-extension/mv3/src/service-worker/services/requestProcessor/handleInitiatorDomainFunction.ts
+++ b/browser-extension/mv3/src/service-worker/services/requestProcessor/handleInitiatorDomainFunction.ts
@@ -75,7 +75,7 @@ export const handleInitiatorDomainFunction = async (
         resourceTypes: [chrome.declarativeNetRequest.ResourceType.XMLHTTPREQUEST],
         tabIds: [tabId],
         requestMethods:
-          matchedPair?.source?.filters[0]?.requestMethod?.map(
+          matchedPair?.source?.filters?.[0]?.requestMethod?.map(
             (method) => method.toLowerCase() as chrome.declarativeNetRequest.RequestMethod
           ) ?? undefined,
         excludedInitiatorDomains: ["requestly.io", "requestly.com"],

--- a/browser-extension/mv3/src/service-worker/services/requestProcessor/handleInitiatorDomainFunction.ts
+++ b/browser-extension/mv3/src/service-worker/services/requestProcessor/handleInitiatorDomainFunction.ts
@@ -74,7 +74,10 @@ export const handleInitiatorDomainFunction = async (
         urlFilter: `|${requestDetails.url}|`,
         resourceTypes: [chrome.declarativeNetRequest.ResourceType.XMLHTTPREQUEST],
         tabIds: [tabId],
-        requestMethods: [requestDetails.method.toLowerCase() as chrome.declarativeNetRequest.RequestMethod],
+        requestMethods:
+          matchedPair?.source?.filters[0]?.requestMethod?.map(
+            (method) => method.toLowerCase() as chrome.declarativeNetRequest.RequestMethod
+          ) ?? undefined,
         excludedInitiatorDomains: ["requestly.io", "requestly.com"],
       },
     },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] For changes in extension's code, both MV2 and MV3 are covered.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->