### PR TITLE
fix: role selector when inviting to workspace

### DIFF
--- a/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/MembersDetails/AddMemberModal/index.jsx
+++ b/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/MembersDetails/AddMemberModal/index.jsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { useIsTeamAdmin } from "../../hooks/useIsTeamAdmin";
 import { toast } from "utils/Toast.js";
 import { Row, Col, Checkbox, Typography } from "antd";
-import { getAvailableTeams, getCurrentlyActiveWorkspace } from "store/features/teams/selectors";
+import { getAvailableTeams, getCurrentlyActiveWorkspace, getUserTeamRole } from "store/features/teams/selectors";
 import { getUserAuthDetails } from "store/selectors";
 import isEmail from "validator/lib/isEmail";
 import { getFunctions, httpsCallable } from "firebase/functions";
@@ -42,6 +42,8 @@ const AddMemberModal = ({ isOpen, toggleModal, callback, teamId: currentTeamId, 
 
   // Global state
   const user = useSelector(getUserAuthDetails);
+  const loggedInUserId = user?.details?.profile?.uid;
+  const isLoggedInUserAdmin = useSelector(getUserTeamRole) === "admin";
   const isAppSumoDeal = user?.details?.planDetails?.type === "appsumo";
 
   const availableTeams = useSelector(getAvailableTeams);
@@ -267,6 +269,8 @@ const AddMemberModal = ({ isOpen, toggleModal, callback, teamId: currentTeamId, 
                           <MemberRoleDropdown
                             placement="bottomRight"
                             isAdmin={makeUserAdmin}
+                            isLoggedInUserAdmin={isLoggedInUserAdmin}
+                            loggedInUserId={loggedInUserId}
                             handleMemberRoleChange={(isAdmin) => setMakeUserAdmin(isAdmin)}
                           />
                         </div>

--- a/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/MembersDetails/AddMemberModal/index.jsx
+++ b/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/MembersDetails/AddMemberModal/index.jsx
@@ -43,7 +43,8 @@ const AddMemberModal = ({ isOpen, toggleModal, callback, teamId: currentTeamId, 
   // Global state
   const user = useSelector(getUserAuthDetails);
   const loggedInUserId = user?.details?.profile?.uid;
-  const isLoggedInUserAdmin = useSelector(getUserTeamRole) === "admin";
+  const userTeamRole = useSelector(getUserTeamRole);
+  const isLoggedInUserAdmin = userTeamRole === "admin" || userTeamRole === "owner";
   const isAppSumoDeal = user?.details?.planDetails?.type === "appsumo";
 
   const availableTeams = useSelector(getAvailableTeams);

--- a/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/MembersDetails/AddMemberModal/index.jsx
+++ b/app/src/features/settings/components/Profile/ManageTeams/TeamViewer/MembersDetails/AddMemberModal/index.jsx
@@ -22,6 +22,7 @@ import EmailInputWithDomainBasedSuggestions from "components/common/EmailInputWi
 import "./AddMemberModal.css";
 import { fetchBillingIdByOwner, toggleWorkspaceMappingInBillingTeam } from "backend/billing";
 import TEAM_WORKSPACES from "config/constants/sub/team-workspaces";
+import { TeamRole } from "types";
 
 const AddMemberModal = ({ isOpen, toggleModal, callback, teamId: currentTeamId, source }) => {
   //Component State
@@ -44,7 +45,7 @@ const AddMemberModal = ({ isOpen, toggleModal, callback, teamId: currentTeamId, 
   const user = useSelector(getUserAuthDetails);
   const loggedInUserId = user?.details?.profile?.uid;
   const userTeamRole = useSelector(getUserTeamRole);
-  const isLoggedInUserAdmin = userTeamRole === "admin" || userTeamRole === "owner";
+  const isLoggedInUserAdmin = userTeamRole === TeamRole.admin;
   const isAppSumoDeal = user?.details?.planDetails?.type === "appsumo";
 
   const availableTeams = useSelector(getAvailableTeams);

--- a/app/src/store/features/teams/selectors.js
+++ b/app/src/store/features/teams/selectors.js
@@ -1,5 +1,6 @@
 import { ReducerKeys } from "store/constants";
 import { getUserAuthDetails } from "store/selectors";
+import { TeamRole } from "types";
 
 export const getTeamsState = (state) => {
   return state[ReducerKeys.TEAMS];
@@ -29,7 +30,6 @@ export const getUserTeamRole = (state) => {
   const memberData = getCurrentlyActiveWorkspaceMembers(state)[userId];
 
   if (!memberData) return null;
-  if (memberData.isOwner) return "owner";
-  if (memberData.isAdmin) return "admin";
-  return "member";
+  if (memberData.isOwner || memberData.isAdmin) return TeamRole.admin;
+  return TeamRole.write;
 };

--- a/app/src/store/features/teams/selectors.js
+++ b/app/src/store/features/teams/selectors.js
@@ -1,4 +1,5 @@
 import { ReducerKeys } from "store/constants";
+import { getUserAuthDetails } from "store/selectors";
 
 export const getTeamsState = (state) => {
   return state[ReducerKeys.TEAMS];
@@ -17,4 +18,18 @@ export const getIsWorkspaceMode = (state) => {
 
 export const getCurrentlyActiveWorkspaceMembers = (state) => {
   return getTeamsState(state).currentlyActiveWorkspaceMembers;
+};
+
+export const getUserTeamRole = (state) => {
+  const user = getUserAuthDetails(state);
+  const userId = user?.details?.profile?.uid;
+
+  if (!userId) return null;
+
+  const memberData = getCurrentlyActiveWorkspaceMembers(state)[userId];
+
+  if (!memberData) return null;
+  if (memberData.isOwner) return "owner";
+  if (memberData.isAdmin) return "admin";
+  return "member";
 };


### PR DESCRIPTION
- admins and owners will be able to select whether to invite as member or admin
- members can only invite (won't see dropdown)

P.S. introduces the `getUserTeamRole` reducer that will be useful later when implementing ACLs