### PR TITLE
feat: set existing-terminal as active when receiving event from background

### DIFF
--- a/app/src/hooks/AppModeInitializer.js
+++ b/app/src/hooks/AppModeInitializer.js
@@ -186,6 +186,16 @@ const AppModeInitializer = () => {
               trackDesktopBGEvent(payload?.name, payload?.params);
             }
           });
+          window.RQ.DESKTOP.SERVICES.IPC.registerEvent("helper-server-hit", () => {
+            dispatch(
+              actions.updateDesktopSpecificAppProperty({
+                appId: "existing-terminal",
+                property: "isActive",
+                value: true,
+              })
+            );
+            trackDesktopBGEvent("helper-server-hit");
+          });
         });
       }
     }

--- a/app/src/modules/analytics/events/desktopApp/backgroundEvents.ts
+++ b/app/src/modules/analytics/events/desktopApp/backgroundEvents.ts
@@ -6,6 +6,6 @@ export function trackDesktopMainEvent(name: string, param: Record<any, any> = {}
 }
 
 export function trackDesktopBGEvent(name: string, param: Record<any, any> = {}) {
-  param["source"] = "desktop_main";
+  param["source"] = "background_renderer";
   trackEvent(name, param);
 }


### PR DESCRIPTION
UI to set the `active` state for `existing-terminal` based on the event from [these changes](https://github.com/requestly/requestly-desktop-app/pull/118)