### PR TITLE
fix: android emulator device description was overflowing grid

### DIFF
--- a/app/src/components/mode-specific/desktop/MySources/Sources/index.css
+++ b/app/src/components/mode-specific/desktop/MySources/Sources/index.css
@@ -34,7 +34,7 @@
   padding: 11px 16px;
   width: 100%;
   display: grid;
-  grid-template-columns: 1fr 1fr 0.5fr;
+  grid-template-columns: 1fr auto 0.5fr;
   align-items: center;
   border: 1px solid var(--border-dark);
   border-radius: var(--border-radius-sm);
@@ -50,6 +50,7 @@
 }
 .connected-apps-modal .source-grid .source-item .source-description {
   padding-left: 10px;
+  word-break: break-word;
 }
 .connected-apps-modal .source-grid .source-item .danger-btn,
 .connected-apps-modal .rq-modal-footer .danger-btn {

--- a/app/src/components/mode-specific/desktop/MySources/Sources/index.js
+++ b/app/src/components/mode-specific/desktop/MySources/Sources/index.js
@@ -77,7 +77,7 @@ const Sources = ({ isOpen, toggle, ...props }) => {
         const updatedAppsList = { ...desktopSpecificDetails.appsList };
         devices.forEach((device) => {
           if (!desktopSpecificDetails.appsList[device.id]) {
-            console.log("Adding Device", device.id);
+            console.log("Adding Device", device);
             updatedAppsList[device.id] = {
               id: "android-adb",
               type: "mobile",


### PR DESCRIPTION
before
![screenshot_2024-10-11_at_12 01 15___pm](https://github.com/user-attachments/assets/c0c485d2-6549-42a0-9b81-5d5cceb6ae18)

after
![Screenshot 2024-10-14 at 3 45 40 PM](https://github.com/user-attachments/assets/710de200-6853-44c4-a19e-3dc84fb5d281)
