### PR TITLE
ENGG-2233: Fix editors back button behaviour

### DIFF
--- a/app/src/components/features/mocksV2/MockEditorIndex/MockEditorIndex.tsx
+++ b/app/src/components/features/mocksV2/MockEditorIndex/MockEditorIndex.tsx
@@ -147,9 +147,9 @@ const MockEditorIndex: React.FC<Props> = ({
             return;
           }
           if (mockType === MockType.FILE) {
-            return redirectToFileMockEditorEditMock(navigate, mockId);
+            return redirectToFileMockEditorEditMock(navigate, mockId, true);
           }
-          return redirectToMockEditorEditMock(navigate, mockId);
+          return redirectToMockEditorEditMock(navigate, mockId, true);
         }
         toast.error("Mock Create Error");
       });

--- a/app/src/utils/RedirectionUtils.js
+++ b/app/src/utils/RedirectionUtils.js
@@ -46,12 +46,13 @@ export const redirectToCreateRuleEditor = (navigate, rule) => {
 };
 
 /* FEATURE - RULES - Edit a Rule */
-export const redirectToRuleEditor = (navigate, ruleId, source, newTab = false) => {
+export const redirectToRuleEditor = (navigate, ruleId, source, newTab = false, popCurrentRouteFromHistory = false) => {
   if (newTab) {
     window.open(`${PATHS.RULE_EDITOR.EDIT_RULE.ABSOLUTE}/${ruleId}`, "_blank");
   } else {
     navigate(`${PATHS.RULE_EDITOR.EDIT_RULE.ABSOLUTE}/${ruleId}`, {
       state: { source },
+      replace: popCurrentRouteFromHistory,
     });
   }
 };
@@ -451,14 +452,14 @@ export const redirectToDownloadPage = () => {
   window.open(APP_CONSTANTS.LINKS.REQUESTLY_DOWNLOAD_PAGE, "_blank");
 };
 
-export const redirectToMockEditorEditMock = (navigate, mockId) => {
+export const redirectToMockEditorEditMock = (navigate, mockId, popCurrentRouteFromHistory = false) => {
   const mockEditUrl = `${PATHS.MOCK_SERVER_V2.EDIT.ABSOLUTE}`.replace(":mockId", mockId);
-  navigate(mockEditUrl);
+  navigate(mockEditUrl, { replace: popCurrentRouteFromHistory });
 };
 
-export const redirectToFileMockEditorEditMock = (navigate, mockId) => {
+export const redirectToFileMockEditorEditMock = (navigate, mockId, popCurrentRouteFromHistory = false) => {
   const mockEditUrl = `${PATHS.FILE_SERVER_V2.EDIT.ABSOLUTE}`.replace(":mockId", mockId);
-  navigate(mockEditUrl);
+  navigate(mockEditUrl, { replace: popCurrentRouteFromHistory });
 };
 
 export const redirectToMockEditorCreateMock = (navigate, newTab = false, collectionId = "") => {

--- a/app/src/utils/RedirectionUtils.js
+++ b/app/src/utils/RedirectionUtils.js
@@ -46,13 +46,28 @@ export const redirectToCreateRuleEditor = (navigate, rule) => {
 };
 
 /* FEATURE - RULES - Edit a Rule */
-export const redirectToRuleEditor = (navigate, ruleId, source, newTab = false, popCurrentRouteFromHistory = false) => {
+/**
+ * Redirects the user to the rule editor for a specific rule.
+ *
+ * @param {function} navigate - The navigation function from react-router.
+ * @param {string} ruleId - The ID of the rule to edit.
+ * @param {string} source - The source of the navigation (for analytics or state management).
+ * @param {boolean} [newTab=false] - If true, opens the rule editor in a new tab.
+ * @param {boolean} [replaceCurrentRouteInHistory=false] - If true, replaces the current route in history instead of adding a new one.
+ */
+export const redirectToRuleEditor = (
+  navigate,
+  ruleId,
+  source,
+  newTab = false,
+  replaceCurrentRouteInHistory = false
+) => {
   if (newTab) {
     window.open(`${PATHS.RULE_EDITOR.EDIT_RULE.ABSOLUTE}/${ruleId}`, "_blank");
   } else {
     navigate(`${PATHS.RULE_EDITOR.EDIT_RULE.ABSOLUTE}/${ruleId}`, {
       state: { source },
-      replace: popCurrentRouteFromHistory,
+      replace: replaceCurrentRouteInHistory,
     });
   }
 };
@@ -452,14 +467,28 @@ export const redirectToDownloadPage = () => {
   window.open(APP_CONSTANTS.LINKS.REQUESTLY_DOWNLOAD_PAGE, "_blank");
 };
 
-export const redirectToMockEditorEditMock = (navigate, mockId, popCurrentRouteFromHistory = false) => {
+/**
+ * Redirects to the mock editor for editing an existing mock.
+ *
+ * @param {function} navigate - The navigation function from react-router.
+ * @param {string} mockId - The ID of the mock to edit.
+ * @param {boolean} [replaceCurrentRouteInHistory=false] - If true, replaces the current route in history instead of adding a new one.
+ */
+export const redirectToMockEditorEditMock = (navigate, mockId, replaceCurrentRouteInHistory = false) => {
   const mockEditUrl = `${PATHS.MOCK_SERVER_V2.EDIT.ABSOLUTE}`.replace(":mockId", mockId);
-  navigate(mockEditUrl, { replace: popCurrentRouteFromHistory });
+  navigate(mockEditUrl, { replace: replaceCurrentRouteInHistory });
 };
 
-export const redirectToFileMockEditorEditMock = (navigate, mockId, popCurrentRouteFromHistory = false) => {
+/**
+ * Redirects to the file mock editor for editing an existing file mock.
+ *
+ * @param {function} navigate - The navigation function from react-router.
+ * @param {string} mockId - The ID of the file mock to edit.
+ * @param {boolean} [replaceCurrentRouteInHistory=false] - If true, replaces the current route in history instead of adding a new one.
+ */
+export const redirectToFileMockEditorEditMock = (navigate, mockId, replaceCurrentRouteInHistory = false) => {
   const mockEditUrl = `${PATHS.FILE_SERVER_V2.EDIT.ABSOLUTE}`.replace(":mockId", mockId);
-  navigate(mockEditUrl, { replace: popCurrentRouteFromHistory });
+  navigate(mockEditUrl, { replace: replaceCurrentRouteInHistory });
 };
 
 export const redirectToMockEditorCreateMock = (navigate, newTab = false, collectionId = "") => {

--- a/app/src/views/features/rules/RuleEditor/components/Header/ActionButtons/CreateRuleButton/index.jsx
+++ b/app/src/views/features/rules/RuleEditor/components/Header/ActionButtons/CreateRuleButton/index.jsx
@@ -324,7 +324,7 @@ const CreateRuleButton = ({
         .then(() => {
           if (!isRuleEditorModal && MODE === APP_CONSTANTS.RULE_EDITOR_CONFIG.MODES.CREATE) {
             dispatch(actions.updateSecondarySidebarCollapse(true));
-            redirectToRuleEditor(navigate, finalRuleData.id, MODE);
+            redirectToRuleEditor(navigate, finalRuleData.id, MODE, false, true);
           }
         })
         .catch(() => {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary:**
This pull request introduces a new boolean parameter `popCurrentRouteFromHistory` to several navigation functions in `ReductionUtils.js`, updates their implementation to use this parameter, and adds it to the calls to these functions in `MockEditorIndex.tsx`. Additionally, the `CreateRuleButton` component's redirect function now accepts two new parameters.

**Navigation Function Changes:**
- Added a new boolean parameter `popCurrentRouteFromHistory` to the functions `redirectToRuleEditor`, `redirectToMockEditorEditMock`, and `redirectToFileMockEditorEditMock` in `ReductionUtils.js`.
- Updated the implementation of these functions to include the new parameter and use it to replace the current route in the navigation history.

**CreateRuleButton Component Changes:**
- The redirect function in `CreateRuleButton` now accepts five arguments: navigate, finalRuleData.id, MODE, isRuleEditorModal, and isCreateRule.
- Added two new parameters, isRuleEditorModal and isCreateRule, to the redirect function call.
- The new parameters are currently set to false and true, respectively.

**Impact:**
- The new navigation behavior can be controlled in the `MockEditorIndex` component.
- The impact and usage of the new parameters in the `CreateRuleButton` component are unclear from the provided context. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>