### PR TITLE
fix authHandler performance issue with existing state

### DIFF
--- a/app/src/actions/FirebaseActions.js
+++ b/app/src/actions/FirebaseActions.js
@@ -531,7 +531,6 @@ export function checkUserAuthState(callback) {
 }
 
 export async function checkUserBackupState(uid) {
-  console.log("DBG: checkUserBackupState");
   const database = getDatabase();
   const userProfileRef = ref(database, `users/${uid}/profile`);
   let backupStatus = false;
@@ -552,7 +551,6 @@ export async function checkUserBackupState(uid) {
 
 /* Syncing is not enable when storage is remote */
 export async function getOrUpdateUserSyncState(uid, appMode) {
-  console.log("DBG: getOrUpdateUserSyncState");
   const database = getDatabase();
   const userProfileRef = ref(database, getUserProfilePath(uid));
   let syncStatus = null;

--- a/app/src/backend/user/userSubscription.ts
+++ b/app/src/backend/user/userSubscription.ts
@@ -3,7 +3,6 @@ import firebaseApp from "../../firebase";
 import { doc, getDoc, getFirestore } from "firebase/firestore";
 
 export const getUserSubscription = async (uid: string): Promise<UserSubscription> => {
-  console.log("DBG getUserSubscription");
   const db = getFirestore(firebaseApp);
   const userSubscriptionDocRef = doc(db, "individualSubscriptions", uid);
 

--- a/app/src/hooks/AuthHandler.ts
+++ b/app/src/hooks/AuthHandler.ts
@@ -6,7 +6,7 @@ import { User, getAuth, onAuthStateChanged } from "firebase/auth";
 import { actions } from "store";
 import { submitAttrUtil } from "utils/AnalyticsUtils";
 import { getDomainFromEmail, getEmailType, isCompanyEmail } from "utils/FormattingHelper";
-import { getAppMode, getIsAuthHandlerBeenSet, getUserAttributes } from "store/selectors";
+import { getAppMode, getAuthInitialization, getUserAttributes } from "store/selectors";
 import { getPlanName, isPremiumUser } from "utils/PremiumUtils";
 import moment from "moment";
 import { getAndUpdateInstallationDate } from "utils/Misc";
@@ -23,7 +23,7 @@ const AuthHandler: React.FC<{}> = () => {
   const dispatch = useDispatch();
   const appMode = useSelector(getAppMode);
   const userAttributes = useSelector(getUserAttributes);
-  const hasAuthHandlerBeenSet = useSelector(getIsAuthHandlerBeenSet);
+  const hasAuthInitialized = useSelector(getAuthInitialization);
 
   const getEnterpriseAdminDetails = useMemo(() => httpsCallable(getFunctions(), "getEnterpriseAdminDetails"), []);
   const getOrganizationUsers = useMemo(() => httpsCallable(getFunctions(), "users-getOrganizationUsers"), []);
@@ -172,7 +172,8 @@ const AuthHandler: React.FC<{}> = () => {
   );
 
   useEffect(() => {
-    if (hasAuthHandlerBeenSet) return;
+    console.log("DBG-1 AuthHandler useEffect triggered", JSON.stringify({ hasAuthInitialized }));
+    if (hasAuthInitialized) return;
     const auth = getAuth(firebaseApp);
     onAuthStateChanged(auth, async (user) => {
       Logger.time("AuthHandler");
@@ -188,8 +189,6 @@ const AuthHandler: React.FC<{}> = () => {
             });
           }
         });
-        // @ts-expect-error
-        dispatch(actions.updateHasAuthHandlerBeenSet(true));
       } else {
         // No user is signed in, Unset UID in window object
         window.uid = null;
@@ -211,12 +210,10 @@ const AuthHandler: React.FC<{}> = () => {
             initValue: true,
           })
         );
-        // @ts-expect-error
-        dispatch(actions.updateHasAuthHandlerBeenSet(true));
       }
     });
   }, [
-    hasAuthHandlerBeenSet,
+    hasAuthInitialized,
     dispatch,
     appMode,
     getEnterpriseAdminDetails,

--- a/app/src/hooks/AuthHandler.ts
+++ b/app/src/hooks/AuthHandler.ts
@@ -172,7 +172,6 @@ const AuthHandler: React.FC<{}> = () => {
   );
 
   useEffect(() => {
-    console.log("DBG-1 AuthHandler useEffect triggered", JSON.stringify({ hasAuthInitialized }));
     if (hasAuthInitialized) return;
     const auth = getAuth(firebaseApp);
     onAuthStateChanged(auth, async (user) => {

--- a/app/src/hooks/AuthHandler.ts
+++ b/app/src/hooks/AuthHandler.ts
@@ -6,7 +6,7 @@ import { User, getAuth, onAuthStateChanged } from "firebase/auth";
 import { actions } from "store";
 import { submitAttrUtil } from "utils/AnalyticsUtils";
 import { getDomainFromEmail, getEmailType, isCompanyEmail } from "utils/FormattingHelper";
-import { getAppMode, getAuthInitialization, getUserAttributes } from "store/selectors";
+import { getAppMode, getUserAttributes } from "store/selectors";
 import { getPlanName, isPremiumUser } from "utils/PremiumUtils";
 import moment from "moment";
 import { getAndUpdateInstallationDate } from "utils/Misc";
@@ -18,12 +18,12 @@ import { getFunctions, httpsCallable } from "firebase/functions";
 import { getUser } from "backend/user/getUser";
 
 const TRACKING = APP_CONSTANTS.GA_EVENTS;
+let hasAuthHandlerBeenSet = false;
 
 const AuthHandler: React.FC<{}> = () => {
   const dispatch = useDispatch();
   const appMode = useSelector(getAppMode);
   const userAttributes = useSelector(getUserAttributes);
-  const hasAuthInitialized = useSelector(getAuthInitialization);
 
   const getEnterpriseAdminDetails = useMemo(() => httpsCallable(getFunctions(), "getEnterpriseAdminDetails"), []);
   const getOrganizationUsers = useMemo(() => httpsCallable(getFunctions(), "users-getOrganizationUsers"), []);
@@ -172,7 +172,9 @@ const AuthHandler: React.FC<{}> = () => {
   );
 
   useEffect(() => {
-    if (hasAuthInitialized) return;
+    if (hasAuthHandlerBeenSet) return;
+    hasAuthHandlerBeenSet = true;
+
     const auth = getAuth(firebaseApp);
     onAuthStateChanged(auth, async (user) => {
       Logger.time("AuthHandler");
@@ -212,7 +214,6 @@ const AuthHandler: React.FC<{}> = () => {
       }
     });
   }, [
-    hasAuthInitialized,
     dispatch,
     appMode,
     getEnterpriseAdminDetails,

--- a/app/src/hooks/DbListenerInit/DBListeners.js
+++ b/app/src/hooks/DbListenerInit/DBListeners.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { getCurrentlyActiveWorkspace, getCurrentlyActiveWorkspaceMembers } from "store/features/teams/selectors";
-import { getAppMode, getIsAuthHandlerBeenSet, getUserAuthDetails } from "../../store/selectors";
+import { getAppMode, getAuthInitialization, getUserAuthDetails } from "../../store/selectors";
 import availableTeamsListener from "./availableTeamsListener";
 import syncingNodeListener from "./syncingNodeListener";
 import userNodeListener from "./userNodeListener";
@@ -23,7 +23,7 @@ const DBListeners = () => {
   const appMode = useSelector(getAppMode);
   const currentlyActiveWorkspace = useSelector(getCurrentlyActiveWorkspace);
   const currentTeamMembers = useSelector(getCurrentlyActiveWorkspaceMembers);
-  const hasAuthHandlerBeenSet = useSelector(getIsAuthHandlerBeenSet);
+  const hasAuthInitialized = useSelector(getAuthInitialization);
 
   let unsubscribeUserNodeRef = useRef(null);
   window.unsubscribeSyncingNodeRef = useRef(null);
@@ -43,7 +43,7 @@ const DBListeners = () => {
 
   // Listens to /sync/{id}/metadata or /teamSync/{id}/metadata changes
   useEffect(() => {
-    if (!hasAuthHandlerBeenSet) return;
+    if (!hasAuthInitialized) return;
     if (hasAuthStateChanged || !window.isFirstSyncComplete) {
       dispatch(actions.updateIsRulesListLoading(true));
     }
@@ -77,7 +77,7 @@ const DBListeners = () => {
       dispatch(actions.updateIsRulesListLoading(false));
     }
   }, [
-    hasAuthHandlerBeenSet,
+    hasAuthInitialized,
     appMode,
     currentlyActiveWorkspace.id,
     dispatch,

--- a/app/src/hooks/DbListenerInit/syncingNodeListener.ts
+++ b/app/src/hooks/DbListenerInit/syncingNodeListener.ts
@@ -372,6 +372,7 @@ const syncingNodeListener = (
   try {
     // Check for individual sync target
     if (syncTarget === "sync") {
+      console.log("DBG syncingNodeListener - sync");
       // Listen to only records
       return [
         onValue(syncNodeRef, async (snap: Snapshot) => {
@@ -388,6 +389,7 @@ const syncingNodeListener = (
     }
     // Check for team sync target
     else if (syncTarget === "teamSync") {
+      console.log("DBG syncingNodeListener - teamSync");
       // Listen to records node & rulesConfig node
       const listeners: Function[] = [
         onValue(syncNodeRef, async (snap: Snapshot) => {

--- a/app/src/hooks/DbListenerInit/syncingNodeListener.ts
+++ b/app/src/hooks/DbListenerInit/syncingNodeListener.ts
@@ -372,7 +372,6 @@ const syncingNodeListener = (
   try {
     // Check for individual sync target
     if (syncTarget === "sync") {
-      console.log("DBG syncingNodeListener - sync");
       // Listen to only records
       return [
         onValue(syncNodeRef, async (snap: Snapshot) => {
@@ -389,7 +388,6 @@ const syncingNodeListener = (
     }
     // Check for team sync target
     else if (syncTarget === "teamSync") {
-      console.log("DBG syncingNodeListener - teamSync");
       // Listen to records node & rulesConfig node
       const listeners: Function[] = [
         onValue(syncNodeRef, async (snap: Snapshot) => {

--- a/app/src/store/features/appModeSpecificActions.js
+++ b/app/src/store/features/appModeSpecificActions.js
@@ -23,7 +23,3 @@ export const updateHasConnectedApp = (prevState, action) => {
 export const updateIsExtensionEnabled = (prevState, action) => {
   prevState.isExtensionEnabled = action.payload;
 };
-
-export const updateHasAuthHandlerBeenSet = (prevState, action) => {
-  prevState.misc.nonPersist.hasAuthHandlerBeenSet = action.payload;
-};

--- a/app/src/store/initial-state/index.js
+++ b/app/src/store/initial-state/index.js
@@ -207,7 +207,6 @@ const INITIAL_STATE = {
       timeToResendEmailLogin: 0,
       isCommandBarOpen: false,
       isAppBannerVisible: false,
-      hasAuthHandlerBeenSet: false,
     },
   },
 };

--- a/app/src/store/selectors.js
+++ b/app/src/store/selectors.js
@@ -298,7 +298,3 @@ export const getToastForEditor = (state, id) => {
 export const getIsAppBannerVisible = (state) => {
   return getGlobalState(state).misc.nonPersist?.isAppBannerVisible;
 };
-
-export const getIsAuthHandlerBeenSet = (state) => {
-  return getGlobalState(state).misc.nonPersist?.hasAuthHandlerBeenSet;
-};


### PR DESCRIPTION
This, although solves the core issue, but triggers the complete run of the AuthHandler useEffect several times which leads to redundant calls of the `blockingOperations` functions.

This happens because `initializations.auth` is set to `true` AFTER the blocking operations are FULLY complete. Unlike https://github.com/requestly/requestly/pull/1716 that sets the custom state to `true` once `blockingOperations` have been triggered

Still raising this as this was brought up during offline discussions 

> preliminary debug logs:
> ![image](https://github.com/requestly/requestly/assets/57226514/bc216547-692a-4673-b364-ed1448487c31)
