### PR TITLE
[ENGG-3683] fix: update pricing page copies

### DIFF
--- a/app/src/features/pricing/constants/pricingFeatures.ts
+++ b/app/src/features/pricing/constants/pricingFeatures.ts
@@ -24,7 +24,11 @@ export const PricingFeatures: PlanFeatures = {
           tooltip: "Header rules are free and unlimited. They don't count toward your rule usage limits",
         },
         {
-          title: "5 Files",
+          title: "5 API Mock Endpoints",
+          enabled: true,
+        },
+        {
+          title: "5 Files (JS / CSS)",
           enabled: true,
         },
       ],
@@ -44,7 +48,11 @@ export const PricingFeatures: PlanFeatures = {
           tooltip: "Override API responses, Modify Request Body, Insert Custom Scripts + Standard HTTP Modifications",
         },
         {
-          title: "5 Files",
+          title: "5 API Mock Endpoints",
+          enabled: true,
+        },
+        {
+          title: "5 Files (JS / CSS)",
           enabled: true,
         },
         {
@@ -68,7 +76,11 @@ export const PricingFeatures: PlanFeatures = {
           tooltip: "Override API responses, Modify Request Body, Insert Custom Scripts + Standard HTTP Modifications",
         },
         {
-          title: "10 Files",
+          title: "10 API Mock Endpoints",
+          enabled: true,
+        },
+        {
+          title: "10 Files (JS / CSS)",
           enabled: true,
         },
         {
@@ -86,11 +98,19 @@ export const PricingFeatures: PlanFeatures = {
       heading: "For collaboration in teams",
       features: [
         {
-          title: "Unlimited rules",
+          title: "Unlimited Rules",
           enabled: true,
         },
         {
-          title: "Unlimited Files",
+          title: "Unlimited Groups",
+          enabled: true,
+        },
+        {
+          title: "Unlimited Mock Endpoints",
+          enabled: true,
+        },
+        {
+          title: "Unlimited Files (JS / CSS)",
           enabled: true,
         },
         {


### PR DESCRIPTION
Changelog:
- Changed 5 Files to 5 Files (JS / CSS)
- Added a separate line-entry for 5 API Mock Endpoints (above 5 files)
- Similarly, Unlimited Files should be splited into two entries 
   - Unlimited Files (JS, CSS)
   - Unlimited Mock endpoints
- Add Unlimited Groups in Professional Plan

In Page:
![Screenshot 2025-05-27 at 4 15 55 PM](https://github.com/user-attachments/assets/7cb2f8d3-b399-4bd4-bd24-789d4189c17c)

In modal:
![Screenshot 2025-05-27 at 4 17 44 PM](https://github.com/user-attachments/assets/ea4887cc-066a-4b28-a0ee-5cf364b870e6)
