### PR TITLE
fix: pricing page plan cards wrapping

### DIFF
--- a/app/src/features/pricing/components/PricingPage/pricingIndexPage.scss
+++ b/app/src/features/pricing/components/PricingPage/pricingIndexPage.scss
@@ -111,6 +111,7 @@
 
     .plan-card {
       flex: 1;
+      min-width: 300px;
     }
   }
 }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary:**
Added `min-width` property with a value of `300px` to the `.plan-card` class in the pricing page component for improved layout.

**Key Points:**
- Made change in `pricingIndexPage.scss` located in `app/src/features/pricing/components/PricingPage`.
- Affected `.plan-card` class styling.

**Categories:**
- **CSS:** Adjusted `min-width` property for `.plan-card` class.
- **Layout:** Modified pricing plan card layout.
- **PricingPage:** Updated Styling for Pricing Page component.
- **Styling:** Applied new CSS property to `.plan-card`.
- **plan-card:** Set `min-width` for specific pricing plan card class. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>