### PR TITLE
[ENGG-3013] fix: Override Node methods to prevent Google Translate from breaking the app when translating

### DIFF
--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -22,6 +22,16 @@ const container = document.getElementById("root");
 const root = createRoot(container);
 const appFlavour = getAppFlavour();
 
+/* Google translate replaces textNodes from the DOM  with <font> tag 
+  Beacuse of this, React throws error when re-rednering the component
+  This is a workaround to fix the issue
+
+
+  It overrides the removeChild and insertBefore methods of Node.prototype if the child's parentNode is not the same as the current node. This patch swallows the error and return the child node. 
+  
+  This is a workaround to fix the issue
+*/
+
 if (typeof Node === "function" && Node.prototype) {
   const originalRemoveChild = Node.prototype.removeChild;
   Node.prototype.removeChild = function (child) {


### PR DESCRIPTION
Refer: https://github.com/facebook/react/issues/11538#issuecomment-417504600