### PR TITLE
ENGG-2809: Add T&C footer in auth modal

### DIFF
--- a/app/src/config/constants/sub/links.js
+++ b/app/src/config/constants/sub/links.js
@@ -80,6 +80,8 @@ const LINKS = {
   REQUESTLY_PRIVACY_POLICY: "https://requestly.com/privacy",
   // Terms and Conditions
   REQUESTLY_TERMS_AND_CONDITIONS: "https://requestly.com/terms/",
+  //Privacy Statement
+  REQUESTLY_PRIVACY_STATEMENT: "https://requestly.com/privacy/",
   //Contact Us
   CONTACT_US: "mailto:" + GLOBAL_CONSTANTS.COMPANY_INFO.SUPPORT_EMAIL,
   // Contact Us Page

--- a/app/src/features/onboarding/components/auth/components/Form/index.scss
+++ b/app/src/features/onboarding/components/auth/components/Form/index.scss
@@ -16,7 +16,7 @@
 
 .onboarding-auth-mode-switch-wrapper {
   font-size: var(--requestly-font-size-sm, 13px);
-  color: var(--text-light);
+  color: var(--requestly-color-text-subtle);
 
   .onboarding-auth-mode-switcher {
     text-decoration: underline;
@@ -143,4 +143,10 @@
   font-weight: var(--requestly-font-weight-normal);
   line-height: var(--requestly-font-line-height-xs);
   margin-top: 8px;
+}
+
+.auth-form-footer {
+  font-size: var(--requestly-font-size-xs);
+  color: var(--requestly-color-text-placeholder);
+  margin-top: 20px;
 }

--- a/app/src/features/onboarding/components/auth/components/Form/index.tsx
+++ b/app/src/features/onboarding/components/auth/components/Form/index.tsx
@@ -29,6 +29,7 @@ import { AuthWarningBanner } from "./components/AuthWarningBanner";
 import { isDisposableEmail } from "utils/AuthUtils";
 import { useFeatureValue } from "@growthbook/growthbook-react";
 import { getAppFlavour } from "utils/AppUtils";
+import LINKS from "config/constants/sub/links";
 import "./index.scss";
 
 interface AuthFormProps {
@@ -342,6 +343,17 @@ export const AuthForm: React.FC<AuthFormProps> = ({
           {authMode === AUTH.ACTION_LABELS.SIGN_UP ? "Sign in" : "Sign up now"}
         </span>
       </Row>
+      <div className="auth-form-footer">
+        By clicking {authMode === AUTH.ACTION_LABELS.SIGN_UP ? "Sign up with Google" : "Sign in with Google"}, Continue
+        with Single Sign-on (SSO) or Continue you agree to our{" "}
+        <a href={LINKS.REQUESTLY_TERMS_AND_CONDITIONS} target="_blank" rel="noreferrer">
+          Terms and Conditions
+        </a>{" "}
+        and{" "}
+        <a href={LINKS.REQUESTLY_PRIVACY_STATEMENT} target="_blank" rel="noreferrer">
+          Privacy Statement
+        </a>
+      </div>
     </>
   ) : (
     <div className="w-full">


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2025-01-13 at 11 01 07 AM" src="https://github.com/user-attachments/assets/961c4319-6008-47f7-acb0-8ed9c93376e3" />
