### PR TITLE
[ENGG-2925] fix: status text not being populated in API client scripts

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -58,6 +58,7 @@
         "fuzzysort": "^2.0.4",
         "handlebars": "^4.7.8",
         "html-validate": "^8.9.1",
+        "http-status": "^2.1.0",
         "is-empty": "^1.2.0",
         "javascript-1flow-sdk": "^1.0.2",
         "js-file-download": "^0.4.12",
@@ -10799,6 +10800,14 @@
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
       "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw=="
+    },
+    "node_modules/http-status": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-status/-/http-status-2.1.0.tgz",
+      "integrity": "sha512-O5kPr7AW7wYd/BBiOezTwnVAnmSNFY+J7hlZD2X5IOxVBetjcHAiTXhzj0gMrnojQlwy+UT1/Y3H3vJ3UlmvLA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/https-browserify": {
       "version": "1.0.0",
@@ -26654,6 +26663,11 @@
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
       "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw=="
+    },
+    "http-status": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-status/-/http-status-2.1.0.tgz",
+      "integrity": "sha512-O5kPr7AW7wYd/BBiOezTwnVAnmSNFY+J7hlZD2X5IOxVBetjcHAiTXhzj0gMrnojQlwy+UT1/Y3H3vJ3UlmvLA=="
     },
     "https-browserify": {
       "version": "1.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -88,6 +88,7 @@
     "fuzzysort": "^2.0.4",
     "handlebars": "^4.7.8",
     "html-validate": "^8.9.1",
+    "http-status": "^2.1.0",
     "is-empty": "^1.2.0",
     "javascript-1flow-sdk": "^1.0.2",
     "js-file-download": "^0.4.12",

--- a/app/src/features/apiClient/helpers/modules/scriptsV2/worker/script-internals/RQmethods.ts
+++ b/app/src/features/apiClient/helpers/modules/scriptsV2/worker/script-internals/RQmethods.ts
@@ -6,6 +6,7 @@ import { expect } from "chai";
 import { Options as AjvOptions } from "ajv";
 import { TestExecutor } from "./testExecutor";
 import { AssertionHandler } from "./assertionHandler";
+import { status } from "http-status";
 
 // unsupported methods
 const createInfiniteChainable = (methodName: string) => {
@@ -105,11 +106,10 @@ export class RQ implements SandboxAPI {
     if (!originalResponse) {
       return (this.response = undefined);
     }
-
     const responseProperties = {
       ...originalResponse,
       code: originalResponse.status,
-      status: originalResponse.statusText,
+      status: (status as { [key: number]: string })[originalResponse.status],
       responseTime: originalResponse.time,
     };
 


### PR DESCRIPTION
We have to maintain the status code mapping ourselves. As HTTP/2 onwards we do not have statusText returned by the server. [Refer](https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText#value). 