### PR TITLE
feat: import websession for desktop network sessions viewer

### DIFF
--- a/app/src/modules/analytics/events/features/constants.js
+++ b/app/src/modules/analytics/events/features/constants.js
@@ -38,9 +38,17 @@ export const SESSION_RECORDING = {
   },
   network: {
     import: {
-      btn_clicked: "import_external_har_button_clicked",
-      completed: "import_external_har_completed",
-      canceled: "import_external_har_canceled",
+      har: {
+        btn_clicked: "import_external_har_button_clicked",
+        completed: "import_external_har_completed",
+        canceled: "import_external_har_canceled",
+      },
+
+      web_sessions: {
+        btn_clicked: "import_web_session_button_clicked",
+        completed: "import_web_session_completed",
+        canceled: "import_web_session_canceled",
+      },
     },
     delete: {
       btn_clicked: "delete_network_session_clicked_from_list",

--- a/app/src/modules/analytics/events/features/sessionRecording/networkSessions.ts
+++ b/app/src/modules/analytics/events/features/sessionRecording/networkSessions.ts
@@ -8,13 +8,23 @@ export enum ActionSource {
 }
 
 export function trackHarImportButtonClicked() {
-  trackEvent(SESSION_RECORDING.network.import.btn_clicked);
+  trackEvent(SESSION_RECORDING.network.import.har.btn_clicked);
 }
 export function trackHarImportCanceled() {
-  trackEvent(SESSION_RECORDING.network.import.canceled);
+  trackEvent(SESSION_RECORDING.network.import.har.canceled);
 }
 export function trackHarImportCompleted() {
-  trackEvent(SESSION_RECORDING.network.import.completed);
+  trackEvent(SESSION_RECORDING.network.import.har.completed);
+}
+
+export function trackWebSessionImportButtonClicked() {
+  trackEvent(SESSION_RECORDING.network.import.web_sessions.btn_clicked);
+}
+export function trackWebSessionImportCanceled() {
+  trackEvent(SESSION_RECORDING.network.import.web_sessions.canceled);
+}
+export function trackWebSessionImportCompleted() {
+  trackEvent(SESSION_RECORDING.network.import.web_sessions.completed);
 }
 
 export function trackDeleteNetworkSessionClicked(source: ActionSource) {

--- a/app/src/views/features/sessions/SessionsIndexPageContainer/NetworkSessions/NetworkSessionViewer/NetworkSessionViewer.tsx
+++ b/app/src/views/features/sessions/SessionsIndexPageContainer/NetworkSessions/NetworkSessionViewer/NetworkSessionViewer.tsx
@@ -43,7 +43,9 @@ import CreateMocksModeBanner from "./CreateMocksModeBanner";
 import "./networkSessions.scss";
 
 export const NetworkSessionViewer: React.FC = () => {
-  const { id } = useParams();
+  const params = useParams();
+  console.debug("params", params);
+  const id = params.id;
   const dispatch = useDispatch();
   const navigate = useNavigate();
 

--- a/app/src/views/features/sessions/SessionsIndexPageContainer/NetworkSessions/NetworkSessionViewer/networkSessions.scss
+++ b/app/src/views/features/sessions/SessionsIndexPageContainer/NetworkSessions/NetworkSessionViewer/networkSessions.scss
@@ -46,6 +46,12 @@
     .network-session-list-heading {
       margin-bottom: 0;
     }
+
+    .import-btn-group {
+      display: flex;
+      align-items: flex-end;
+      gap: 4px;
+    }
   }
 }
 

--- a/app/src/views/features/sessions/SessionsIndexPageContainer/NetworkSessions/NetworkSessionsList.jsx
+++ b/app/src/views/features/sessions/SessionsIndexPageContainer/NetworkSessions/NetworkSessionsList.jsx
@@ -25,6 +25,7 @@ import { redirectToNetworkSession } from "utils/RedirectionUtils";
 import { toast } from "utils/Toast";
 import { isFeatureCompatible } from "utils/CompatibilityUtils";
 import FEATURES from "config/constants/sub/features";
+import { ImportFromWebSessionsButton } from "./ImportFromWebSessionsButton";
 
 const { Text } = Typography;
 
@@ -171,7 +172,10 @@ const NetworkSessionsList = ({ networkSessionsMetadata }) => {
             {isDesktopSessionsCompatible ? (
               <ImportHarModalButton />
             ) : (
-              <HarImportModal onSaved={stableOnSuccessfulHarImport} btnText="Import HAR" />
+              <div className="import-btn-group">
+                <ImportFromWebSessionsButton onSaved={stableOnSuccessfulHarImport} btnText="Import .RQLY File" />
+                <HarImportModal onSaved={stableOnSuccessfulHarImport} btnText="Import HAR" />
+              </div>
             )}
           </Space>
         }


### PR DESCRIPTION
- writes a converter for webSessions network events to har
- adds analytics events
- does not use [the new import](https://github.com/requestly/requestly/pull/957) since it still isn't stable


![Screenshot 2024-06-26 at 9 29 11 AM](https://github.com/requestly/requestly/assets/57226514/b2b588a2-2240-443a-af2a-3914ed6c5e02)


https://github.com/requestly/requestly/assets/57226514/80d8e11d-4eee-420d-9361-22d2c365c8e6


