### PR TITLE
[ENGG-3627] added debug logs when toggling extension status

### DIFF
--- a/browser-extension/common/src/popup/components/Popup/index.tsx
+++ b/browser-extension/common/src/popup/components/Popup/index.tsx
@@ -46,9 +46,16 @@ const Popup: React.FC = () => {
   }, [currentTab]);
 
   const handleToggleExtensionStatus = useCallback((newStatus: boolean) => {
+    console.log("[Popup] handleToggleExtensionStatus", {
+      newStatus,
+    });
     chrome.runtime.sendMessage(
       { action: EXTENSION_MESSAGES.TOGGLE_EXTENSION_STATUS, newStatus },
       ({ success, updatedStatus }) => {
+        console.log("[Popup] handleToggleExtensionStatus callback", {
+          success,
+          updatedStatus,
+        });
         if (!success) {
           message.error("Cannot update extension status. Please contact support.", 0.75);
           return;

--- a/browser-extension/mv3/src/service-worker/services/contextMenu.ts
+++ b/browser-extension/mv3/src/service-worker/services/contextMenu.ts
@@ -1,4 +1,4 @@
-import { onVariableChange, setVariable, Variable } from "../variable";
+import { setVariable, Variable } from "../variable";
 import { isExtensionEnabled } from "../../utils";
 import extensionIconManager from "./extensionIconManager";
 import { sendMessageToApp } from "./messageHandler/sender";
@@ -19,11 +19,21 @@ export const updateActivationStatus = (isExtensionEnabled: boolean) => {
     title: isExtensionEnabled ? ToggleActivationStatusLabel.DEACTIVATE : ToggleActivationStatusLabel.ACTIVATE,
   });
 
+  console.log(`[updateActivationStatus] starting...`, {
+    isExtensionEnabled,
+    extensionIconState: extensionIconManager.getState(),
+  });
+
   if (isExtensionEnabled) {
     extensionIconManager.markExtensionEnabled();
   } else {
     extensionIconManager.markExtensionDisabled();
   }
+
+  console.log(`[updateActivationStatus] finished...`, {
+    isExtensionEnabled,
+    extensionIconState: extensionIconManager.getState(),
+  });
 
   if (isExtensionEnabled === false) {
     stopRecordingOnAllTabs();
@@ -43,7 +53,13 @@ export const initContextMenu = async () => {
     if (info.menuItemId === MenuItem.TOGGLE_ACTIVATION_STATUS) {
       const isExtensionStatusEnabled = await isExtensionEnabled();
       const extensionStatus = !isExtensionStatusEnabled;
+      console.log(`[initContextMenu.listener] context menu clicked`, {
+        extensionStatus,
+        extensionIconState: extensionIconManager.getState(),
+      });
+
       await setVariable<boolean>(Variable.IS_EXTENSION_ENABLED, extensionStatus);
+      updateActivationStatus(extensionStatus);
       sendMessageToApp({
         action: CLIENT_MESSAGES.NOTIFY_EXTENSION_STATUS_UPDATED,
         isExtensionEnabled: extensionStatus,
@@ -54,5 +70,5 @@ export const initContextMenu = async () => {
   const isExtensionStatusEnabled = await isExtensionEnabled();
   updateActivationStatus(isExtensionStatusEnabled);
 
-  onVariableChange<boolean>(Variable.IS_EXTENSION_ENABLED, updateActivationStatus);
+  // onVariableChange<boolean>(Variable.IS_EXTENSION_ENABLED, updateActivationStatus);
 };

--- a/browser-extension/mv3/src/service-worker/services/extensionIconManager.ts
+++ b/browser-extension/mv3/src/service-worker/services/extensionIconManager.ts
@@ -138,6 +138,13 @@ class ExtensionIconManager {
     this.#setExtensionIcon(this.#icons.DEFAULT);
     this.#updateIconStateForAllTabs();
   }
+
+  getState() {
+    return {
+      isExtensionDisabled: this.#isExtensionDisabled,
+      connectedToDesktopApp: this.#connectedToDesktopApp,
+    };
+  }
 }
 
 const extensionIconManager = new ExtensionIconManager();

--- a/browser-extension/mv3/src/service-worker/services/messageHandler/listener.ts
+++ b/browser-extension/mv3/src/service-worker/services/messageHandler/listener.ts
@@ -32,6 +32,7 @@ import {
 } from "../desktopApp/index";
 import { sendMessageToApp } from "./sender";
 import { updateExtensionStatus } from "../utils";
+import extensionIconManager from "../extensionIconManager";
 
 export const initMessageHandler = () => {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -100,11 +101,19 @@ export const initMessageHandler = () => {
         return true;
 
       case EXTENSION_MESSAGES.TOGGLE_EXTENSION_STATUS:
+        console.log(`[Toggle extension status] message received`, {
+          message,
+        });
         updateExtensionStatus(message.newStatus)
           .then((updatedStatus) => {
-            sendResponse({
+            const response = {
               success: true,
               updatedStatus,
+            };
+            sendResponse(response);
+            console.log(`[Toggle extension status] response sent`, {
+              ...response,
+              extensionIconState: extensionIconManager.getState(),
             });
           })
           .catch((e) => {
@@ -115,6 +124,8 @@ export const initMessageHandler = () => {
               "[messageHandler.handleToggleExtensionStatus] Error occurred while updating extension status.",
               {
                 error: e.message,
+                extensionIconState: extensionIconManager.getState(),
+                message,
               }
             );
           });

--- a/browser-extension/mv3/src/service-worker/services/utils.ts
+++ b/browser-extension/mv3/src/service-worker/services/utils.ts
@@ -2,6 +2,8 @@ import { ScriptAttributes, ScriptCodeType, ScriptObject, ScriptType } from "comm
 import { setVariable, Variable } from "../variable";
 import { sendMessageToApp } from "./messageHandler/sender";
 import { CLIENT_MESSAGES } from "common/constants";
+import extensionIconManager from "./extensionIconManager";
+import { updateActivationStatus } from "./contextMenu";
 
 /* Do not refer any external variable in below function other than arguments */
 const addInlineJS = (
@@ -165,7 +167,13 @@ export const updateExtensionStatus = async (newStatus: boolean) => {
     throw new Error(`[updateExtensionStatus] newStatus is not boolean but ${typeof newStatus}`);
   }
 
+  console.log(`[updateExtensionStatus] starting...`, {
+    newStatus,
+    extensionIconState: extensionIconManager.getState(),
+  });
+
   await setVariable<boolean>(Variable.IS_EXTENSION_ENABLED, newStatus);
+  updateActivationStatus(newStatus);
   sendMessageToApp({ action: CLIENT_MESSAGES.NOTIFY_EXTENSION_STATUS_UPDATED, isExtensionEnabled: newStatus });
 
   return newStatus;


### PR DESCRIPTION
1. Added debug logs
2. Removed the listener to handle extension activation status otherwise errors were not being captured