### PR TITLE
fix: typescript config - compilation error

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noImplicitAny": true,
     "noImplicitReturns": false,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "strict": false,
     "esModuleInterop": true,

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,6 +2,7 @@
   "name": "@requestly/shared",
   "version": "1.0.0",
   "description": "",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "run-s cleanup build-dist build-alias",
@@ -58,6 +59,13 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "import": "./dist/index.esm.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "types/*": [
+        "dist/types/*/index.d.ts"
+      ]
     }
   }
 }

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "ESNext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Typescript was not compiling because `moduleResolution` was set as `bundler` in [this commit](https://github.com/requestly/requestly/blob/cf51d760185ab553f66f150d2f537e04d52a8a7b/app/tsconfig.json).

The above change was done to import typing from `@requestly/shared` module.

This PR 
1. Resets `moduleResolution` to `node`
2. Fixes shared module's `typesVersions` to import types from subpaths of `@requestly/shared`