### PR TITLE
[ENGG-1727] fix: fetch rules of groups in the delete modal action

### DIFF
--- a/app/src/features/rules/modals/UngroupOrDeleteRulesModalWrapper/index.tsx
+++ b/app/src/features/rules/modals/UngroupOrDeleteRulesModalWrapper/index.tsx
@@ -1,24 +1,46 @@
-import React, { useEffect, useState } from "react";
+import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
+import React, { useCallback, useEffect, useState } from "react";
 import UngroupOrDeleteRulesModal from "components/features/rules/UngroupOrDeleteRulesModal";
-import { Group } from "features/rules/types/rules";
+import { Group, Rule } from "features/rules/types/rules";
 import { useRulesModalsContext } from "features/rules/context/modals";
+import { StorageService } from "init";
+import { useSelector } from "react-redux";
+import { getAppMode } from "store/selectors";
 
 interface Props {}
 
 export const UngroupOrDeleteRulesModalWrapper: React.FC<Props> = () => {
   const { setOpenGroupDeleteModalAction } = useRulesModalsContext();
 
+  const appMode = useSelector(getAppMode);
+
   const [isModalActive, setIsModalActive] = useState(false);
   const [groupToDelete, setGroupToDelete] = useState<Group | null>(null);
 
+  const [groupRules, setGroupRules] = useState<Rule[]>([]);
+
+  const getAllRulesofGroup = useCallback(
+    async (groupId: Group["id"]) => {
+      return await StorageService(appMode)
+        .getRecords(GLOBAL_CONSTANTS.OBJECT_TYPES.RULE)
+        .then((rules: Rule[]) => {
+          const groupRules = rules.filter((rule) => rule.groupId === groupId);
+          return groupRules;
+        });
+    },
+    [appMode]
+  );
+
   useEffect(() => {
-    const openModal = (group: Group) => {
+    const openModal = async (group: Group) => {
+      const storageRules = await getAllRulesofGroup(group.id);
+      setGroupRules(storageRules);
       setGroupToDelete(group);
       setIsModalActive(true);
     };
 
     setOpenGroupDeleteModalAction(() => openModal);
-  }, [setOpenGroupDeleteModalAction]);
+  }, [setOpenGroupDeleteModalAction, getAllRulesofGroup]);
 
   const onClose = () => {
     setGroupToDelete(null);
@@ -28,8 +50,7 @@ export const UngroupOrDeleteRulesModalWrapper: React.FC<Props> = () => {
   return isModalActive ? (
     <UngroupOrDeleteRulesModal
       groupIdToDelete={groupToDelete?.id}
-      // @ts-ignore
-      groupRules={groupToDelete?.children ?? []}
+      groupRules={groupRules}
       isOpen={isModalActive}
       toggle={onClose}
       callback={() => {}}

--- a/app/src/features/rules/modals/UngroupOrDeleteRulesModalWrapper/index.tsx
+++ b/app/src/features/rules/modals/UngroupOrDeleteRulesModalWrapper/index.tsx
@@ -1,46 +1,24 @@
-import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import UngroupOrDeleteRulesModal from "components/features/rules/UngroupOrDeleteRulesModal";
-import { Group, Rule } from "features/rules/types/rules";
+import { Group } from "features/rules/types/rules";
 import { useRulesModalsContext } from "features/rules/context/modals";
-import { StorageService } from "init";
-import { useSelector } from "react-redux";
-import { getAppMode } from "store/selectors";
 
 interface Props {}
 
 export const UngroupOrDeleteRulesModalWrapper: React.FC<Props> = () => {
   const { setOpenGroupDeleteModalAction } = useRulesModalsContext();
 
-  const appMode = useSelector(getAppMode);
-
   const [isModalActive, setIsModalActive] = useState(false);
   const [groupToDelete, setGroupToDelete] = useState<Group | null>(null);
 
-  const [groupRules, setGroupRules] = useState<Rule[]>([]);
-
-  const getAllRulesofGroup = useCallback(
-    async (groupId: Group["id"]) => {
-      return await StorageService(appMode)
-        .getRecords(GLOBAL_CONSTANTS.OBJECT_TYPES.RULE)
-        .then((rules: Rule[]) => {
-          const groupRules = rules.filter((rule) => rule.groupId === groupId);
-          return groupRules;
-        });
-    },
-    [appMode]
-  );
-
   useEffect(() => {
-    const openModal = async (group: Group) => {
-      const storageRules = await getAllRulesofGroup(group.id);
-      setGroupRules(storageRules);
+    const openModal = (group: Group) => {
       setGroupToDelete(group);
       setIsModalActive(true);
     };
 
     setOpenGroupDeleteModalAction(() => openModal);
-  }, [setOpenGroupDeleteModalAction, getAllRulesofGroup]);
+  }, [setOpenGroupDeleteModalAction]);
 
   const onClose = () => {
     setGroupToDelete(null);
@@ -50,7 +28,8 @@ export const UngroupOrDeleteRulesModalWrapper: React.FC<Props> = () => {
   return isModalActive ? (
     <UngroupOrDeleteRulesModal
       groupIdToDelete={groupToDelete?.id}
-      groupRules={groupRules}
+      // @ts-ignore
+      groupRules={groupToDelete?.children ?? []}
       isOpen={isModalActive}
       toggle={onClose}
       callback={() => {}}

--- a/app/src/features/rules/screens/rulesList/components/RulesList/components/RulesTable/hooks/useRuleTableColumns.tsx
+++ b/app/src/features/rules/screens/rulesList/components/RulesList/components/RulesTable/hooks/useRuleTableColumns.tsx
@@ -338,7 +338,7 @@ const useRuleTableColumns = (options: Record<string, boolean>) => {
             danger: true,
             onClick: (info) => {
               info.domEvent?.stopPropagation?.();
-              groupDeleteAction(normalizeRecord(record) as Group);
+              groupDeleteAction(record as Group);
             },
             label: (
               <Row>


### PR DESCRIPTION
group children were normalized during the [table refactor](https://github.com/requestly/requestly/pull/1526). This might have got missed due to the ts-ignore
