### PR TITLE
[ENGG-2800]: Refactor KeyValueTable component

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -158,7 +158,7 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({ data, variables, o
       rowKey="id"
       columns={columns as ColumnTypes}
       data={memoizedData}
-      locale={{ emptyText: `No query params found` }}
+      locale={{ emptyText: `No entries found` }}
       components={{
         body: {
           row: EditableRow,

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/KeyValueTable/KeyValueTableRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/KeyValueTable/KeyValueTableRow.tsx
@@ -1,8 +1,6 @@
 import React, { useContext } from "react";
 import { Checkbox, Form, FormInstance } from "antd";
-import { KeyValueFormType, KeyValuePair } from "features/apiClient/types";
-import { trackEnableKeyValueToggled } from "modules/analytics/events/features/apiClient";
-import Logger from "lib/logger";
+import { KeyValuePair } from "features/apiClient/types";
 import { RQSingleLineEditor } from "features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor";
 import { EnvironmentVariables } from "backend/environment/types";
 
@@ -28,7 +26,6 @@ interface EditableCellProps {
   editable: boolean;
   dataIndex: keyof KeyValuePair;
   record: KeyValuePair;
-  pairtype: KeyValueFormType;
   variables: EnvironmentVariables;
   handleUpdatePair: (record: KeyValuePair) => void;
 }
@@ -39,7 +36,6 @@ export const EditableCell: React.FC<React.PropsWithChildren<EditableCellProps>> 
   children,
   dataIndex,
   record,
-  pairtype,
   variables,
   handleUpdatePair,
   ...restProps
@@ -50,8 +46,8 @@ export const EditableCell: React.FC<React.PropsWithChildren<EditableCellProps>> 
     try {
       const values = await form.validateFields();
       handleUpdatePair({ ...record, ...values });
-    } catch (errInfo) {
-      Logger.log(pairtype, " KeyValueTable: Save failed:", errInfo);
+    } catch (error) {
+      console.error("Error saving key-value pair", error);
     }
   };
 
@@ -69,7 +65,6 @@ export const EditableCell: React.FC<React.PropsWithChildren<EditableCellProps>> 
             onChange={(e) => {
               form.setFieldsValue({ [dataIndex]: e.target.checked });
               save();
-              trackEnableKeyValueToggled(e.target.checked, pairtype);
             }}
           />
         ) : (

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/RequestTabs.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/RequestTabs.tsx
@@ -1,14 +1,15 @@
 import { Tabs, TabsProps, Tag } from "antd";
 import React, { memo, useEffect, useMemo, useState } from "react";
-import { KeyValueFormType, RQAPI, RequestContentType } from "../../../../../../../../types";
+import { RQAPI, RequestContentType } from "../../../../../../../../types";
 import RequestBody from "../../RequestBody";
 import { sanitizeKeyValuePairs, supportsRequestBody } from "../../../../../../utils";
-import { KeyValueTable } from "../KeyValueTable/KeyValueTable";
 import { ScriptEditor } from "../../../Scripts/components/ScriptEditor/ScriptEditor";
 import { useFeatureIsOn } from "@growthbook/growthbook-react";
 import useEnvironmentManager from "backend/environment/hooks/useEnvironmentManager";
 import "./requestTabs.scss";
 import AuthorizationView from "../AuthorizationView";
+import { QueryParamsTable } from "./components/QueryParamsTable/QueryParamsTable";
+import { HeadersTable } from "./components/HeadersTable/HeadersTable";
 
 enum Tab {
   QUERY_PARAMS = "query_params",
@@ -64,12 +65,7 @@ const RequestTabs: React.FC<Props> = ({
           <LabelWithCount label="Query Params" count={sanitizeKeyValuePairs(requestEntry.request.queryParams).length} />
         ),
         children: (
-          <KeyValueTable
-            data={requestEntry.request.queryParams}
-            setKeyValuePairs={setRequestEntry}
-            pairType={KeyValueFormType.QUERY_PARAMS}
-            variables={variables}
-          />
+          <QueryParamsTable requestEntry={requestEntry} setRequestEntry={setRequestEntry} variables={variables} />
         ),
       },
       {
@@ -102,11 +98,10 @@ const RequestTabs: React.FC<Props> = ({
         key: Tab.HEADERS,
         label: <LabelWithCount label="Headers" count={sanitizeKeyValuePairs(requestEntry.request.headers).length} />,
         children: (
-          <KeyValueTable
-            data={requestEntry.request.headers}
-            setKeyValuePairs={setRequestEntry}
-            pairType={KeyValueFormType.HEADERS}
+          <HeadersTable
+            headers={requestEntry.request.headers}
             variables={variables}
+            setRequestEntry={setRequestEntry}
           />
         ),
       },

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/components/HeadersTable/HeadersTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/components/HeadersTable/HeadersTable.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { EnvironmentVariables } from "backend/environment/types";
+import { KeyValuePair, RQAPI } from "features/apiClient/types";
+import { KeyValueTable } from "../../../KeyValueTable/KeyValueTable";
+
+interface HeadersTableProps {
+  headers: KeyValuePair[];
+  variables: EnvironmentVariables;
+  setRequestEntry: (updaterFn: (prev: RQAPI.Entry) => RQAPI.Entry) => void;
+}
+
+export const HeadersTable: React.FC<HeadersTableProps> = ({ headers, variables, setRequestEntry }) => {
+  const handleHeadersChange = (updatedHeaders: KeyValuePair[]) => {
+    setRequestEntry((prev) => ({
+      ...prev,
+      request: {
+        ...prev.request,
+        headers: updatedHeaders,
+      },
+    }));
+  };
+
+  return <KeyValueTable data={headers} variables={variables} onChange={handleHeadersChange} />;
+};

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/components/HeadersTable/HeadersTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/components/HeadersTable/HeadersTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { EnvironmentVariables } from "backend/environment/types";
 import { KeyValuePair, RQAPI } from "features/apiClient/types";
 import { KeyValueTable } from "../../../KeyValueTable/KeyValueTable";
@@ -10,15 +10,18 @@ interface HeadersTableProps {
 }
 
 export const HeadersTable: React.FC<HeadersTableProps> = ({ headers, variables, setRequestEntry }) => {
-  const handleHeadersChange = (updatedHeaders: KeyValuePair[]) => {
-    setRequestEntry((prev) => ({
-      ...prev,
-      request: {
-        ...prev.request,
-        headers: updatedHeaders,
-      },
-    }));
-  };
+  const handleHeadersChange = useCallback(
+    (updatedHeaders: KeyValuePair[]) => {
+      setRequestEntry((prev) => ({
+        ...prev,
+        request: {
+          ...prev.request,
+          headers: updatedHeaders,
+        },
+      }));
+    },
+    [setRequestEntry]
+  );
 
   return <KeyValueTable data={headers} variables={variables} onChange={handleHeadersChange} />;
 };

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/components/QueryParamsTable/QueryParamsTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/components/QueryParamsTable/QueryParamsTable.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { EnvironmentVariables } from "backend/environment/types";
+import { KeyValuePair, QueryParamSyncType, RQAPI } from "features/apiClient/types";
+import { KeyValueTable } from "../../../KeyValueTable/KeyValueTable";
+import { syncQueryParams } from "features/apiClient/screens/apiClient/utils";
+
+interface QueryParamsTableProps {
+  requestEntry: RQAPI.Entry;
+  variables: EnvironmentVariables;
+  setRequestEntry: (updaterFn: (prev: RQAPI.Entry) => RQAPI.Entry) => void;
+}
+
+export const QueryParamsTable: React.FC<QueryParamsTableProps> = ({ requestEntry, variables, setRequestEntry }) => {
+  const handleUpdateQueryParams = (updatedPairs: KeyValuePair[]) => {
+    setRequestEntry((prev) => ({
+      ...prev,
+      request: {
+        ...prev.request,
+        queryParams: updatedPairs,
+        ...syncQueryParams(updatedPairs, requestEntry.request.url, QueryParamSyncType.URL),
+      },
+    }));
+  };
+
+  return (
+    <KeyValueTable data={requestEntry.request.queryParams} variables={variables} onChange={handleUpdateQueryParams} />
+  );
+};

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/components/QueryParamsTable/QueryParamsTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/RequestTabs/components/QueryParamsTable/QueryParamsTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { EnvironmentVariables } from "backend/environment/types";
 import { KeyValuePair, QueryParamSyncType, RQAPI } from "features/apiClient/types";
 import { KeyValueTable } from "../../../KeyValueTable/KeyValueTable";
@@ -11,16 +11,19 @@ interface QueryParamsTableProps {
 }
 
 export const QueryParamsTable: React.FC<QueryParamsTableProps> = ({ requestEntry, variables, setRequestEntry }) => {
-  const handleUpdateQueryParams = (updatedPairs: KeyValuePair[]) => {
-    setRequestEntry((prev) => ({
-      ...prev,
-      request: {
-        ...prev.request,
-        queryParams: updatedPairs,
-        ...syncQueryParams(updatedPairs, requestEntry.request.url, QueryParamSyncType.URL),
-      },
-    }));
-  };
+  const handleUpdateQueryParams = useCallback(
+    (updatedPairs: KeyValuePair[]) => {
+      setRequestEntry((prev) => ({
+        ...prev,
+        request: {
+          ...prev.request,
+          queryParams: updatedPairs,
+          ...syncQueryParams(updatedPairs, prev.request.url, QueryParamSyncType.URL),
+        },
+      }));
+    },
+    [setRequestEntry]
+  );
 
   return (
     <KeyValueTable data={requestEntry.request.queryParams} variables={variables} onChange={handleUpdateQueryParams} />

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/form-body-renderer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/form-body-renderer.tsx
@@ -1,5 +1,5 @@
 import { EnvironmentVariables } from "backend/environment/types";
-import { KeyValueFormType, KeyValuePair, RQAPI } from "features/apiClient/types";
+import { KeyValuePair } from "features/apiClient/types";
 import { useCallback, useContext } from "react";
 import { RequestBodyContext, useFormBody } from "../request-body-state-manager";
 import { RequestBodyProps } from "../request-body-types";
@@ -15,15 +15,14 @@ export function FormBody(props: {
   const { formBody, setFormBody } = useFormBody(requestBodyStateManager);
 
   const handleFormChange = useCallback(
-    (updaterFn: (prev: RQAPI.Entry) => RQAPI.Entry) => {
+    (updatedPairs: KeyValuePair[]) => {
       setRequestEntry((prev) => {
-        const updatedEntry = updaterFn(prev);
-        setFormBody(updatedEntry.request.body as KeyValuePair[]);
+        setFormBody(updatedPairs);
         return {
           ...prev,
           request: {
             ...prev.request,
-            body: updatedEntry.request.body,
+            body: updatedPairs,
             bodyContainer: requestBodyStateManager.serialize(),
           },
         };
@@ -32,12 +31,5 @@ export function FormBody(props: {
     [setRequestEntry, setFormBody, requestBodyStateManager]
   );
 
-  return (
-    <KeyValueTable
-      pairType={KeyValueFormType.FORM}
-      data={formBody}
-      setKeyValuePairs={handleFormChange}
-      variables={environmentVariables}
-    />
-  );
+  return <KeyValueTable data={formBody} variables={environmentVariables} onChange={handleFormChange} />;
 }


### PR DESCRIPTION
The component is currently highly coupled with API requestEntry state

* The table should only accept the `pairs`, `onChange` handler and `variables`

*  Let the respective parent component of KeyValueTable handle the request entry update

* Avoid passing `pairType`  prop,  parent will handle it.