### PR TITLE
[ENGG-3109] fix: unsaved tab changes showing up in case of existing requests

### DIFF
--- a/app/src/features/apiClient/components/common/APIClient/APIClient.tsx
+++ b/app/src/features/apiClient/components/common/APIClient/APIClient.tsx
@@ -2,18 +2,20 @@ import { Modal } from "antd";
 import React, { useMemo } from "react";
 import { APIClientRequest } from "./types";
 import BetaBadge from "components/misc/BetaBadge";
-import { RequestContentType, RequestMethod, RQAPI } from "features/apiClient/types";
+import { QueryParamSyncType, RequestContentType, RequestMethod, RQAPI } from "features/apiClient/types";
 import {
   filterHeadersToImport,
   generateKeyValuePairsFromJson,
   getContentTypeFromRequestHeaders,
   getEmptyAPIEntry,
   parseCurlRequest,
+  syncQueryParams,
 } from "features/apiClient/screens/apiClient/utils";
 import { CONTENT_TYPE_HEADER } from "features/apiClient/constants";
 import APIClientView from "../../../screens/apiClient/components/clientView/APIClientView";
 import { BottomSheetPlacement, BottomSheetProvider } from "componentsV2/BottomSheet";
 import "./apiClient.scss";
+import { isEmpty } from "lodash";
 
 interface Props {
   request: string | APIClientRequest; // string for cURL request
@@ -68,6 +70,15 @@ const APIClient: React.FC<Props> = ({ request, openInModal, isModalOpen, onModal
         entry.request.body = generateKeyValuePairsFromJson(formDataObj);
       }
     }
+
+    entry.request = {
+      ...entry.request,
+      ...syncQueryParams(
+        entry.request.queryParams,
+        entry.request.url,
+        isEmpty(entry.request.queryParams) ? QueryParamSyncType.TABLE : QueryParamSyncType.SYNC
+      ),
+    };
 
     return entry;
   }, [request]);

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/APIClientView.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/APIClientView.tsx
@@ -43,7 +43,6 @@ import { useLocation, useParams, useSearchParams } from "react-router-dom";
 import { useHasUnsavedChanges } from "hooks";
 import { useTabsLayoutContext } from "layouts/TabsLayout";
 import { ApiClientExecutor } from "features/apiClient/helpers/apiClientExecutor/apiClientExecutor";
-import { isEmpty } from "lodash";
 import CopyAsModal from "../modals/CopyAsModal/CopyAsModal";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
 
@@ -140,21 +139,10 @@ const APIClientView: React.FC<Props> = ({ apiEntry, apiEntryDetails, notifyApiRe
   }, [updateTab, activeTab?.id, requestId, apiEntryDetails?.id, hasUnsavedChanges]);
 
   useEffect(() => {
-    if (apiEntry) {
-      setEntry({
-        ...apiEntry,
-        request: {
-          ...apiEntry.request,
-          ...syncQueryParams(
-            apiEntry.request.queryParams,
-            apiEntry.request.url,
-            isEmpty(apiEntry.request.queryParams) ? QueryParamSyncType.TABLE : QueryParamSyncType.SYNC
-          ),
-        },
-      });
+    if (entry) {
       setRequestName("");
     }
-  }, [apiEntry]);
+  }, [entry]);
 
   const setUrl = useCallback((url: string) => {
     setEntry((entry) => ({

--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/raw-body-renderer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/renderers/raw-body-renderer.tsx
@@ -46,7 +46,7 @@ export function RawBody(props: {
         language={editorLanguage}
         value={text}
         handleChange={handleTextChange}
-        prettifyOnInit={contentType === "application/json"}
+        prettifyOnInit={false}
         isResizable={false}
         hideCharacterCount
         envVariables={environmentVariables}


### PR DESCRIPTION
Cause for unsaved changes triggerering:
1. Query params getting synced with URL after the creation of entry object.
2. Body being formatted on editor init.

Fixes
1. Query params are synced with URL at the time of entry object creation.
2. Body will not format on editor init. It is not needed as API client body already saves with formatted code