### PR TITLE
[ENGG-2413]Persist filters in traffic table

### DIFF
--- a/app/src/store/index.js
+++ b/app/src/store/index.js
@@ -59,13 +59,17 @@ const globalReducer = getReducerWithLocalStorageSync("root", globalSlice.reducer
   "rules.isSampleRulesImported",
 ]);
 
+const persistedDesktopReducer = getReducerWithLocalStorageSync("desktopTrafficTable", desktopTrafficTableReducer, [
+  "filters",
+]);
+
 export const reduxStore = configureStore({
   reducer: {
     [ReducerKeys.GLOBAL]: globalReducer,
     [ReducerKeys.SESSION_RECORDING]: sessionRecordingReducer,
     [ReducerKeys.HAR_PREVIEW]: harPreviewReducer,
     [ReducerKeys.TEAMS]: teamsReducer,
-    [ReducerKeys.DESKTOP_TRAFFIC_TABLE]: desktopTrafficTableReducer,
+    [ReducerKeys.DESKTOP_TRAFFIC_TABLE]: persistedDesktopReducer,
     [ReducerKeys.RULES]: recordsReducer, // SLICE ALSO CONTAINS GROUP RECORDS
     [ReducerKeys.BILLING]: billingReducer,
     [ReducerKeys.INCENTIVIZATION]: incentivizationReducer,


### PR DESCRIPTION
- Filters added to the top filters in desktop app will be persisted after closing and reopening of the application
- Search bar will also persist the searched query