### PR TITLE
[ENGG-2197] fix: RQ rule editor default state

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js
@@ -22,9 +22,6 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
   const [requestTypePopupSelection, setRequestTypePopupSelection] = useState(
     pair?.request?.type ?? GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC
   );
-  const [editorStaticValue, setEditorStaticValue] = useState(
-    pair?.request?.type === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC && pair.request.value
-  );
 
   const codeFormattedFlag = useRef(null);
   const { getFeatureLimitValue } = useFeatureLimiter();
@@ -35,8 +32,6 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
         let value = "{}";
         if (requestType === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.CODE) {
           value = ruleDetails["REQUEST_BODY_JAVASCRIPT_DEFAULT_VALUE"];
-        } else if (requestType === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC) {
-          setEditorStaticValue(value);
         }
 
         dispatch(
@@ -74,10 +69,6 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
   }, [pair.request.type]);
 
   const requestBodyChangeHandler = (value) => {
-    if (pair.request.type === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC) {
-      setEditorStaticValue(value);
-    }
-
     dispatch(
       actions.updateRulePairAtGivenPath({
         pairIndex,
@@ -196,11 +187,7 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
                     : EditorLanguage.JSON
                 }
                 defaultValue={getEditorDefaultValue()}
-                value={
-                  pair.request.type === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC
-                    ? editorStaticValue
-                    : pair.request.value
-                }
+                value={pair.request.value}
                 handleChange={requestBodyChangeHandler}
                 isReadOnly={isInputDisabled}
                 analyticEventProperties={{ source: "rule_editor", rule_type: RuleType.REQUEST }}

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ResponseBodyRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ResponseBodyRow/index.js
@@ -38,9 +38,6 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
   const [responseTypePopupSelection, setResponseTypePopupSelection] = useState(
     pair?.response?.type ?? GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.STATIC
   );
-  const [editorStaticValue, setEditorStaticValue] = useState(
-    pair?.response?.type === GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.STATIC && pair.response.value
-  );
 
   const codeFormattedFlag = useRef(null);
   const { getFeatureLimitValue } = useFeatureLimiter();
@@ -53,9 +50,8 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
           value = ruleDetails["RESPONSE_BODY_JAVASCRIPT_DEFAULT_VALUE"];
         } else if (responseBodyType === GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.LOCAL_FILE) {
           value = "";
-        } else {
-          setEditorStaticValue(value);
         }
+
         dispatch(
           actions.updateRulePairAtGivenPath({
             pairIndex,
@@ -144,10 +140,6 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
   };
 
   const responseBodyChangeHandler = (value) => {
-    if (pair.response.type === GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.STATIC) {
-      setEditorStaticValue(value);
-    }
-
     dispatch(
       actions.updateRulePairAtGivenPath({
         pairIndex,
@@ -307,11 +299,7 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
                     : EditorLanguage.JSON
                 }
                 defaultValue={getEditorDefaultValue()}
-                value={
-                  pair.response.type === GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.STATIC
-                    ? editorStaticValue
-                    : pair.response.value
-                }
+                value={pair.response.value}
                 isReadOnly={isInputDisabled}
                 handleChange={responseBodyChangeHandler}
                 isResizable

--- a/app/src/componentsV2/CodeEditor/components/Editor/Editor.tsx
+++ b/app/src/componentsV2/CodeEditor/components/Editor/Editor.tsx
@@ -103,8 +103,7 @@ const Editor: React.FC<EditorProps> = ({
     } else {
       setEditorContent(value);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultValue]);
+  }, [defaultValue, value]);
 
   const handleEditorClose = useCallback(
     (id: string) => {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary:**
This pull request simplifies the codebase by removing state management for static request body values and updating rendering for `RequestBodyRow` and `ResponseBodyRow` components.

**State Management:**
- Removes `editorStaticValue` state and related logic from `RequestBodyRow`.

**Rendering:**
- Both `RequestBodyRow` and `ResponseBodyRow` components now directly render `pair.request.value` and `pair.response.value` respectively.

**Categorized Changes:**

**State Management:**
- Removes `editorStaticValue` state and related logic.

**Rendering:**
- Updates `RequestBodyRow` and `ResponseBodyRow` components to render `pair.request.value` and `pair.response.value`.

**Hooks:**
- Introduces `getFeatureLimitValue` hook and uses it in the `ResponseBodyRow` component for dynamic behavior.

**Component Updates:**
- Updates `ResponseBodyRow` component to use `pair.response.value` directly for setting the code editor value.

**Code Simplification:**
- Removes conditional logic for setting the `editorStaticValue` state. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>