### PR TITLE
Added support to hold different content types in body

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/RequestTabs.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/RequestTabs.tsx
@@ -77,8 +77,18 @@ const RequestTabs: React.FC<Props> = ({
         label: (
           <LabelWithCount label="Body" count={requestEntry.request.body ? 1 : 0} showDot={isRequestBodySupported} />
         ),
-        children: (
+        children: requestEntry.request.bodyContainer ? (
           <RequestBody
+            mode="multiple"
+            bodyContainer={requestEntry.request.bodyContainer}
+            contentType={requestEntry.request.contentType}
+            setRequestEntry={setRequestEntry}
+            setContentType={setContentType}
+            variables={variables}
+          />
+        ) : (
+          <RequestBody
+            mode="single"
             body={requestEntry.request.body}
             contentType={requestEntry.request.contentType}
             setRequestEntry={setRequestEntry}

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/form-body-renderer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/form-body-renderer.tsx
@@ -1,0 +1,43 @@
+import { EnvironmentVariables } from "backend/environment/types";
+import { KeyValueFormType, KeyValuePair, RQAPI } from "features/apiClient/types";
+import { useCallback, useContext } from "react";
+import { RequestBodyContext, useFormBody } from "../request-body-state-manager";
+import { RequestBodyProps } from "../request-body-types";
+import { KeyValueTable } from "../components/KeyValueTable/KeyValueTable";
+
+export function FormBody(props: {
+  environmentVariables: EnvironmentVariables;
+  setRequestEntry: RequestBodyProps["setRequestEntry"];
+}) {
+  const { environmentVariables, setRequestEntry } = props;
+
+  const { requestBodyStateManager } = useContext(RequestBodyContext);
+  const { formBody, setFormBody } = useFormBody(requestBodyStateManager);
+
+  const handleFormChange = useCallback(
+    (updaterFn: (prev: RQAPI.Entry) => RQAPI.Entry) => {
+      setRequestEntry((prev) => {
+        const updatedEntry = updaterFn(prev);
+        setFormBody(updatedEntry.request.body as KeyValuePair[]);
+        return {
+          ...prev,
+          request: {
+            ...prev.request,
+            body: updatedEntry.request.body,
+            bodyContainer: requestBodyStateManager.serialize(),
+          },
+        };
+      });
+    },
+    [setRequestEntry, setFormBody, requestBodyStateManager]
+  );
+
+  return (
+    <KeyValueTable
+      pairType={KeyValueFormType.FORM}
+      data={formBody}
+      setKeyValuePairs={handleFormChange}
+      variables={environmentVariables}
+    />
+  );
+}

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/json-body-renderer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/json-body-renderer.tsx
@@ -1,0 +1,46 @@
+import { useCallback, useContext } from "react";
+import CodeEditor, { EditorLanguage } from "componentsV2/CodeEditor";
+import { EnvironmentVariables } from "backend/environment/types";
+import { useDebounce } from "hooks/useDebounce";
+import { RequestBodyContext, useTextBody } from "../request-body-state-manager";
+import { RequestBodyProps } from "../request-body-types";
+
+export function JsonBody(props: {
+  environmentVariables: EnvironmentVariables;
+  setRequestEntry: RequestBodyProps["setRequestEntry"];
+}) {
+  const { environmentVariables, setRequestEntry } = props;
+
+  const { requestBodyStateManager } = useContext(RequestBodyContext);
+  const { text, setText } = useTextBody(requestBodyStateManager);
+
+  const handleTextChange = useDebounce(
+    useCallback(
+      (value: string) => {
+        setText(value);
+        setRequestEntry((prev) => ({
+          ...prev,
+          request: { ...prev.request, body: value, bodyContainer: requestBodyStateManager.serialize() },
+        }));
+      },
+      [setRequestEntry, setText, requestBodyStateManager]
+    ),
+    500,
+    { leading: true, trailing: true }
+  );
+
+  return (
+    <CodeEditor
+      key={"json_body"}
+      language={EditorLanguage.JSON}
+      defaultValue={text}
+      value={text}
+      handleChange={handleTextChange}
+      prettifyOnInit={true}
+      isResizable={false}
+      hideCharacterCount
+      analyticEventProperties={{ source: "api_client" }}
+      envVariables={environmentVariables}
+    />
+  );
+}

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/raw-body-renderer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/raw-body-renderer.tsx
@@ -1,0 +1,48 @@
+import { useCallback, useContext } from "react";
+import CodeEditor from "componentsV2/CodeEditor";
+import { EnvironmentVariables } from "backend/environment/types";
+import { useDebounce } from "hooks/useDebounce";
+import { RequestBodyContext, useTextBody } from "../request-body-state-manager";
+import { RequestBodyProps } from "../request-body-types";
+
+export function RawBody(props: {
+  environmentVariables: EnvironmentVariables;
+  setRequestEntry: RequestBodyProps["setRequestEntry"];
+}) {
+  const { environmentVariables, setRequestEntry } = props;
+
+  const { requestBodyStateManager } = useContext(RequestBodyContext);
+  const { text, setText } = useTextBody(requestBodyStateManager);
+
+  const handleTextChange = useDebounce(
+    useCallback(
+      (value: string) => {
+        setText(value);
+        setRequestEntry((prev) => ({
+          ...prev,
+          request: { ...prev.request, body: value, bodyContainer: requestBodyStateManager.serialize() },
+        }));
+      },
+      [setRequestEntry, setText, requestBodyStateManager]
+    ),
+    500,
+    { leading: true, trailing: true }
+  );
+
+  return (
+    <CodeEditor
+      key={"raw_body"}
+      language={null}
+      defaultValue={text}
+      value={text}
+      handleChange={handleTextChange}
+      isResizable={false}
+      hideCharacterCount
+      analyticEventProperties={{ source: "api_client" }}
+      envVariables={environmentVariables}
+      config={{
+        enablePrettify: false,
+      }}
+    />
+  );
+}

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/request-body-state-manager.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/request-body-state-manager.ts
@@ -1,0 +1,75 @@
+import { createContext, useState } from "react";
+
+import { KeyValuePair } from "features/apiClient/types";
+import { RQAPI } from "../../../../../../types";
+
+/**
+ * This class maintains body state for different content types.
+ */
+export class RequestBodyStateManager {
+  private text: string;
+  private form: KeyValuePair[];
+
+  constructor(params: RQAPI.RequestBodyContainer) {
+    // defaults are set since some databases like firestore don't handle "undefined"
+    this.text = params.text || "";
+    this.form = params.form || [];
+  }
+
+  setText(text: string) {
+    this.text = text;
+  }
+
+  setForm(form: KeyValuePair[]) {
+    this.form = form;
+  }
+
+  getText() {
+    return this.text;
+  }
+
+  getForm() {
+    return this.form;
+  }
+
+  serialize(): RQAPI.RequestBodyContainer {
+    return {
+      text: this.text,
+      form: this.form,
+    };
+  }
+}
+
+/**
+ * This is a utility hook which enables syncing react state and 'RequestBodyStateManager'
+ */
+export function useFormBody(requestBodyStateManager: RequestBodyStateManager) {
+  const [formBody, _setFormBody] = useState<RQAPI.RequestFormBody>(requestBodyStateManager.getForm() || []);
+  return {
+    formBody,
+    setFormBody(form: RQAPI.RequestFormBody) {
+      requestBodyStateManager.setForm(form);
+      _setFormBody(form);
+    },
+  };
+}
+
+/**
+ * This is a utility hook which enables syncing react state and 'RequestBodyStateManager'
+ */
+export function useTextBody(requestBodyStateManager: RequestBodyStateManager) {
+  const [text, _setText] = useState<string>(requestBodyStateManager.getText());
+  return {
+    text,
+    setText(text: string) {
+      requestBodyStateManager.setText(text);
+      _setText(text);
+    },
+  };
+}
+
+export const RequestBodyContext = createContext<{
+  requestBodyStateManager: RequestBodyStateManager;
+}>({
+  requestBodyStateManager: new RequestBodyStateManager({}),
+});

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/request-body-types.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/request-body-types.ts
@@ -1,0 +1,21 @@
+import { EnvironmentVariables } from "backend/environment/types";
+import { RQAPI, RequestContentType } from "../../../../../../types";
+
+export type RequestBodyProps = {
+  contentType: RequestContentType;
+  variables: EnvironmentVariables;
+  setRequestEntry: (updaterFn: (prev: RQAPI.Entry) => RQAPI.Entry) => void;
+  setContentType: (contentType: RequestContentType) => void;
+} & /**
+ * We maintain two modes now, single and multiple. In single mode the body can hold
+ * just one kind of data. In multiple, it holds all kinds simultaenously.
+ */ (
+  | {
+      mode: "single";
+      body: RQAPI.RequestBody;
+    }
+  | {
+      mode: "multiple";
+      bodyContainer: RQAPI.RequestBodyContainer;
+    }
+);

--- a/app/src/features/apiClient/types.ts
+++ b/app/src/features/apiClient/types.ts
@@ -58,7 +58,15 @@ export namespace RQAPI {
     POST_RESPONSE = "postResponse",
   }
 
-  export type RequestBody = string | KeyValuePair[]; // in case of form data, body will be key-value pairs
+  export type RequestBody = RequestJsonBody | RequestRawBody | RequestFormBody; // in case of form data, body will be key-value pairs
+  export type RequestJsonBody = string;
+  export type RequestRawBody = string;
+  export type RequestFormBody = KeyValuePair[];
+
+  export type RequestBodyContainer = {
+    text?: string;
+    form?: KeyValuePair[];
+  };
 
   export type AuthOptions<T extends AUTHORIZATION_TYPES = AUTHORIZATION_TYPES> = {
     currentAuthType: T;
@@ -71,6 +79,7 @@ export namespace RQAPI {
     method: RequestMethod;
     headers: KeyValuePair[];
     body?: RequestBody;
+    bodyContainer?: RequestBodyContainer;
     contentType?: RequestContentType;
   }
 


### PR DESCRIPTION
This is a refactor of types, component structure, and capability. We are moving away from `RequestBody` and embracing `RequestBodyContainer` which lets use hold data for different content types.