### PR TITLE
fix: add threshold to sources grid growth adjustments

### DIFF
--- a/app/src/components/mode-specific/desktop/MySources/Sources/index.css
+++ b/app/src/components/mode-specific/desktop/MySources/Sources/index.css
@@ -34,7 +34,7 @@
   padding: 11px 16px;
   width: 100%;
   display: grid;
-  grid-template-columns: 1fr auto 0.5fr;
+  grid-template-columns: 1fr minmax(auto, 1fr) 0.5fr;
   align-items: center;
   border: 1px solid var(--border-dark);
   border-radius: var(--border-radius-sm);


### PR DESCRIPTION
https://github.com/requestly/requestly/pull/2237 broke the other tiles so adding a `minmax` to avoid uneven growth of grid columns