### PR TITLE
fix: create api from the repo layer, rather than trying to update it 

### DIFF
--- a/app/src/features/apiClient/screens/BrunoImporter/index.tsx
+++ b/app/src/features/apiClient/screens/BrunoImporter/index.tsx
@@ -153,7 +153,7 @@ export const BrunoImporter: React.FC<BrunoImporterProps> = ({ onSuccess }) => {
 
       const updatedApi = { ...api, collectionId: newCollectionId };
       try {
-        const newApi = await apiClientRecordsRepository.updateRecord(updatedApi, updatedApi.id);
+        const newApi = await apiClientRecordsRepository.createRecordWithId(updatedApi, updatedApi.id);
         onSaveRecord(newApi.data, "none");
         importedApisCount++;
       } catch (error) {


### PR DESCRIPTION
https://github.com/requestly/requestly/pull/2732 broke bruno importer, was not making new records for item[type="api"]