### PR TITLE
Add .edu.al to eligible domains list for students plan

### DIFF
--- a/eligible-student-domains.md
+++ b/eligible-student-domains.md
@@ -24,6 +24,7 @@ The following domains are eligible for the student programme:
     ".edu.kh",
     ".edu.tw",
     ".edu.cn",
+    ".edu.al",
     ".ac.id",
     "bennington.edu",
     "yonsei.ac.kr",


### PR DESCRIPTION
This PR adds a new entry to the list found at [eligible-student-domains.md](https://github.com/requestly/requestly/blob/master/eligible-student-domains.md) that should cover most academic institutions in Albania, and allow their studends access to the [Requestly Student Program](https://requestly.com/student-program/).

Changes proposed:
- Added the academic TLD `.edu.al` to the list of eligible student domains.