### PR TITLE
chore: bump version of requestly-core to v1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/requestly-core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/requestly-core",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "eslint": "^8.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/requestly-core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Requestly app, extension and other components ",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
for some reason v1.0.4 was already published on npm even though the changes were not visible in code