### PR TITLE
[ENGG-2511] Fix: Pre-script & post response UI precedence

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/Scripts/components/ScriptEditor/ScriptEditor.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/Scripts/components/ScriptEditor/ScriptEditor.tsx
@@ -17,13 +17,13 @@ const DEFAULT_SCRIPT_VALUES = {
 };
 
 export const ScriptEditor: React.FC<ScriptEditorProps> = ({ scripts, setScripts }) => {
-  const ActiveScript = scripts?.[RQAPI.ScriptType.PRE_REQUEST]
+  const activeScriptType = scripts?.[RQAPI.ScriptType.PRE_REQUEST]
     ? RQAPI.ScriptType.PRE_REQUEST
     : scripts?.[RQAPI.ScriptType.POST_RESPONSE]
     ? RQAPI.ScriptType.POST_RESPONSE
     : RQAPI.ScriptType.PRE_REQUEST;
 
-  const [scriptType, setScriptType] = useState<RQAPI.ScriptType>(ActiveScript);
+  const [scriptType, setScriptType] = useState<RQAPI.ScriptType>(activeScriptType);
 
   const scriptTypeOptions = useMemo(() => {
     return (

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/Scripts/components/ScriptEditor/ScriptEditor.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/Scripts/components/ScriptEditor/ScriptEditor.tsx
@@ -17,7 +17,13 @@ const DEFAULT_SCRIPT_VALUES = {
 };
 
 export const ScriptEditor: React.FC<ScriptEditorProps> = ({ scripts, setScripts }) => {
-  const [scriptType, setScriptType] = useState<RQAPI.ScriptType>(RQAPI.ScriptType.PRE_REQUEST);
+  const ActiveScript = scripts?.[RQAPI.ScriptType.PRE_REQUEST]
+    ? RQAPI.ScriptType.PRE_REQUEST
+    : scripts?.[RQAPI.ScriptType.POST_RESPONSE]
+    ? RQAPI.ScriptType.POST_RESPONSE
+    : RQAPI.ScriptType.PRE_REQUEST;
+
+  const [scriptType, setScriptType] = useState<RQAPI.ScriptType>(ActiveScript);
 
   const scriptTypeOptions = useMemo(() => {
     return (


### PR DESCRIPTION
- If the post-response script is defined, select that by default
- If both are defined, select Pre-Request
