### PR TITLE
chore: set rule count badge overflow to 10_000

### DIFF
--- a/app/src/features/rules/screens/rulesList/components/RulesList/components/RulesListContentHeader/RulesListContentHeader.tsx
+++ b/app/src/features/rules/screens/rulesList/components/RulesList/components/RulesListContentHeader/RulesListContentHeader.tsx
@@ -147,7 +147,7 @@ const RulesListContentHeader: React.FC<Props> = ({ searchValue, setSearchValue, 
           <div className="label">
             All{" "}
             {records.length ? (
-              <Badge count={records.filter((record) => isRule(record)).length} overflowCount={20} />
+              <Badge count={records.filter((record) => isRule(record)).length} overflowCount={10_000} />
             ) : null}
           </div>
         ),


### PR DESCRIPTION
earlier it was 20
Can't remove this argument since default is 99

selected 10,000 as a distant upper limit (should not be hitting these anytime soon)