### PR TITLE
chore: add target to all anchor tags

### DIFF
--- a/app/src/components/mode-specific/desktop/MySources/Sources/InstructionsModal/Android/CertificateDownload.js
+++ b/app/src/components/mode-specific/desktop/MySources/Sources/InstructionsModal/Android/CertificateDownload.js
@@ -13,7 +13,10 @@ const CertificateDownloadInstructions = ({ device_id }) => {
               <List.Item.Meta
                 title={
                   <>
-                    b. Go to <a href="http://requestly.io/ssl">http://requestly.io/ssl</a>{" "}
+                    b. Go to{" "}
+                    <a href="http://requestly.io/ssl" target="__blank">
+                      http://requestly.io/ssl
+                    </a>{" "}
                     <span style={{ color: "red" }}>(Use http here. Not https)</span>
                   </>
                 }

--- a/app/src/components/mode-specific/desktop/MySources/Sources/InstructionsModal/ExistingBrowser.tsx
+++ b/app/src/components/mode-specific/desktop/MySources/Sources/InstructionsModal/ExistingBrowser.tsx
@@ -24,7 +24,10 @@ const ExistingBrowserInstructionModal: React.FC<{
                   <List.Item.Meta
                     title={
                       <>
-                        a. Install Requestly Extension from <a href="https://requestly.com">requestly.com</a>
+                        a. Install Requestly Extension from{" "}
+                        <a href="https://requestly.com" target="__blank">
+                          requestly.com
+                        </a>
                       </>
                     }
                   />

--- a/app/src/components/mode-specific/desktop/MySources/Sources/InstructionsModal/IOS/CertificateDownload.js
+++ b/app/src/components/mode-specific/desktop/MySources/Sources/InstructionsModal/IOS/CertificateDownload.js
@@ -19,7 +19,10 @@ const CertificateDownloadInstructions = ({ device_id }) => {
               <List.Item.Meta
                 title={
                   <>
-                    b. Go to <a href="http://requestly.io/ssl">http://requestly.io/ssl</a>{" "}
+                    b. Go to{" "}
+                    <a href="http://requestly.io/ssl" target="__blank">
+                      http://requestly.io/ssl
+                    </a>{" "}
                     <span style={{ color: "red" }}>(Use http here. Not https)</span>
                   </>
                 }

--- a/app/src/components/mode-specific/desktop/MySources/Sources/InstructionsModal/common/TestProxy.js
+++ b/app/src/components/mode-specific/desktop/MySources/Sources/InstructionsModal/common/TestProxy.js
@@ -18,7 +18,10 @@ const TestProxyInstructions = ({ device }) => {
           <List.Item.Meta
             title={
               <>
-                b. Go to <a href="http://amiusing.requestly.io">http://amiusing.requestly.io</a>
+                b. Go to{" "}
+                <a href="http://amiusing.requestly.io" target="__blank">
+                  http://amiusing.requestly.io
+                </a>
                 &nbsp;
                 <span style={{ color: "red" }}>(Use http here. Not https)</span>
               </>

--- a/app/src/features/onboarding/components/auth/components/Form/index.tsx
+++ b/app/src/features/onboarding/components/auth/components/Form/index.tsx
@@ -531,7 +531,10 @@ export const AuthForm: React.FC<AuthFormProps> = ({
             terms
           </a>
           . Learn about how we use and protect your data in our{" "}
-          <a href="https://requestly.com/privacy/">privacy policy</a>.
+          <a href="https://requestly.com/privacy/" target="_blank" rel="noreferrer">
+            privacy policy
+          </a>
+          .
         </div>
       )}
     </div>


### PR DESCRIPTION
- else was a bug in case of desktop app as the link would then be opened in the current renederer (with no way of going back to the app)
- did not enforce for `mailto` links as they already open the native email client