### PR TITLE
fix: mock server header buttons UI alignment

### DIFF
--- a/app/src/components/features/mocksV2/MockEditorIndex/Editor/Header/index.css
+++ b/app/src/components/features/mocksV2/MockEditorIndex/Editor/Header/index.css
@@ -23,6 +23,7 @@
 .mock-editor-layout-header .header-right-section {
   display: flex;
   gap: 12px;
+  align-items: center;
 }
 
 .mock-editor-layout-header .header-right-section .ant-btn-icon-only svg {


### PR DESCRIPTION
- before
![image](https://github.com/user-attachments/assets/bac854e6-6ea3-41ac-83b0-e7f094e7056b)

- after
<img width="1402" alt="Screenshot 2025-04-16 at 4 13 15 PM" src="https://github.com/user-attachments/assets/eccd18c6-d7d6-410d-9b9b-1091111bfcaf" />

