### PR TITLE
[ENGG-3400] fix: editor buttons overflowing

### DIFF
--- a/app/src/views/features/rules/RuleEditor/components/Header/RuleEditorHeader.css
+++ b/app/src/views/features/rules/RuleEditor/components/Header/RuleEditorHeader.css
@@ -52,6 +52,7 @@
   justify-content: flex-end;
   column-gap: 8px;
   flex-wrap: wrap;
+  margin-left: -8px;
 }
 
 .rule-editor-back-btn {


### PR DESCRIPTION
- before
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/4d5f94ec-ba1e-4146-a90b-f528d13d7c1f" />

- after
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/f6ea6ab3-b7e7-4658-9a2e-b013be33953f" />
