### PR TITLE
fix: code string with html tags makes string be parsed as html

### DIFF
--- a/app/src/views/features/rules/RuleEditor/components/Header/ActionButtons/CreateRuleButton/actions/insertScriptValidators.js
+++ b/app/src/views/features/rules/RuleEditor/components/Header/ActionButtons/CreateRuleButton/actions/insertScriptValidators.js
@@ -224,7 +224,7 @@ function isHTMLString(str, generatedDocument) {
 
   return (
     // nodeType 1 is for element nodes
-    Array.from(generatedDocument.body.childNodes).some((node) => node.nodeType === 1) || // most nodes end up in body
+    /* Array.from(generatedDocument.body.childNodes).some((node) => node.nodeType === 1) || // most nodes end up in body */ // commenting since being this thorough is causing issues
     Array.from(generatedDocument.head.childNodes).some((node) => node.nodeType === 1) // special nodes like link and style end up in head
   );
 }
@@ -309,7 +309,9 @@ function extractDOMNodeDetails(htmlCodeString, nodeName) {
   const doc = parser.parseFromString(htmlCodeString, "text/html");
   const blocks = doc.getElementsByTagName(nodeName) ?? [];
   return Array.from(blocks).map((htmlBlock) => {
+    console.log("DBG: extractDOMNodeDetails: htmlBlock", htmlBlock);
     const innerText = getInnerMostText(htmlBlock.innerText, nodeName);
+    console.log("DBG: extractDOMNodeDetails: innerText", innerText);
     return {
       innerText,
       attributes: Array.from(htmlBlock.attributes).map((attr) => ({ name: attr.name, value: attr.value })),


### PR DESCRIPTION
the check being commented out was added to make sure strings like 
`<div>hello</div><script>console.log("Hello, World!");</script><style>body { background-color: red; }</style>`

get parsed as html even though our usecase dictates that we don't have any other html tags in the console.
Strings with tags other than script, style or link end up in body when parsing with  `domParser`. 

The problem is that if the string contains a script tag like the following contains `span`

```javscript
	const div = document.createElement("div");
	    div.id = "rq_banner";
	    div.innerHTML = "<span>🚀 Introducing this new feature powered by Requestly!!</span>";
	    document.body.appendChild(div);
```

this content will get detected as html rather than string (`isHTMLString` returns true for this)

hence removing the check which although makes the issue go away, but requires testing to ensure all the other messages shown to the user are still consistent and correct.