### PR TITLE
feat: graphql details in network traffic table

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/converter.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/converter.ts
@@ -110,7 +110,6 @@ export const convertHarJsonToRQLogs = (har: Har): RQNetworkLog[] => {
         headers: requestHeaders,
         body: entry.request.postData?.text,
         queryParams: entry.request.queryString,
-        GQLDetails: getGraphQLDetails(entry),
       },
       response: {
         statusCode: entry.response.status,
@@ -123,6 +122,9 @@ export const convertHarJsonToRQLogs = (har: Har): RQNetworkLog[] => {
             : JSON.stringify(entry.response.content?.text),
       },
       requestShellCurl: entry?._RQDetails?.requestShellCurl || "",
+      metadata: {
+        GQLDetails: getGraphQLDetails(entry),
+      },
       actions: entry?._RQDetails?.actions || [],
       requestState: entry?._RQDetails?.requestState || "",
       consoleLogs: entry?._RQDetails?.consoleLogs || [],

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/converter.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/converter.ts
@@ -1,6 +1,7 @@
 import { Har, HarEntry, HarHeaderEntry, HarRequest, HarResponse, HeaderMap, RQNetworkLog } from "./types";
 
 import { v4 as uuidv4 } from "uuid";
+import { getGraphQLDetails } from "./utils";
 
 const createHarHeaders = (headersObject: HeaderMap) => {
   const headers: HarHeaderEntry[] = [];
@@ -109,6 +110,7 @@ export const convertHarJsonToRQLogs = (har: Har): RQNetworkLog[] => {
         headers: requestHeaders,
         body: entry.request.postData?.text,
         queryParams: entry.request.queryString,
+        GQLDetails: getGraphQLDetails(entry), // can be behind a feature flag for now to avoid performance impact for everyone
       },
       response: {
         statusCode: entry.response.status,

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/converter.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/converter.ts
@@ -110,7 +110,7 @@ export const convertHarJsonToRQLogs = (har: Har): RQNetworkLog[] => {
         headers: requestHeaders,
         body: entry.request.postData?.text,
         queryParams: entry.request.queryString,
-        GQLDetails: getGraphQLDetails(entry), // can be behind a feature flag for now to avoid performance impact for everyone
+        GQLDetails: getGraphQLDetails(entry),
       },
       response: {
         statusCode: entry.response.status,

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/types.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/types.ts
@@ -70,10 +70,10 @@ interface HarResponseContent {
   encoding?: string;
 }
 
-type HarRequestQueryString = HarMapEntry;
+export type HarRequestQueryString = HarMapEntry;
 export type HarHeaderEntry = HarMapEntry;
 
-interface HarMapEntry {
+export interface HarMapEntry {
   name: string;
   value: string;
   comment?: string;
@@ -102,6 +102,13 @@ interface LogRequest {
   headers: HeaderMap;
   body: any;
   queryParams: HarMapEntry[];
+  GQLDetails: GQLDetails | null;
+}
+
+interface GQLDetails {
+  query: string;
+  variables: any; // TBD @nsr
+  operationName: string;
 }
 
 interface LogResponse {

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/types.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/types.ts
@@ -92,6 +92,7 @@ export interface RQNetworkLog {
   consoleLogs: any; // array of logs generated in script based rules
   domain?: string;
   app?: string;
+  metadata: Metadata;
 }
 
 interface LogRequest {
@@ -102,6 +103,9 @@ interface LogRequest {
   headers: HeaderMap;
   body: any;
   queryParams: HarMapEntry[];
+}
+
+interface Metadata {
   GQLDetails: GQLDetails | null;
 }
 

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/utils.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/utils.ts
@@ -1,7 +1,7 @@
 import { saveAs } from "file-saver";
 
 import { createLogsHar } from "./converter";
-import { Har, RQNetworkLog } from "./types";
+import { Har, RQNetworkLog, HarEntry } from "./types";
 
 export function downloadLogs(logs: RQNetworkLog[]) {
   const harLogs = createLogsHar(logs);
@@ -13,4 +13,42 @@ export function downloadLogs(logs: RQNetworkLog[]) {
 export function downloadHar(har: Har, preferredName?: string) {
   const jsonBlob = new Blob([JSON.stringify(har, null, 2)], { type: "application/json" });
   saveAs(jsonBlob, preferredName ? `${preferredName}.har` : "requestly_logs.har");
+}
+
+export function getGraphQLDetails(harEntry: HarEntry): RQNetworkLog["request"]["GQLDetails"] {
+  const method = harEntry.request.method;
+
+  let GQLQuery = null,
+    GQLVariables = null,
+    GQLOperationName = null;
+
+  if (method === "GET" || method === "HEAD") {
+    const urlSearchParams = harEntry.request.queryString;
+    GQLQuery = urlSearchParams.find((param) => param.name === "query")?.value;
+    GQLVariables = urlSearchParams.find((param) => param.name === "variables")?.value;
+    GQLOperationName = urlSearchParams.find((param) => param.name === "operationName")?.value;
+  } else if (method === "POST") {
+    const postData = harEntry.request.postData;
+    if (postData) {
+      const postDataText = postData.text;
+      try {
+        const postDataJson = JSON.parse(postDataText);
+        GQLQuery = postDataJson.query ?? null;
+        GQLVariables = postDataJson.variables ?? null;
+        GQLOperationName = postDataJson.operationName ?? null;
+      } catch (e) {
+        // skip
+      }
+    }
+  }
+
+  if (GQLQuery || GQLOperationName) {
+    return {
+      query: GQLQuery,
+      variables: GQLVariables,
+      operationName: GQLOperationName,
+    };
+  }
+
+  return null;
 }

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/utils.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficExporter/harLogs/utils.ts
@@ -15,7 +15,7 @@ export function downloadHar(har: Har, preferredName?: string) {
   saveAs(jsonBlob, preferredName ? `${preferredName}.har` : "requestly_logs.har");
 }
 
-export function getGraphQLDetails(harEntry: HarEntry): RQNetworkLog["request"]["GQLDetails"] {
+export function getGraphQLDetails(harEntry: HarEntry): RQNetworkLog["metadata"]["GQLDetails"] {
   const method = harEntry.request.method;
 
   let GQLQuery = null,

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -1,13 +1,14 @@
 .url-wrapper {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  gap: 4px;
+  justify-content: start;
   .url {
     white-space: nowrap;
     display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
-    flex-grow: 1;
+    flex-grow: auto;
   }
 
   .graphql-operation-name {

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -1,0 +1,18 @@
+.url-wrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  .url {
+    white-space: nowrap;
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-grow: 1;
+  }
+
+  .graphql-operation-name {
+    font-style: italic;
+    color: var(--map-tokens-secondary-secondary-400, #b568f9);
+    font-weight: 400;
+  }
+}

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -1,19 +1,36 @@
-.url-wrapper {
-  display: flex;
-  flex-direction: row;
-  gap: 4px;
-  justify-content: start;
-  .url {
-    white-space: nowrap;
-    display: inline-block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex-grow: auto;
+.web-traffic-table-container {
+  table {
+    tbody {
+      tr[aria-selected="true"] {
+        .graphql-operation-name {
+          color: var(--text-default);
+        }
+      }
+    }
   }
 
-  .graphql-operation-name {
-    font-style: italic;
-    color: var(--map-tokens-secondary-secondary-400, #b568f9);
-    font-weight: 400;
+  .url-wrapper {
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    justify-content: start;
+
+    .url {
+      white-space: nowrap;
+      display: inline-block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex-grow: auto;
+    }
+
+    .graphql-operation-name {
+      font-style: italic;
+      color: var(--map-tokens-secondary-secondary-400, #b568f9);
+      font-weight: 400;
+
+      &.selected {
+        color: var(--text-default);
+      }
+    }
   }
 }

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
@@ -15,6 +15,8 @@ import { RQNetworkLog } from "../../../TrafficExporter/harLogs/types";
 import { Checkbox } from "antd";
 import { trackMockResponsesRequestsSelected } from "modules/analytics/events/features/sessionRecording/mockResponseFromSession";
 
+import "./index.scss";
+
 export const ITEM_SIZE = 30;
 
 interface Props {
@@ -145,7 +147,13 @@ const NetworkTable: React.FC<Props> = ({
         render: (url: string, log: RQNetworkLog) => {
           if (log.request.GQLDetails) {
             const { operationName } = log.request.GQLDetails;
-            return operationName ? `[${operationName}] ${url}` : url;
+            console.log("operationName", operationName);
+            return (
+              <div className="url-wrapper">
+                <span className="url">{url}</span>
+                <span className="graphql-operation-name">{`(${operationName})`}</span>
+              </div>
+            );
           }
 
           return url;

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
@@ -142,6 +142,14 @@ const NetworkTable: React.FC<Props> = ({
         title: "URL",
         dataIndex: "url",
         width: "48%",
+        render: (url: string, log: RQNetworkLog) => {
+          if (log.request.GQLDetails) {
+            const { operationName } = log.request.GQLDetails;
+            return operationName ? `[${operationName}] ${url}` : url;
+          }
+
+          return url;
+        },
       },
       {
         id: "method",
@@ -219,7 +227,6 @@ const NetworkTable: React.FC<Props> = ({
               return null;
             }
             const columnData = get(log, getColumnKey(column?.dataIndex));
-
             return (
               <Table.Cell key={column.id} title={!column?.render ? columnData : ""}>
                 {column?.render ? column.render(columnData, log) : columnData}

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
@@ -145,9 +145,8 @@ const NetworkTable: React.FC<Props> = ({
         dataIndex: "url",
         width: "48%",
         render: (url: string, log: RQNetworkLog) => {
-          if (log.request.GQLDetails) {
-            const { operationName } = log.request.GQLDetails;
-            console.log("operationName", operationName);
+          if (log.metadata.GQLDetails) {
+            const { operationName } = log.metadata.GQLDetails;
             return (
               <div className="url-wrapper">
                 <span className="url">{url}</span>

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
@@ -145,7 +145,7 @@ const NetworkTable: React.FC<Props> = ({
         dataIndex: "url",
         width: "48%",
         render: (url: string, log: RQNetworkLog) => {
-          if (log.metadata.GQLDetails) {
+          if (log?.metadata?.GQLDetails) {
             const { operationName } = log.metadata.GQLDetails;
             return (
               <div className="url-wrapper">
@@ -253,13 +253,15 @@ const NetworkTable: React.FC<Props> = ({
         startWalkthrough={!isTrafficTableTourCompleted && isConnectedAppsTourCompleted}
         onTourComplete={() => dispatch(actions.updateProductTourCompleted({ tour: TOUR_TYPES.TRAFFIC_TABLE }))}
       />
-      <VirtualTableV2
-        header={header}
-        renderLogRow={renderLogRow}
-        logs={logs}
-        selectedRowData={selectedRowData}
-        onReplayRequest={onReplayRequest}
-      />
+      <div className="web-traffic-table-container">
+        <VirtualTableV2
+          header={header}
+          renderLogRow={renderLogRow}
+          logs={logs}
+          selectedRowData={selectedRowData}
+          onReplayRequest={onReplayRequest}
+        />
+      </div>
       {isReplayRequestModalOpen ? (
         <APIClient
           request={apiClientRequestForSelectedRowRef.current}

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/RequestSummary.js
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/RequestSummary.js
@@ -1,6 +1,6 @@
 import { Table } from "@devtools-ds/table";
 
-const exclude_keys = ["headers", "body", "queryParams"];
+const exclude_keys = ["headers", "body", "queryParams", "GQLDetails"];
 
 const renderSummaryTable = (request_data) => {
   return (

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
@@ -269,18 +269,16 @@ const CurrentTrafficTable = ({
           Logger.log(err);
         }
 
-        if (!includeLog && log?.request?.GQLDetails) {
-          // search also on GraphQL properties
-          const operationName = log?.metadata?.GQLDetails?.operationName?.toLowerCase() || "";
-          const query = log?.metadata?.GQLDetails?.query?.toLowerCase() || "";
+        if (!includeLog && log?.request?.body) {
+          const body = log.request.body.toLowerCase();
           try {
             // TODO: @wrongsahil fix this. Special Characters are breaking the UI
             let reg = null;
             if (searchFilter.regex) {
               reg = new RegExp(searchTerm);
-              includeLog = operationName.match(reg) || query.match(reg);
+              includeLog = body.match(reg);
             } else {
-              includeLog = operationName.includes(searchTerm) || query.includes(searchTerm);
+              includeLog = body.includes(searchTerm);
             }
           } catch (err) {
             Logger.log(err);

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
@@ -268,6 +268,24 @@ const CurrentTrafficTable = ({
         } catch (err) {
           Logger.log(err);
         }
+
+        if (!includeLog && log?.request?.GQLDetails) {
+          // search also on GraphQL properties
+          const operationName = log?.request?.GQLDetails?.operationName?.toLowerCase() || "";
+          const query = log?.request?.GQLDetails?.query?.toLowerCase() || "";
+          try {
+            // TODO: @wrongsahil fix this. Special Characters are breaking the UI
+            let reg = null;
+            if (searchFilter.regex) {
+              reg = new RegExp(searchTerm);
+              includeLog = operationName.match(reg) || query.match(reg);
+            } else {
+              includeLog = operationName.includes(searchTerm) || query.includes(searchTerm);
+            }
+          } catch (err) {
+            Logger.log(err);
+          }
+        }
       }
 
       if (!includeLog) {

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
@@ -271,8 +271,8 @@ const CurrentTrafficTable = ({
 
         if (!includeLog && log?.request?.GQLDetails) {
           // search also on GraphQL properties
-          const operationName = log?.request?.GQLDetails?.operationName?.toLowerCase() || "";
-          const query = log?.request?.GQLDetails?.query?.toLowerCase() || "";
+          const operationName = log?.metadata?.GQLDetails?.operationName?.toLowerCase() || "";
+          const query = log?.metadata?.GQLDetails?.query?.toLowerCase() || "";
           try {
             // TODO: @wrongsahil fix this. Special Characters are breaking the UI
             let reg = null;


### PR DESCRIPTION
- adds `GaphQLDetails` property to `RQNetworkLog.request`
- searches over this property in the table
- adds prefix of operation name to the url column