### PR TITLE
draft: add storagePath to mocks

### DIFF
--- a/app/src/backend/mocks/createMock.ts
+++ b/app/src/backend/mocks/createMock.ts
@@ -4,7 +4,7 @@ import { MockRecordType, RQMockSchema } from "components/features/mocksV2/types"
 import { getOwnerId } from "backend/utils";
 import { updateUserMockSelectorsMap, uploadResponseBodyFiles } from "./common";
 import { BODY_IN_BUCKET_ENABLED } from "./constants";
-import { createResponseBodyFilepath } from "./utils";
+import { createMockDataPath, createResponseBodyFilepath } from "./utils";
 import { updateMockFromFirebase } from "./updateMock";
 import Logger from "lib/logger";
 
@@ -23,6 +23,7 @@ export const createMock = async (uid: string, mockData: RQMockSchema, teamId?: s
       responsesWithBody.push({ ...response });
       response.body = null;
     });
+    mockData.storagePath = createMockDataPath(uid, mockData.id, teamId);
   }
 
   const mockId = await createMockFromFirebase(uid, mockData, teamId);

--- a/app/src/backend/mocks/utils.ts
+++ b/app/src/backend/mocks/utils.ts
@@ -1,10 +1,22 @@
-export const createResponseBodyBucketpath = (uid: string, mockId: string, teamId?: string): string => {
+export const createMockDataPath = (uid: string, mockId: string, teamId?: string): string => {
   if (teamId) {
-    return `teams/${teamId}/mocks/${mockId}/body`;
+    return `teams/${teamId}/mocks/${mockId}`;
   }
-  return `users/${uid}/mocks/${mockId}/body`;
+  return `users/${uid}/mocks/${mockId}`;
+};
+
+export const createResponseBodyBucketpath = (uid: string, mockId: string, teamId?: string): string => {
+  return createMockDataPath(uid, mockId, teamId) + "/body";
 };
 
 export const createResponseBodyFilepath = (uid: string, mockId: string, fileName: string, teamId?: string): string => {
   return createResponseBodyBucketpath(uid, mockId, teamId) + `/${fileName}`;
+};
+
+export const createMockLogsBucketPath = (uid: string, mockId: string, teamId?: string): string => {
+  return createMockDataPath(uid, mockId, teamId) + "/logs";
+};
+
+export const createMockLogFilePath = (uid: string, mockId: string, logId: string, teamId?: string): string => {
+  return createMockLogsBucketPath(uid, mockId, teamId) + `/${logId}`;
 };

--- a/app/src/components/features/mocksV2/types.ts
+++ b/app/src/components/features/mocksV2/types.ts
@@ -29,6 +29,7 @@ export interface RQMockMetadataSchema extends MockMetadataSchema {
   collectionId?: string;
   createdBy?: string;
   lastUpdatedBy?: string;
+  storagePath?: string;
 }
 
 export interface RQMockCollection {


### PR DESCRIPTION
To make integration for [mock logs](https://github.com/requestly/requestly-mock-server/pull/21) cleaner