### PR TITLE
feat: add featureFlag to override team syncing setting

### DIFF
--- a/app/src/config/constants/sub/features.js
+++ b/app/src/config/constants/sub/features.js
@@ -78,4 +78,7 @@ FEATURES.DESKTOP_SESSIONS = "all_desktop_session_features";
 
 FEATURES.COMPRESS_RULE_PAIRS = "compress_rule_pairs";
 
+FEATURES.OVERRIDE_TEAM_SYNC_STATUS = "override_team_sync_status";
+FEATURES.OVERRIDEN_SYNC_STATUS_VALUE = "overriden_sync_status_value";
+
 export default FEATURES;

--- a/app/src/features/settings/components/GlobalSettings/components/SettingsItem/index.tsx
+++ b/app/src/features/settings/components/GlobalSettings/components/SettingsItem/index.tsx
@@ -9,6 +9,7 @@ interface SettingsItemProps extends SwitchProps {
   toolTipTitle?: ReactNode;
   settingsBody?: ReactNode;
   onChange: (status: boolean, event?: React.MouseEvent<HTMLButtonElement>) => void;
+  isChangeAble?: boolean;
 }
 
 const SettingsItem: React.FC<SettingsItemProps> = ({
@@ -18,6 +19,7 @@ const SettingsItem: React.FC<SettingsItemProps> = ({
   onChange,
   settingsBody,
   toolTipTitle = "",
+  isChangeAble = true,
   ...props
 }) => {
   return (
@@ -28,9 +30,15 @@ const SettingsItem: React.FC<SettingsItemProps> = ({
         {settingsBody}
       </Col>
       <Col span={2} style={{ alignSelf: "self-start", marginTop: "8px" }}>
-        <Tooltip title={toolTipTitle}>
-          <Switch checked={isActive} onChange={onChange} {...props} />
-        </Tooltip>
+        {isChangeAble ? (
+          <Tooltip title={toolTipTitle}>
+            <Switch checked={isActive} onChange={onChange} {...props} />
+          </Tooltip>
+        ) : (
+          <Tooltip title="Enforced organisation wide. Please contact support to change.">
+            <Switch defaultChecked={isActive} disabled {...props} />
+          </Tooltip>
+        )}
       </Col>
     </Row>
   );

--- a/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/TeamSettings/WorkspaceStatusSyncing/index.js
+++ b/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/TeamSettings/WorkspaceStatusSyncing/index.js
@@ -5,11 +5,13 @@ import { useDispatch, useSelector } from "react-redux";
 import { getAppMode, getUserAuthDetails } from "store/selectors";
 import { get } from "firebase/database";
 import { getNodeRef } from "actions/FirebaseActions";
-import { getRecordsSyncPath } from "utils/syncing/syncDataUtils";
+import { getRecordsSyncPath, getSyncRuleStatus } from "utils/syncing/syncDataUtils";
 import { getCurrentlyActiveWorkspace } from "store/features/teams/selectors";
 import SettingsItem from "features/settings/components/GlobalSettings/components/SettingsItem";
 import { trackSettingsToggled } from "modules/analytics/events/misc/settings";
 import { decompressRecords } from "utils/Compression";
+import FEATURES from "config/constants/sub/features";
+import { useFeatureValue } from "@growthbook/growthbook-react";
 
 const WorkspaceStatusSyncing = () => {
   const dispatch = useDispatch();
@@ -18,9 +20,16 @@ const WorkspaceStatusSyncing = () => {
   const appMode = useSelector(getAppMode);
   const currentlyActiveWorkspace = useSelector(getCurrentlyActiveWorkspace);
   // Component State
-  const [syncRuleStatus, setSyncRuleStatus] = useState(localStorage.getItem("syncRuleStatus") === "true" || false);
+  const [syncRuleStatus, setSyncRuleStatus] = useState(getSyncRuleStatus());
+  const isWorkspaceSyncOverriden = useFeatureValue(FEATURES.OVERRIDE_TEAM_SYNC_STATUS, false);
+  const overridenSyncValue = useFeatureValue(FEATURES.OVERRIDEN_SYNC_STATUS_VALUE, true);
 
   const handleToggleStatusSyncing = async () => {
+    if (isWorkspaceSyncOverriden) {
+      toast.info("This setting is enforced organisation wide\n Please contact support to change this.");
+      // not reconfiguring local state so as to preserve user's original choice before override
+      return;
+    }
     const triggerSync = async () => {
       const syncNodeRef = getNodeRef(
         getRecordsSyncPath("teamSync", user.details.profile.uid, currentlyActiveWorkspace.id)
@@ -54,10 +63,11 @@ const WorkspaceStatusSyncing = () => {
 
   return (
     <SettingsItem
-      isActive={syncRuleStatus}
+      isActive={isWorkspaceSyncOverriden ? overridenSyncValue : syncRuleStatus}
       onChange={handleToggleStatusSyncing}
       title="Enable status syncing in team workspaces"
       caption="Stay updated by automatically syncing rule modifications with your teammates."
+      isChangeAble={isWorkspaceSyncOverriden ? false : true}
     />
   );
 };

--- a/app/src/utils/syncing/syncDataUtils.js
+++ b/app/src/utils/syncing/syncDataUtils.js
@@ -65,6 +65,14 @@ export const getTeamUserRuleConfigPath = (ruleOrGroupId) => {
   return teamUserRuleAllConfigsPath;
 };
 
+export const getSyncRuleStatus = () => {
+  if (growthbook.isOn(FEATURES.OVERRIDE_TEAM_SYNC_STATUS)) {
+    return growthbook.getFeatureValue(FEATURES.OVERRIDEN_SYNC_STATUS_VALUE, true);
+  } else {
+    return localStorage.getItem("syncRuleStatus") === "true" || false;
+  }
+};
+
 // The intent of this function is to somehow prevent writing of user's personal rule config into teams's rule config
 // It works by modifying the original param received: latestRules
 const preventWorkspaceSyncWrite = async (key, latestRules, objectId, uid, remoteRecords, myLocalRecords, appMode) => {
@@ -103,7 +111,7 @@ export const updateUserSyncRecords = async (uid, records, appMode, options) => {
 
   // Check if it's team syncing. We might not want to write some props like "isFavourite" to this node. Instead, we can write it to userConfig node
   if (isSameWorkspaceOperation && window.currentlyActiveWorkspaceTeamId) {
-    const syncRuleStatus = localStorage.getItem("syncRuleStatus") === "true" || false;
+    const syncRuleStatus = getSyncRuleStatus();
     // Get current values from db and use them xD // @sagar, what's so funny?
     const allRemoteRecords = (await getValueAsPromise(getRecordsSyncPath())) || {};
     const remoteRecords = {};
@@ -220,7 +228,7 @@ export const parseRemoteRecords = async (appMode, allRemoteRecords = {}) => {
     // Todo - @sagar - Fix duplicate code - src/hooks/DbListenerInit/syncingNodeListener.js
     // Check if it's team syncing. We might not want to read some props like "isFavourite" from this not. Instead we an read from userConfig node
     if (window.currentlyActiveWorkspaceTeamId) {
-      const syncRuleStatus = localStorage.getItem("syncRuleStatus") === "true" || false;
+      const syncRuleStatus = getSyncRuleStatus();
       // Get current values from local storage and use them
       const teamUserRuleAllConfigsPath = getTeamUserRuleAllConfigsPath();
       if (!teamUserRuleAllConfigsPath) return [];
@@ -312,7 +320,7 @@ export const syncToLocalFromFirebase = async (allSyncedRecords, appMode, uid) =>
   // START - Handle prevention of syncing of isFavourite and syncRuleStatus in Team Workspaces
   if (window.currentlyActiveWorkspaceTeamId) {
     allSyncedRecords = processRecordsArrayIntoObject(allSyncedRecords);
-    const syncRuleStatus = localStorage.getItem("syncRuleStatus") === "true" || false;
+    const syncRuleStatus = getSyncRuleStatus();
     const personalRuleConfigs = await getValueAsPromise(getTeamUserRuleAllConfigsPath(null, uid));
     // Get current values from local storage and use them xD
     for (const objectId in allSyncedRecords) {


### PR DESCRIPTION
introduces two feature flags:
1. `override_team_sync_status` - default value `false`
2. `overriden_sync_status_value` - default vaule `true`

The second flag is enforced only if first one is `true`. Else the localStorage state is used