### PR TITLE
refactor+fix: extract invite routes to a separate file 

### DIFF
--- a/app/src/features/onboarding/components/persona/components/personaScreen/index.tsx
+++ b/app/src/features/onboarding/components/persona/components/personaScreen/index.tsx
@@ -213,7 +213,7 @@ export const PersonaScreen: React.FC<Props> = ({ isOpen }) => {
                   </Row>
                 )}
                 <Typography.Title level={5} style={{ marginTop: user.loggedIn ? "24px" : 0, fontWeight: 500 }}>
-                  Helps us in optimizing your experience
+                  Help us in optimizing your experience
                 </Typography.Title>
                 {shouldShowPersonaInput && (
                   <Col className="mt-16">

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -19,6 +19,7 @@ import { onboardingRoutes } from "./onboardingRoutes";
 import { settingRoutes } from "features/settings/routes";
 import { miscRoutes } from "./miscRoutes";
 import { desktopSessionsRoutes } from "./desktopSessionRoutes";
+import { inviteRoutes } from "./inviteRoutes";
 
 export const routesV2: RouteObject[] = [
   /** Misc **/
@@ -43,6 +44,7 @@ export const routesV2: RouteObject[] = [
           ...desktopRoutes,
           ...mockServerRoutes,
           ...onboardingRoutes,
+          ...inviteRoutes,
           ...settingRoutes,
           ...miscRoutes,
           ...desktopSessionsRoutes,

--- a/app/src/routes/inviteRoutes.tsx
+++ b/app/src/routes/inviteRoutes.tsx
@@ -1,0 +1,10 @@
+import { RouteObject } from "react-router-dom";
+import PATHS from "config/constants/sub/paths";
+import InviteView from "views/misc/Invite";
+
+export const inviteRoutes: RouteObject[] = [
+  {
+    path: PATHS.INVITE.RELATIVE,
+    element: <InviteView />,
+  },
+];

--- a/app/src/routes/onboardingRoutes.tsx
+++ b/app/src/routes/onboardingRoutes.tsx
@@ -1,6 +1,5 @@
 import { Navigate, RouteObject } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
-import InviteView from "views/misc/Invite";
 
 export const onboardingRoutes: RouteObject[] = [
   {
@@ -14,9 +13,5 @@ export const onboardingRoutes: RouteObject[] = [
   {
     path: PATHS.GETTING_STARTED,
     element: <Navigate to={PATHS.HOME.ABSOLUTE} state={{ from: PATHS.GETTING_STARTED }} />,
-  },
-  {
-    path: PATHS.INVITE.RELATIVE,
-    element: <InviteView />,
   },
 ];

--- a/app/src/src-SessionBear/routes/index.tsx
+++ b/app/src/src-SessionBear/routes/index.tsx
@@ -8,6 +8,7 @@ import { settingsRoutes } from "./settingsRoutes";
 import { accountRoutes } from "routes/accountRoutes";
 import DashboardLayout from "src-SessionBear/layouts/DashboardLayout";
 import FullScreenLayout from "layouts/FullScreenLayout";
+import { inviteRoutes } from "routes/inviteRoutes";
 
 export const sessionBearRoutes: RouteObject[] = [
   {
@@ -18,7 +19,14 @@ export const sessionBearRoutes: RouteObject[] = [
       {
         path: "",
         element: <DashboardLayout />,
-        children: [...sessionRoutes, ...miscRoutes, ...authRoutes, ...settingsRoutes, ...accountRoutes],
+        children: [
+          ...sessionRoutes,
+          ...miscRoutes,
+          ...authRoutes,
+          ...settingsRoutes,
+          ...accountRoutes,
+          ...inviteRoutes,
+        ],
       },
       /** Iframe paths  - Without Header, Footer **/
       {


### PR DESCRIPTION
- had to do this to add just invites to the sessionBear routes
- could had added the onboarding routes _(since there is already a check [here](https://github.com/requestly/requestly/blob/f4884bf81db5250232a377762173f891393ef72f/app/src/features/onboarding/utils.ts#L11))_ but that could lead to confusing bugs later