### PR TITLE
fix: API client request URL prefix

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/clientView/APIClientView.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/APIClientView.tsx
@@ -189,18 +189,6 @@ const APIClientView: React.FC<Props> = ({ apiEntry, apiEntryDetails, notifyApiRe
     });
   }, []);
 
-  const onUrlInputBlur = useCallback(
-    (text: string) => {
-      if (text) {
-        const urlWithUrlScheme = addUrlSchemeIfMissing(text);
-        if (urlWithUrlScheme !== text) {
-          setUrl(urlWithUrlScheme);
-        }
-      }
-    },
-    [setUrl]
-  );
-
   const sanitizeEntry = (entry: RQAPI.Entry) => {
     const sanitizedEntry: RQAPI.Entry = {
       ...entry,
@@ -243,6 +231,8 @@ const APIClientView: React.FC<Props> = ({ apiEntry, apiEntryDetails, notifyApiRe
     sanitizedEntry.response = null;
 
     const renderedRequest = renderVariables<RQAPI.Request>(sanitizedEntry.request);
+    renderedRequest.url = addUrlSchemeIfMissing(renderedRequest.url);
+
     const renderedEntry = { ...sanitizedEntry, request: renderedRequest };
 
     abortControllerRef.current = new AbortController();
@@ -399,7 +389,6 @@ const APIClientView: React.FC<Props> = ({ apiEntry, apiEntryDetails, notifyApiRe
               defaultValue={entry.request.url}
               onChange={(text) => setUrl(text)}
               onPressEnter={onUrlInputEnterPressed}
-              onBlur={onUrlInputBlur}
               variables={currentEnvironmentVariables}
               // prefix={<Favicon size="small" url={entry.request.url} debounceWait={500} style={{ marginRight: 2 }} />}
             />

--- a/app/src/features/apiClient/screens/apiClient/utils.ts
+++ b/app/src/features/apiClient/screens/apiClient/utils.ts
@@ -37,7 +37,7 @@ export const makeRequest = async (
 // TODO: move this into top level common folder
 export const addUrlSchemeIfMissing = (url: string): string => {
   if (url && !/^([a-z][a-z0-9+\-.]*):\/\//.test(url)) {
-    return "https://" + url;
+    return "http://" + url;
   }
 
   return url;


### PR DESCRIPTION
Removed auto addition of https:// prefix on input blur and instead adding this if the prefix is not present after resolving the variables in the request URL