### PR TITLE
Revert "[ENGG-2197] fix: RQ rule editor default state"

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js
@@ -22,6 +22,9 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
   const [requestTypePopupSelection, setRequestTypePopupSelection] = useState(
     pair?.request?.type ?? GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC
   );
+  const [editorStaticValue, setEditorStaticValue] = useState(
+    pair?.request?.type === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC && pair.request.value
+  );
 
   const codeFormattedFlag = useRef(null);
   const { getFeatureLimitValue } = useFeatureLimiter();
@@ -32,6 +35,8 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
         let value = "{}";
         if (requestType === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.CODE) {
           value = ruleDetails["REQUEST_BODY_JAVASCRIPT_DEFAULT_VALUE"];
+        } else if (requestType === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC) {
+          setEditorStaticValue(value);
         }
 
         dispatch(
@@ -69,6 +74,10 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
   }, [pair.request.type]);
 
   const requestBodyChangeHandler = (value) => {
+    if (pair.request.type === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC) {
+      setEditorStaticValue(value);
+    }
+
     dispatch(
       actions.updateRulePairAtGivenPath({
         pairIndex,
@@ -187,7 +196,11 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
                     : EditorLanguage.JSON
                 }
                 defaultValue={getEditorDefaultValue()}
-                value={pair.request.value}
+                value={
+                  pair.request.type === GLOBAL_CONSTANTS.REQUEST_BODY_TYPES.STATIC
+                    ? editorStaticValue
+                    : pair.request.value
+                }
                 handleChange={requestBodyChangeHandler}
                 isReadOnly={isInputDisabled}
                 analyticEventProperties={{ source: "rule_editor", rule_type: RuleType.REQUEST }}

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ResponseBodyRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ResponseBodyRow/index.js
@@ -38,6 +38,9 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
   const [responseTypePopupSelection, setResponseTypePopupSelection] = useState(
     pair?.response?.type ?? GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.STATIC
   );
+  const [editorStaticValue, setEditorStaticValue] = useState(
+    pair?.response?.type === GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.STATIC && pair.response.value
+  );
 
   const codeFormattedFlag = useRef(null);
   const { getFeatureLimitValue } = useFeatureLimiter();
@@ -50,8 +53,9 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
           value = ruleDetails["RESPONSE_BODY_JAVASCRIPT_DEFAULT_VALUE"];
         } else if (responseBodyType === GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.LOCAL_FILE) {
           value = "";
+        } else {
+          setEditorStaticValue(value);
         }
-
         dispatch(
           actions.updateRulePairAtGivenPath({
             pairIndex,
@@ -140,6 +144,10 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
   };
 
   const responseBodyChangeHandler = (value) => {
+    if (pair.response.type === GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.STATIC) {
+      setEditorStaticValue(value);
+    }
+
     dispatch(
       actions.updateRulePairAtGivenPath({
         pairIndex,
@@ -299,7 +307,11 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
                     : EditorLanguage.JSON
                 }
                 defaultValue={getEditorDefaultValue()}
-                value={pair.response.value}
+                value={
+                  pair.response.type === GLOBAL_CONSTANTS.RESPONSE_BODY_TYPES.STATIC
+                    ? editorStaticValue
+                    : pair.response.value
+                }
                 isReadOnly={isInputDisabled}
                 handleChange={responseBodyChangeHandler}
                 isResizable

--- a/app/src/componentsV2/CodeEditor/components/Editor/Editor.tsx
+++ b/app/src/componentsV2/CodeEditor/components/Editor/Editor.tsx
@@ -103,7 +103,8 @@ const Editor: React.FC<EditorProps> = ({
     } else {
       setEditorContent(value);
     }
-  }, [defaultValue, value]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultValue]);
 
   const handleEditorClose = useCallback(
     (id: string) => {


### PR DESCRIPTION
Reverts requestly/requestly#2114
 
 **PR Summary by Typo**
------------

 **Summary:**
1. Introduced state management for static request and response bodies.
2. Updated rendering of request and response body values based on their types.

**Key Points:**
- Added `editorStaticValue` state for managing static values of request and response bodies.
- Conditionally set `editorStaticValue` based on request/response type and value presence.
- Updated `RequestBodyRow` and `ResponseBodyRow` components to use `editorStaticValue`.

**Changes:**

**Request Body:**
1. Imported and added `useState` hook.
2. Declared `editorStaticValue` and `setEditorStaticValue` states.
3. Conditionally set `editorStaticValue` in `RequestBodyRow`.
4. Updated `value` assignment in `RequestBodyRow` to use `editorStaticValue`.

**Response Body:**
1. Imported `useState` and `useRef` hooks.
2. Declared `editorStaticValue` and `setEditorStaticValue` states.
3. Conditionally set `editorStaticValue` in `ResponseBodyRow`.
4. Updated `value` prop of editor component to use `editorStaticValue` in `ResponseBodyRow`.
5. Updated `Editor` component to set `editorContent` state only on `defaultValue` prop change.

**Categories:**
- State Management
- Conditional Rendering
- Component Updates
- Prop Updates
- Dependency Management 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>