### PR TITLE
ENGG-3251: App primary sidebar UI improvements

### DIFF
--- a/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/PrimarySidebar.css
+++ b/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/PrimarySidebar.css
@@ -2,6 +2,7 @@
   position: relative;
   width: 100%;
   max-width: 5rem;
+  padding: var(--space-2, 4px);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -29,6 +30,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  margin: 8px 0;
 }
 
 .primary-sidebar-container li .primary-sidebar-link {
@@ -36,41 +38,45 @@
 }
 
 .primary-sidebar-container .primary-sidebar-link {
-  padding: 8px 4px;
-  min-height: 4.5rem;
-  margin-bottom: 2px;
+  width: 56px;
+  height: 56px;
   display: flex;
   align-items: center;
   flex-direction: column;
   justify-content: center;
-  row-gap: 8px;
-  color: var(--text-dark-gray);
+  align-items: center;
+  padding: 6px;
+  gap: var(--space-4, 8px);
+  color: var(--requestly-color-text-placeholder);
+  border-radius: 4px;
   border: none;
-  border-radius: 0;
 }
 
-.primary-sidebar-container .primary-sidebar-link:hover,
-.primary-sidebar-container .primary-sidebar-link:active,
-/* .primary-sidebar-container .primary-sidebar-link:focus, */
-.primary-sidebar-container .primary-sidebar-active-link {
+.primary-sidebar-container .primary-sidebar-link:hover {
   cursor: pointer;
   color: var(--white);
-  background-color: var(--gray-dark);
-  border: none !important;
+  background-color: var(--requestly-color-white-t-10);
+}
+
+.primary-sidebar-container .primary-sidebar-link:active,
+.primary-sidebar-container .primary-sidebar-active-link,
+.primary-sidebar-container .primary-sidebar-active-link:hover {
+  color: var(--requestly-color-text-default);
+  background-color: var(--requestly-color-white-t-20);
 }
 
 .primary-sidebar-container .primary-sidebar-active-link {
   border-left-color: var(--primary);
 }
 
-.primary-sidebar-link .icon__wrapper svg {
-  width: 1rem;
-  height: 1rem;
+.primary-sidebar-link svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
 }
 
 .primary-sidebar-link .link-title {
   font-size: var(--requestly-font-size-2xs);
-  font-weight: var(--requestly-font-weight-medium);
   line-height: 15.92px;
   text-align: center;
 }
@@ -85,6 +91,9 @@
   right: -30px;
   font-size: 8px;
   padding: 1px 2px;
+  z-index: 1;
+  background: var(--requestly-color-surface-2);
+  border: 1px solid var(--requestly-color-surface-3);
 }
 
 .primary-sidebar-bottom-btns {

--- a/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/components/InviteButton/InviteButton.tsx
+++ b/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/components/InviteButton/InviteButton.tsx
@@ -59,7 +59,7 @@ const InviteButton: React.FC = () => {
         }}
         className="primary-sidebar-link w-full"
       >
-        <span className="icon__wrapper">{<InviteIcon />}</span>
+        <InviteIcon />
         <span className="link-title">{"Invite"}</span>
       </RQButton>
     </>

--- a/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/components/PrimarySidebarLink/PrimarySidebarLink.tsx
+++ b/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/components/PrimarySidebarLink/PrimarySidebarLink.tsx
@@ -20,7 +20,7 @@ export const PrimarySidebarLink: React.FC<PrimarySidebarItem> = ({
       };
     }}
   >
-    <span className="icon__wrapper">{icon}</span>
+    {icon}
     <span className="link-title">{title}</span>
   </NavLink>
 );

--- a/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/index.tsx
+++ b/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/index.tsx
@@ -109,7 +109,15 @@ export const PrimarySidebar: React.FC = () => {
         id: 6,
         title: "Sessions",
         path: PATHS.SESSIONS.INDEX,
-        icon: <SessionIcon />,
+        icon: (
+          <Tooltip
+            placement="right"
+            open={isSavingNetworkSession}
+            title={showTooltipForSessionIcon ? "View and manage your saved sessions here" : ""}
+          >
+            <SessionIcon />
+          </Tooltip>
+        ),
         display: true,
       },
     ];

--- a/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/index.tsx
+++ b/app/src/layouts/DashboardLayout/Sidebar/PrimarySidebar/index.tsx
@@ -63,21 +63,21 @@ export const PrimarySidebar: React.FC = () => {
       },
       {
         id: 1,
-        title: "Network traffic",
+        title: "Network",
         path: PATHS.DESKTOP.INTERCEPT_TRAFFIC.RELATIVE,
         icon: <NetworkTrafficIcon />,
         display: appMode === GLOBAL_CONSTANTS.APP_MODES.DESKTOP,
       },
       {
         id: 2,
-        title: "Network inspector",
+        title: "Network",
         path: PATHS.NETWORK_INSPECTOR.RELATIVE,
         icon: <NetworkTrafficInspectorIcon />,
         display: appMode === GLOBAL_CONSTANTS.APP_MODES.EXTENSION && !isSafariBrowser(),
       },
       {
         id: 3,
-        title: "HTTP Rules",
+        title: "Rules",
         path: PATHS.RULES.INDEX,
         icon: (
           <SafariComingSoonTooltip isVisible={isSafariExtension()}>
@@ -85,11 +85,10 @@ export const PrimarySidebar: React.FC = () => {
           </SafariComingSoonTooltip>
         ),
         display: true,
-        activeColor: "var(--http-rules)",
       },
       {
         id: 4,
-        title: "API client",
+        title: "APIs",
         path: PATHS.API_CLIENT.INDEX,
         icon: (
           <span className="icon-with-badge">
@@ -98,33 +97,20 @@ export const PrimarySidebar: React.FC = () => {
           </span>
         ),
         display: true,
-        activeColor: "var(--api-client)",
       },
       {
         id: 5,
-        title: "Mock server",
+        title: "Mocks",
         path: PATHS.MOCK_SERVER.INDEX,
         icon: <MockServerIcon />,
         display: true,
-        activeColor: "var(--mock-server)",
       },
       {
         id: 6,
         title: "Sessions",
         path: PATHS.SESSIONS.INDEX,
-        icon: (
-          <Tooltip
-            placement="right"
-            open={isSavingNetworkSession}
-            title={showTooltipForSessionIcon ? "View and manage your saved sessions here" : ""}
-          >
-            <span className="icon-with-badge">
-              <SessionIcon />
-            </span>
-          </Tooltip>
-        ),
+        icon: <SessionIcon />,
         display: true,
-        activeColor: "var(--session-recording)",
       },
     ];
 
@@ -143,7 +129,6 @@ export const PrimarySidebar: React.FC = () => {
           </Tooltip>
         ),
         display: true,
-        activeColor: "var(--desktop-sessions)",
       };
     }
     return items;


### PR DESCRIPTION
Before:
<img width="1470" alt="Screenshot 2025-03-19 at 12 59 04 PM" src="https://github.com/user-attachments/assets/0fc71e76-d624-469f-930e-f3a0d764b309" />
After:
<img width="1470" alt="Screenshot 2025-03-19 at 12 59 41 PM" src="https://github.com/user-attachments/assets/9afc35ae-ffe5-4054-a7f2-c144bd515e0f" />
