### PR TITLE
[ENGG-2443] fix: new environment variable route

### DIFF
--- a/app/src/features/apiClient/routes.tsx
+++ b/app/src/features/apiClient/routes.tsx
@@ -62,10 +62,6 @@ export const apiClientRoutes: RouteObject[] = [
             path: PATHS.API_CLIENT.ENVIRONMENTS.RELATIVE + "/:envId",
             element: <EnvironmentView />,
           },
-          {
-            path: PATHS.API_CLIENT.ENVIRONMENTS.NEW.RELATIVE,
-            element: <EnvironmentView />,
-          },
         ],
       },
     ],


### PR DESCRIPTION
Changes: 
- No need to handle `/new` env route as this will get handled in `/:envId` route