### PR TITLE
fix: remove unwanted 'allRules' from useEffect dependency array

### DIFF
--- a/app/src/views/features/rules/RuleEditor/components/Header/ActionButtons/Status/index.js
+++ b/app/src/views/features/rules/RuleEditor/components/Header/ActionButtons/Status/index.js
@@ -6,7 +6,6 @@ import {
 } from "../../../../../../../../components/features/rules/RuleBuilder/actions";
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
 import { getAppMode, getCurrentlySelectedRuleData, getUserAuthDetails } from "../../../../../../../../store/selectors";
-import { getAllRules } from "store/features/rules/selectors";
 import { Switch, Tooltip } from "antd";
 import { toast } from "utils/Toast.js";
 import { trackRuleEditorHeaderClicked } from "modules/analytics/events/common/rules";
@@ -25,7 +24,6 @@ const Status = ({ isDisabled = false, isRuleEditorModal, isSampleRule = false, s
   const location = useLocation();
   const dispatch = useDispatch();
   const currentlySelectedRuleData = useSelector(getCurrentlySelectedRuleData);
-  const allRules = useSelector(getAllRules);
   const user = useSelector(getUserAuthDetails);
   const appMode = useSelector(getAppMode);
 
@@ -104,7 +102,7 @@ const Status = ({ isDisabled = false, isRuleEditorModal, isSampleRule = false, s
         stableChangeRuleStatus(GLOBAL_CONSTANTS.RULE_STATUS.ACTIVE);
       }
     }
-  }, [allRules, stableChangeRuleStatus, user, location.pathname, hasUserTriedToChangeRuleStatus]);
+  }, [stableChangeRuleStatus, user, location.pathname, hasUserTriedToChangeRuleStatus]);
 
   const isChecked = isRuleCurrentlyActive();
 

--- a/app/src/views/features/rules/RuleEditor/components/Header/ActionButtons/actions/index.js
+++ b/app/src/views/features/rules/RuleEditor/components/Header/ActionButtons/actions/index.js
@@ -1,10 +1,8 @@
-//UTILS
-import { redirectToRules } from "../../../../../../../../utils/RedirectionUtils";
 //EXTERNALS
 import { StorageService } from "../../../../../../../../init";
 import { generateObjectCreationDate } from "utils/DateTimeUtils";
-import { trackErrorInRuleCreation, trackRuleEditorClosed } from "modules/analytics/events/common/rules";
-import { cloneDeep, snakeCase } from "lodash";
+import { trackErrorInRuleCreation } from "modules/analytics/events/common/rules";
+import { cloneDeep } from "lodash";
 import Logger from "lib/logger";
 import * as Sentry from "@sentry/react";
 import { detectUnsettledPromise } from "utils/FunctionUtils";


### PR DESCRIPTION
removed `allRules` from `useEffect` dependency array. it was causing infinite rerenders in case of insert script rule.