### PR TITLE
[ENGG-2206] fix: make sharedlist first option in share modal

### DIFF
--- a/app/src/components/common/SharingModal/index.tsx
+++ b/app/src/components/common/SharingModal/index.tsx
@@ -30,23 +30,10 @@ export const SharingModal: React.FC<ModalProps> = ({
   callback = () => {},
 }) => {
   const availableTeams = useSelector(getAvailableTeams);
-  const [activeTab, setActiveTab] = useState(SharingOptions.WORKSPACE);
+  const [activeTab, setActiveTab] = useState(SharingOptions.SHARE_LINK);
 
   const sharingOptions: TabsProps["items"] = useMemo(
     () => [
-      {
-        key: SharingOptions.WORKSPACE,
-        label: "Share in workspace",
-        children: (
-          <>
-            {selectedRules?.length ? (
-              <ShareInWorkspaces selectedRules={selectedRules} toggleModal={toggleModal} onRulesShared={callback} />
-            ) : (
-              <EmptySelectionView />
-            )}
-          </>
-        ),
-      },
       {
         key: SharingOptions.SHARE_LINK,
         label: "Shared list",
@@ -54,6 +41,19 @@ export const SharingModal: React.FC<ModalProps> = ({
           <>
             {selectedRules?.length ? (
               <ShareLinkView selectedRules={selectedRules} source={source} onSharedLinkCreated={callback} />
+            ) : (
+              <EmptySelectionView />
+            )}
+          </>
+        ),
+      },
+      {
+        key: SharingOptions.WORKSPACE,
+        label: "Share in workspace",
+        children: (
+          <>
+            {selectedRules?.length ? (
+              <ShareInWorkspaces selectedRules={selectedRules} toggleModal={toggleModal} onRulesShared={callback} />
             ) : (
               <EmptySelectionView />
             )}


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary:**
This pull request modifies the SharingModal component, changing the active tab to "Shared list" and rendering corresponding components accordingly: ShareLinkView for "Shared list" tab and ShareInWorkspaces for "Share in workspace" tab.

**Key Points:**

1. Active tab changed from "Share in workspace" to "Shared list".
2. ShareInWorkspaces rendered for "Share in workspace" tab.
3. ShareLinkView rendered for "Shared list" tab. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>