### PR TITLE
fix: remove broken products down from being rendered on desktop app

### DIFF
--- a/app/src/layouts/DashboardLayout/MenuHeader/ProductsDropDown.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/ProductsDropDown.tsx
@@ -161,21 +161,20 @@ const Products: React.FC<ProductsProps> = (props) => {
     products.splice(5, 1);
   }
 
-  if (appMode !== GLOBAL_CONSTANTS.APP_MODES.DESKTOP)
-    return (
-      <div className="products-grid">
-        {products.map((product, index) => (
-          <ProductTile
-            key={index}
-            title={product.title}
-            icon={product.icon}
-            description={product.description}
-            handleClick={product.handleClick}
-          />
-        ))}
-        <DesktopAppPromoModal open={isDesktopAppPromoModalOpen} onCancel={handleDesktopAppPromoModalClose} />
-      </div>
-    );
+  return (
+    <div className="products-grid">
+      {products.map((product, index) => (
+        <ProductTile
+          key={index}
+          title={product.title}
+          icon={product.icon}
+          description={product.description}
+          handleClick={product.handleClick}
+        />
+      ))}
+      <DesktopAppPromoModal open={isDesktopAppPromoModalOpen} onCancel={handleDesktopAppPromoModalClose} />
+    </div>
+  );
 };
 
 const ProductsDropDown: React.FC<{}> = () => {

--- a/app/src/layouts/DashboardLayout/MenuHeader/index.js
+++ b/app/src/layouts/DashboardLayout/MenuHeader/index.js
@@ -67,7 +67,7 @@ const MenuHeader = () => {
                 >
                   Tutorials
                 </a>
-                <ProductsDropDown />
+                {appMode === GLOBAL_CONSTANTS.APP_MODES.EXTENSION && <ProductsDropDown />}
               </div>
             </Col>
           ) : null}


### PR DESCRIPTION
broken for desktop app. could had fixed that but then would required inputs from other teammates around what options should be displayed how on the desktop app. 
removing for now, can be brought back later.