### PR TITLE
chore: show alert when trying to save too many network logs

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/ActionHeader.jsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/ActionHeader.jsx
@@ -176,14 +176,15 @@ const ActionHeader = ({
   const showFilterLogsAlert = (logsToSave, src) => {
     trackSavingTooManyLogsAlertShown(logsToSave.log.entries.length ?? undefined, src);
     Modal.error({
-      title: "Too many logs",
+      title: "Log Limit Exceeded",
       content: (
         <Typography>
-          Trying to save these many logs might lead to unexpected behavior.
+          Saving this many logs may lead to unexpected app behaviour.
           <br />
-          Please use filters/search to select specific logs that need to be saved.
+          Please use filters or search to select specific logs for saving.
         </Typography>
       ),
+      width: 520,
     });
   };
 

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/ActionHeader.jsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/ActionHeader.jsx
@@ -39,9 +39,9 @@ import { useDebounce } from "hooks/useDebounce";
 
 const { Text } = Typography;
 
-const canSaveLogsWithoutCrashing = (logsToSaveAsHar) => {
+const canSaveLogsWithoutCrashing = (logsCount) => {
   const MAX_ENTRIES = 1500; // ESTIMATE
-  return logsToSaveAsHar.log.entries.length <= MAX_ENTRIES;
+  return logsCount <= MAX_ENTRIES;
 };
 
 const ActionHeader = ({
@@ -173,8 +173,8 @@ const ActionHeader = ({
     trackRQDesktopLastActivity(TRAFFIC_TABLE.TRAFFIC_TABLE_FILTER_CLICKED);
   };
 
-  const showFilterLogsAlert = (logsToSave, src) => {
-    trackSavingTooManyLogsAlertShown(logsToSave.log.entries.length ?? undefined, src);
+  const showExcessLogsAlert = (logsCount, src) => {
+    trackSavingTooManyLogsAlertShown(logsCount, src);
     Modal.error({
       title: "Log Limit Exceeded",
       content: (
@@ -288,10 +288,10 @@ const ActionHeader = ({
                   icon={<DownloadOutlined />}
                   disabled={!filteredLogsCount}
                   onClick={() => {
-                    if (canSaveLogsWithoutCrashing(logsToSaveAsHar)) {
+                    if (canSaveLogsWithoutCrashing(filteredLogsCount)) {
                       downloadHar(logsToSaveAsHar || {}, "");
                     } else {
-                      showFilterLogsAlert(logsToSaveAsHar, "export-har");
+                      showExcessLogsAlert(filteredLogsCount, "export-har");
                     }
                     trackDownloadNetworkSessionClicked(ActionSource.TrafficTable);
                     trackRQDesktopLastActivity(SESSION_RECORDING.network.download);
@@ -312,10 +312,10 @@ const ActionHeader = ({
                     onClick={() => {
                       trackNetworkSessionSaveClicked();
                       trackRQDesktopLastActivity(SESSION_RECORDING.network.save.btn_clicked);
-                      if (canSaveLogsWithoutCrashing(logsToSaveAsHar)) {
+                      if (canSaveLogsWithoutCrashing(filteredLogsCount)) {
                         openSaveModal();
                       } else {
-                        showFilterLogsAlert(logsToSaveAsHar, "save-har");
+                        showExcessLogsAlert(filteredLogsCount, "save-har");
                       }
                     }}
                   >

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/ActionHeader.jsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/ActionHeader.jsx
@@ -40,7 +40,7 @@ import { useDebounce } from "hooks/useDebounce";
 const { Text } = Typography;
 
 const canSaveLogsWithoutCrashing = (logsToSaveAsHar) => {
-  const MAX_ENTRIES = 150; // ESTIMATE
+  const MAX_ENTRIES = 1500; // ESTIMATE
   return logsToSaveAsHar.log.entries.length <= MAX_ENTRIES;
 };
 

--- a/app/src/modules/analytics/events/desktopApp/constants.js
+++ b/app/src/modules/analytics/events/desktopApp/constants.js
@@ -35,4 +35,5 @@ export const TRAFFIC_TABLE = {
   TRAFFIC_TABLE_SEARCHED: "traffic_table_searched",
   TRAFFIC_TABLE_FILTER_CLICKED: "traffic_table_filter_clicked",
   TRAFFIC_TABLE_FILTER_APPLIED: "traffic_table_filter_clicked",
+  TRAFFIC_TABLE_SAVING_EXCESS_LOGS_ALERT_SHOWN: "traffic_table_saving_excess_logs_alert_shown",
 };

--- a/app/src/modules/analytics/events/desktopApp/index.js
+++ b/app/src/modules/analytics/events/desktopApp/index.js
@@ -97,3 +97,8 @@ export const trackTrafficTableFilterApplied = (filter_type, filter_value, count)
   };
   trackEvent(TRAFFIC_TABLE.TRAFFIC_TABLE_FILTER_APPLIED, params);
 };
+
+export const trackSavingTooManyLogsAlertShown = (logsCount, src) => {
+  const params = { logsCount, src };
+  trackEvent(TRAFFIC_TABLE.TRAFFIC_TABLE_SAVING_EXCESS_LOGS_ALERT_SHOWN, params);
+};


### PR DESCRIPTION
since we can't know for sure because 
1. it is more about the size of the logs, rather than the number of entries
2. the threshold might be different for machines with different specifications

starting with a tested estimate of 1500 logs. will change later if required

![Screenshot 2024-10-04 at 9 41 40 AM](https://github.com/user-attachments/assets/db8e38b8-ff0f-4d64-838f-586fe0ad1285)

