### PR TITLE
test mv3: response rule

### DIFF
--- a/browser-extension/mv3/tests/rules/response/responseRule.spec.ts
+++ b/browser-extension/mv3/tests/rules/response/responseRule.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "../../fixtures";
+import { loadRules } from "../../utils";
+import responseRules from "./response_rules.json";
+import testScenarios, { ResponseRuleTestScenario } from "./testScenarios";
+import { IBaseTestData } from "../types";
+
+test.describe("Response Rule", () => {
+  testScenarios.forEach((scenario, i) => {
+    test(scenario.description, async ({ appPage, context }) => {
+      await testResponseRule({ appPage, context, ...scenario });
+    });
+  });
+});
+
+const testResponseRule = async (testScenarioData: ResponseRuleTestScenario & IBaseTestData) => {
+  const { appPage, context, ruleIds, testPageURL, expectedResponseUpdates, pageActions } = testScenarioData;
+  const rules = ruleIds.reduce((acc, ruleId) => ({ ...acc, [ruleId]: responseRules[ruleId] }), {});
+  await loadRules(appPage, rules);
+
+  const testPage = await context.newPage();
+
+  const responseMap = new Map<string, { response: string; statusCode: number }[]>();
+
+  testPage.on("response", async (response: Response) => {
+    const url = response.url();
+    const responseBody = (await response.body()).toString();
+    const statusCode = response.status();
+
+    const responseInfo = { response: responseBody ?? "", statusCode };
+    if (responseMap.has(url)) {
+      responseMap.get(url)?.push(responseInfo);
+    } else {
+      responseMap.set(url, [responseInfo]);
+    }
+  });
+
+  await testPage.goto(testPageURL, { waitUntil: "domcontentloaded" });
+
+  await pageActions?.(testPage);
+
+  for (const { url, expectedResponse, expectedStatusCode } of expectedResponseUpdates) {
+    const responseInfo = responseMap.get(url);
+    expect(responseInfo).toBeDefined();
+    const matchingResponseInfo = responseInfo?.find((info) => info.response === expectedResponse);
+    expect(matchingResponseInfo).toBeDefined();
+    if (expectedStatusCode) expect(matchingResponseInfo?.statusCode).toBe(expectedStatusCode);
+  }
+};

--- a/browser-extension/mv3/tests/rules/response/response_rules.json
+++ b/browser-extension/mv3/tests/rules/response/response_rules.json
@@ -1,0 +1,205 @@
+{
+  "Response_1": {
+    "createdBy": "qaXxGx5db4PAkDfQZMlWtUlbUhH3",
+    "creationDate": 1715153617702,
+    "currentOwner": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "description": "",
+    "groupId": "",
+    "id": "Response_1",
+    "isSample": false,
+    "lastModifiedBy": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "modificationDate": 1720060819138,
+    "name": "3.a. Static Modification",
+    "objectType": "rule",
+    "pairs": [
+      {
+        "id": "9ni7q",
+        "isCompressed": false,
+        "response": {
+          "resourceType": "restApi",
+          "statusCode": "201",
+          "statusText": "Created",
+          "type": "static",
+          "value": "{\"hello\":\"world\",\"testing\":\"response rule\"}"
+        },
+        "source": {
+          "key": "Url",
+          "operator": "Contains",
+          "value": "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz"
+        }
+      }
+    ],
+    "ruleType": "Response",
+    "schemaVersion": "3.0.0",
+    "status": "Inactive"
+  },
+  "Response_2": {
+    "createdBy": "qaXxGx5db4PAkDfQZMlWtUlbUhH3",
+    "creationDate": 1715153617702,
+    "currentOwner": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "description": "",
+    "groupId": "",
+    "id": "Response_2",
+    "isSample": false,
+    "lastModifiedBy": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "modificationDate": 1720060825623,
+    "name": "3.b. Static Modification without server",
+    "objectType": "rule",
+    "pairs": [
+      {
+        "id": "9ni7q",
+        "isCompressed": false,
+        "response": {
+          "resourceType": "restApi",
+          "serveWithoutRequest": true,
+          "statusCode": "201",
+          "statusText": "Created",
+          "type": "static",
+          "value": "{\"hello\":\"world\",\"testing\":\"response rule\"}"
+        },
+        "source": {
+          "key": "Url",
+          "operator": "Contains",
+          "value": "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz"
+        }
+      }
+    ],
+    "ruleType": "Response",
+    "schemaVersion": "3.0.0",
+    "status": "Inactive"
+  },
+  "Response_3": {
+    "createdBy": "qaXxGx5db4PAkDfQZMlWtUlbUhH3",
+    "creationDate": 1715153617702,
+    "currentOwner": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "description": "",
+    "groupId": "",
+    "id": "Response_3",
+    "isSample": false,
+    "lastModifiedBy": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "modificationDate": 1720060831305,
+    "name": "3.c. Dynamic Modification - Sync",
+    "objectType": "rule",
+    "pairs": [
+      {
+        "id": "lybbw",
+        "isCompressed": false,
+        "response": {
+          "resourceType": "restApi",
+          "statusCode": "201",
+          "statusText": "Created",
+          "type": "code",
+          "value": "function modifyResponse(args) {\n  const {method, url, response, responseType, requestHeaders, requestData, responseJSON} = args;\n  console.log({ args });\n  // Change response below depending upon request attributes received in args\n  return {\"dynamic\": \"modification\"};\n}"
+        },
+        "source": {
+          "key": "Url",
+          "operator": "Contains",
+          "value": "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz"
+        }
+      }
+    ],
+    "ruleType": "Response",
+    "schemaVersion": "3.0.0",
+    "status": "Inactive"
+  },
+  "Response_4": {
+    "createdBy": "qaXxGx5db4PAkDfQZMlWtUlbUhH3",
+    "creationDate": 1715153617702,
+    "currentOwner": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "description": "",
+    "groupId": "",
+    "id": "Response_4",
+    "isSample": false,
+    "lastModifiedBy": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "modificationDate": 1720060837551,
+    "name": "3.d. Async Dynamic Modification",
+    "objectType": "rule",
+    "pairs": [
+      {
+        "id": "lybbw",
+        "isCompressed": false,
+        "response": {
+          "resourceType": "restApi",
+          "statusCode": "202",
+          "statusText": "Accepted",
+          "type": "code",
+          "value": "async function modifyResponse(args) {\n  const delay = (delayInms) => {\n    return new Promise(resolve => setTimeout(resolve, delayInms));\n  };\n\n  const {method, url, response, responseType, requestHeaders, requestData, responseJSON} = args;\n  // Change response below depending upon request attributes received in args\n  console.log({args});\n  console.log(\"BEFORE\");\n  await delay(10000);\n  console.log(\"AFTER\");\n  return {\"dynamic\": \"response\"};\n}"
+        },
+        "source": {
+          "key": "Url",
+          "operator": "Contains",
+          "value": "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz"
+        }
+      }
+    ],
+    "ruleType": "Response",
+    "schemaVersion": "3.0.0",
+    "status": "Inactive"
+  },
+  "Response_5": {
+    "createdBy": "oVzEimT53QYBSBokU6xokra2Tc13",
+    "creationDate": 1716787814264,
+    "currentOwner": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "description": "",
+    "groupId": "",
+    "id": "Response_5",
+    "isSample": false,
+    "lastModifiedBy": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "modificationDate": 1720060843138,
+    "name": "Fetch dynamic modification",
+    "objectType": "rule",
+    "pairs": [
+      {
+        "id": "eel80",
+        "isCompressed": false,
+        "response": {
+          "resourceType": "restApi",
+          "statusCode": "",
+          "type": "code",
+          "value": "function modifyResponse(args) {\n  const {method, url, response, responseType, requestHeaders, requestData, responseJSON} = args;\n  // Change response below depending upon request attributes received in args\n  \n  const updatedResponse = response.replaceAll(\"requestly\", \"rq\");\n  console.log(\"Hello\", {updatedResponse});\n  return updatedResponse;\n}"
+        },
+        "source": {
+          "key": "Url",
+          "operator": "Contains",
+          "value": "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz"
+        }
+      }
+    ],
+    "ruleType": "Response",
+    "schemaVersion": "3.0.0",
+    "status": "Inactive"
+  },
+  "Response_6": {
+    "createdBy": "oVzEimT53QYBSBokU6xokra2Tc13",
+    "creationDate": 1716787746422,
+    "currentOwner": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "description": "",
+    "groupId": "",
+    "id": "Response_6",
+    "isSample": false,
+    "lastModifiedBy": "AfhB1kqjeKYJD1P8Q9LawGJLkfT2",
+    "modificationDate": 1720060856104,
+    "name": "Fetch Static Modification",
+    "objectType": "rule",
+    "pairs": [
+      {
+        "id": "o0xe3",
+        "isCompressed": false,
+        "response": {
+          "resourceType": "restApi",
+          "statusCode": "",
+          "type": "static",
+          "value": "{\"foo\":\"bar\"}"
+        },
+        "source": {
+          "key": "Url",
+          "operator": "Contains",
+          "value": "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz"
+        }
+      }
+    ],
+    "ruleType": "Response",
+    "schemaVersion": "3.0.0",
+    "status": "Inactive"
+  }
+}

--- a/browser-extension/mv3/tests/rules/response/testScenarios.ts
+++ b/browser-extension/mv3/tests/rules/response/testScenarios.ts
@@ -1,0 +1,114 @@
+import { Page } from "@playwright/test";
+
+export interface ResponseRuleTestScenario {
+  description: string;
+  ruleIds: string[];
+  testPageURL: string;
+  expectedResponseUpdates: { url: string; expectedResponse: string; expectedStatusCode?: number }[];
+  pageActions?: (page: Page) => Promise<void>;
+}
+
+const scenarios: ResponseRuleTestScenario[] = [
+  {
+    description: "Static modification",
+    testPageURL: "https://example.com",
+    ruleIds: ["Response_1"],
+    expectedResponseUpdates: [
+      {
+        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+        expectedResponse: '{"hello":"world","testing":"response rule"}',
+        expectedStatusCode: 201,
+      },
+    ],
+    pageActions: async (page: Page) => {
+      await page.evaluate(async () => {
+        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+      });
+    },
+  },
+  {
+    description: "Static modification without server",
+    testPageURL: "https://example.com",
+    ruleIds: ["Response_2"],
+    expectedResponseUpdates: [
+      {
+        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+        expectedResponse: '{"hello":"world","testing":"response rule"}',
+        expectedStatusCode: 201,
+      },
+    ],
+    pageActions: async (page: Page) => {
+      await page.evaluate(async () => {
+        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+      });
+    },
+  },
+  {
+    description: "Sync Dynamic modification",
+    testPageURL: "https://example.com",
+    ruleIds: ["Response_3"],
+    expectedResponseUpdates: [
+      {
+        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+        expectedResponse: '{"dynamic": "modification"}',
+        expectedStatusCode: 201,
+      },
+    ],
+    pageActions: async (page: Page) => {
+      await page.evaluate(async () => {
+        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+      });
+    },
+  },
+  {
+    description: "Async Dynamic modification",
+    testPageURL: "https://example.com",
+    ruleIds: ["Response_4"],
+    expectedResponseUpdates: [
+      {
+        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+        expectedResponse: '{"dynamic": "modification"}',
+        expectedStatusCode: 202,
+      },
+    ],
+    pageActions: async (page: Page) => {
+      await page.evaluate(async () => {
+        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+      });
+    },
+  },
+  {
+    description: "Fetch Dynamic modification",
+    testPageURL: "https://example.com",
+    ruleIds: ["Response_5"],
+    expectedResponseUpdates: [
+      {
+        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+        expectedResponse: '{\n  "ok": true,\n  "rq": "rocks",\n  "rq": "super rocks"\n}',
+      },
+    ],
+    pageActions: async (page: Page) => {
+      await page.evaluate(async () => {
+        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+      });
+    },
+  },
+  {
+    description: "Fetch static modification",
+    testPageURL: "https://example.com",
+    ruleIds: ["Response_6"],
+    expectedResponseUpdates: [
+      {
+        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+        expectedResponse: '{"foo":"bar"}',
+      },
+    ],
+    pageActions: async (page: Page) => {
+      await page.evaluate(async () => {
+        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+      });
+    },
+  },
+];
+
+export default scenarios;

--- a/browser-extension/mv3/tests/rules/response/testScenarios.ts
+++ b/browser-extension/mv3/tests/rules/response/testScenarios.ts
@@ -9,106 +9,106 @@ export interface ResponseRuleTestScenario {
 }
 
 const scenarios: ResponseRuleTestScenario[] = [
-  {
-    description: "Static modification",
-    testPageURL: "https://example.com",
-    ruleIds: ["Response_1"],
-    expectedResponseUpdates: [
-      {
-        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
-        expectedResponse: '{"hello":"world","testing":"response rule"}',
-        expectedStatusCode: 201,
-      },
-    ],
-    pageActions: async (page: Page) => {
-      await page.evaluate(async () => {
-        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
-      });
-    },
-  },
-  {
-    description: "Static modification without server",
-    testPageURL: "https://example.com",
-    ruleIds: ["Response_2"],
-    expectedResponseUpdates: [
-      {
-        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
-        expectedResponse: '{"hello":"world","testing":"response rule"}',
-        expectedStatusCode: 201,
-      },
-    ],
-    pageActions: async (page: Page) => {
-      await page.evaluate(async () => {
-        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
-      });
-    },
-  },
-  {
-    description: "Sync Dynamic modification",
-    testPageURL: "https://example.com",
-    ruleIds: ["Response_3"],
-    expectedResponseUpdates: [
-      {
-        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
-        expectedResponse: '{"dynamic": "modification"}',
-        expectedStatusCode: 201,
-      },
-    ],
-    pageActions: async (page: Page) => {
-      await page.evaluate(async () => {
-        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
-      });
-    },
-  },
-  {
-    description: "Async Dynamic modification",
-    testPageURL: "https://example.com",
-    ruleIds: ["Response_4"],
-    expectedResponseUpdates: [
-      {
-        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
-        expectedResponse: '{"dynamic": "modification"}',
-        expectedStatusCode: 202,
-      },
-    ],
-    pageActions: async (page: Page) => {
-      await page.evaluate(async () => {
-        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
-      });
-    },
-  },
-  {
-    description: "Fetch Dynamic modification",
-    testPageURL: "https://example.com",
-    ruleIds: ["Response_5"],
-    expectedResponseUpdates: [
-      {
-        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
-        expectedResponse: '{\n  "ok": true,\n  "rq": "rocks",\n  "rq": "super rocks"\n}',
-      },
-    ],
-    pageActions: async (page: Page) => {
-      await page.evaluate(async () => {
-        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
-      });
-    },
-  },
-  {
-    description: "Fetch static modification",
-    testPageURL: "https://example.com",
-    ruleIds: ["Response_6"],
-    expectedResponseUpdates: [
-      {
-        url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
-        expectedResponse: '{"foo":"bar"}',
-      },
-    ],
-    pageActions: async (page: Page) => {
-      await page.evaluate(async () => {
-        await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
-      });
-    },
-  },
+  // {
+  //   description: "Static modification",
+  //   testPageURL: "https://example.com",
+  //   ruleIds: ["Response_1"],
+  //   expectedResponseUpdates: [
+  //     {
+  //       url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+  //       expectedResponse: '{"hello":"world","testing":"response rule"}',
+  //       expectedStatusCode: 201,
+  //     },
+  //   ],
+  //   pageActions: async (page: Page) => {
+  //     await page.evaluate(async () => {
+  //       await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+  //     });
+  //   },
+  // },
+  // {
+  //   description: "Static modification without server",
+  //   testPageURL: "https://example.com",
+  //   ruleIds: ["Response_2"],
+  //   expectedResponseUpdates: [
+  //     {
+  //       url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+  //       expectedResponse: '{"hello":"world","testing":"response rule"}',
+  //       expectedStatusCode: 201,
+  //     },
+  //   ],
+  //   pageActions: async (page: Page) => {
+  //     await page.evaluate(async () => {
+  //       await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+  //     });
+  //   },
+  // },
+  // {
+  //   description: "Sync Dynamic modification",
+  //   testPageURL: "https://example.com",
+  //   ruleIds: ["Response_3"],
+  //   expectedResponseUpdates: [
+  //     {
+  //       url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+  //       expectedResponse: '{"dynamic": "modification"}',
+  //       expectedStatusCode: 201,
+  //     },
+  //   ],
+  //   pageActions: async (page: Page) => {
+  //     await page.evaluate(async () => {
+  //       await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+  //     });
+  //   },
+  // },
+  // {
+  //   description: "Async Dynamic modification",
+  //   testPageURL: "https://example.com",
+  //   ruleIds: ["Response_4"],
+  //   expectedResponseUpdates: [
+  //     {
+  //       url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+  //       expectedResponse: '{"dynamic": "modification"}',
+  //       expectedStatusCode: 202,
+  //     },
+  //   ],
+  //   pageActions: async (page: Page) => {
+  //     await page.evaluate(async () => {
+  //       await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+  //     });
+  //   },
+  // },
+  // {
+  //   description: "Fetch Dynamic modification",
+  //   testPageURL: "https://example.com",
+  //   ruleIds: ["Response_5"],
+  //   expectedResponseUpdates: [
+  //     {
+  //       url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+  //       expectedResponse: '{\n  "ok": true,\n  "rq": "rocks",\n  "rq": "super rocks"\n}',
+  //     },
+  //   ],
+  //   pageActions: async (page: Page) => {
+  //     await page.evaluate(async () => {
+  //       await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+  //     });
+  //   },
+  // },
+  // {
+  //   description: "Fetch static modification",
+  //   testPageURL: "https://example.com",
+  //   ruleIds: ["Response_6"],
+  //   expectedResponseUpdates: [
+  //     {
+  //       url: "https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz",
+  //       expectedResponse: '{"foo":"bar"}',
+  //     },
+  //   ],
+  //   pageActions: async (page: Page) => {
+  //     await page.evaluate(async () => {
+  //       await fetch("https://requestly.tech/api/mockv2/response-requestly?teamId=9sBQkTnxaMlBY6kWHpoz");
+  //     });
+  //   },
+  // },
 ];
 
 export default scenarios;


### PR DESCRIPTION
all pageAction requests give 404. tried both `response` and `requestEnd` event. The response for main document is captured but not for the pageAction request.

Tried to then move the mock server request to the main `testPageUrl`. The request to those endpoints just fail. might be a problem in mock server?

<img width="982" alt="Screenshot 2024-07-09 at 8 07 18 AM" src="https://github.com/requestly/requestly/assets/57226514/c3669f92-05d6-4b45-92be-e3d2d92b1684">


also tried with `--disable-web-security` flag to bypass if we were having cors errors. But even that didn't work