### PR TITLE
chore: allow ':' in mock endpoint input

### DIFF
--- a/app/src/components/features/mocksV2/MockEditorIndex/utils.ts
+++ b/app/src/components/features/mocksV2/MockEditorIndex/utils.ts
@@ -20,7 +20,7 @@ export const validateEndpoint = (endpoint: string, messagePrefix = "Endpoint") =
     return `${messagePrefix} cannot end with '/'`;
   }
 
-  const pattern = /^[A-Za-z0-9_.\-/]+$/;
+  const pattern = /^[A-Za-z0-9_:.\-/]+$/;
   if (endpoint.match(pattern)) {
     return null;
   } else {


### PR DESCRIPTION
doing this to make it possible to specify URL params