### PR TITLE
Add Alfa-College to eligible-student-domains.md

### DIFF
--- a/eligible-student-domains.md
+++ b/eligible-student-domains.md
@@ -12,6 +12,7 @@ The following domains are eligible for the student programme:
     ".ac.nz",
     ".ac.jp",
     ".ac.za",
-    ".edu.br"
+    ".edu.br",
+    "student.alfa-college.nl"
   ]
 }

--- a/eligible-student-domains.md
+++ b/eligible-student-domains.md
@@ -13,6 +13,6 @@ The following domains are eligible for the student programme:
     ".ac.jp",
     ".ac.za",
     ".edu.br",
-    "student.alfa-college.nl"
+    ".alfa-college.nl"
   ]
 }


### PR DESCRIPTION
This PR adds [Alfa-College Groningen](https://www.alfa-college.nl/) to the list of eligible domains for the Student Program.

For reference, see chat between user1738327488683 and Sachin on Crisp.