### PR TITLE
fix: block updates to sample rule

### DIFF
--- a/app/src/store/features/rulesActions.ts
+++ b/app/src/store/features/rulesActions.ts
@@ -1,6 +1,5 @@
 import { getFilterObjectPath } from "utils/rules/getFilterObjectPath";
-//@ts-ignore
-import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
+// import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
 import { get, set } from "lodash";
 import { GlobalSliceState } from "store/slices/global/types";
 import { Group, QueryParamRule, Rule, ScriptRule } from "@requestly/shared/types/entities/rules";
@@ -151,16 +150,27 @@ export const updateRulePairAtGivenPath = (
 ) => {
   const { pairIndex, updates = {}, triggerUnsavedChangesIndication = true } = action.payload;
 
+  let updated = false;
   for (const [modificationPath, value] of Object.entries(updates)) {
-    set(
-      (prevState.rules.currentlySelectedRule.data as Rule)?.pairs?.[pairIndex],
-      getFilterObjectPath(modificationPath),
-      value
-    );
+    if (isRuleModificationAllowed(prevState.rules.currentlySelectedRule.data as Rule, modificationPath)) {
+      set(
+        (prevState.rules.currentlySelectedRule.data as Rule)?.pairs?.[pairIndex],
+        getFilterObjectPath(modificationPath),
+        value
+      );
+      updated = true;
+    }
   }
 
-  if (triggerUnsavedChangesIndication) {
+  if (updated && triggerUnsavedChangesIndication) {
     prevState.rules.currentlySelectedRule.hasUnsavedChanges = true;
+  }
+
+  function isRuleModificationAllowed(rule: Rule, _modificationPath: string) {
+    if (!rule || rule.isSample) {
+      return false;
+    }
+    return true;
   }
 };
 

--- a/app/src/store/features/rulesActions.ts
+++ b/app/src/store/features/rulesActions.ts
@@ -150,7 +150,7 @@ export const updateRulePairAtGivenPath = (
 ) => {
   const { pairIndex, updates = {}, triggerUnsavedChangesIndication = true } = action.payload;
 
-  let updated = false;
+  let ruleDataModified = false;
   for (const [modificationPath, value] of Object.entries(updates)) {
     if (isRuleModificationAllowed(prevState.rules.currentlySelectedRule.data as Rule, modificationPath)) {
       set(
@@ -158,11 +158,11 @@ export const updateRulePairAtGivenPath = (
         getFilterObjectPath(modificationPath),
         value
       );
-      updated = true;
+      ruleDataModified = true;
     }
   }
 
-  if (updated && triggerUnsavedChangesIndication) {
+  if (ruleDataModified && triggerUnsavedChangesIndication) {
     prevState.rules.currentlySelectedRule.hasUnsavedChanges = true;
   }
 


### PR DESCRIPTION
- This PR tends to solve the issue of the sample script rule's data being corrupted by the `<script>` tag artifacts being added. 
- This is was a brittle system, that was made robust by adding the validation very closely to the record saving methods.
- The `updateRulePairAtGivenPath` action is being called even for sample rules. 
- Updates made via sample rules form deviations in the UX and the steps to be followed to save the rule.
- This needs to be solved wholistically later. But is leading to silent regressions (like the one stated above) and I guess also the issue [this PR](https://github.com/requestly/requestly/pull/2929) intends to fix as well