### PR TITLE
chore: hide mock logs behind feature flag

### DIFF
--- a/app/src/components/features/mocksV2/MockEditorIndex/Editor/index.tsx
+++ b/app/src/components/features/mocksV2/MockEditorIndex/Editor/index.tsx
@@ -28,6 +28,7 @@ import CodeEditor, { EditorLanguage } from "componentsV2/CodeEditor";
 import { BottomSheetLayout, BottomSheetPlacement, BottomSheetProvider } from "componentsV2/BottomSheet";
 import MockLogs from "./BottomSheet/MockLogs";
 import { SheetLayout } from "componentsV2/BottomSheet/types";
+import { useFeatureValue } from "@growthbook/growthbook-react";
 
 interface Props {
   isNew?: boolean;
@@ -59,6 +60,8 @@ const MockEditor: React.FC<Props> = ({
 
   const workspace = useSelector(getCurrentlyActiveWorkspace);
   const teamId = workspace?.id;
+
+  const areLogsVisible = useFeatureValue("mock_logs", false);
 
   const [id] = useState<string>(mockData.id); // No need to edit this. Set by firebase
   const [type] = useState<MockType>(mockData?.type || mockType);
@@ -392,7 +395,7 @@ const MockEditor: React.FC<Props> = ({
     }
   };
 
-  return (
+  return areLogsVisible ? (
     <div className="mock-parent mock-editor-layout-container">
       <BottomSheetProvider defaultPlacement={BottomSheetPlacement.RIGHT}>
         <MockEditorHeader
@@ -443,6 +446,49 @@ const MockEditor: React.FC<Props> = ({
           />
         ) : null}
       </BottomSheetProvider>
+    </div>
+  ) : (
+    <div className="overflow-hidden mock-editor-layout-container">
+      <MockEditorHeader
+        isNewMock={isNew}
+        mockType={mockType}
+        savingInProgress={savingInProgress}
+        handleClose={onClose}
+        handleSave={handleOnSave}
+        handleTest={handleTest}
+        setPassword={setPassword}
+        password={password}
+      />
+      <Col className="mock-editor-title-container">
+        <RQEditorTitle
+          name={name}
+          mode={isNew ? "create" : "edit"}
+          description={desc}
+          namePlaceholder={mockType === MockType.API ? "Mock name" : "File name"}
+          descriptionPlaceholder="Add your description here."
+          nameChangeCallback={onNameChange}
+          descriptionChangeCallback={onDescriptionChange}
+          tagText={fileType}
+          errors={errors}
+        />
+      </Col>
+      <div className="mock-editor-wrapper">
+        <div className="mock-editor-container">
+          <Row className="mock-editor-body">
+            {renderMetadataRow()}
+            {renderMockCodeEditor()}
+          </Row>
+        </div>
+      </div>
+      {!isNew ? (
+        <APIClient
+          request={apiRequest}
+          openInModal
+          modalTitle="Test mock endpoint"
+          isModalOpen={isTestModalOpen}
+          onModalClose={() => setIsTestModalOpen(false)}
+        />
+      ) : null}
     </div>
   );
 };

--- a/app/src/components/features/mocksV2/MockEditorIndex/MockEditorIndex.tsx
+++ b/app/src/components/features/mocksV2/MockEditorIndex/MockEditorIndex.tsx
@@ -99,7 +99,7 @@ const MockEditorIndex: React.FC<Props> = ({
       .finally(() => {
         setIsMockCollectionLoading(false);
       });
-  }, [mockEditorData.collectionId, teamId, uid]);
+  }, [mockEditorData?.collectionId, teamId, uid]);
 
   const onMockSave = (data: MockEditorDataSchema) => {
     setSavingInProgress(true);

--- a/app/src/components/features/mocksV2/MockEditorIndex/MockEditorIndex.tsx
+++ b/app/src/components/features/mocksV2/MockEditorIndex/MockEditorIndex.tsx
@@ -99,7 +99,7 @@ const MockEditorIndex: React.FC<Props> = ({
       .finally(() => {
         setIsMockCollectionLoading(false);
       });
-  }, [mockEditorData?.collectionId]);
+  }, [mockEditorData.collectionId, teamId, uid]);
 
   const onMockSave = (data: MockEditorDataSchema) => {
     setSavingInProgress(true);


### PR DESCRIPTION
Current UI from https://github.com/requestly/requestly/pull/2082 degrades the UX of mock editor hence hiding it for now, and bringing back old changes