### PR TITLE
fix: auth config validations

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/AuthorizationView/types/AuthConfig.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/clientView/components/request/components/AuthorizationView/types/AuthConfig.ts
@@ -72,7 +72,7 @@ export class ApiKeyAuthorizationConfig implements AuthConfig<Authorization.Type.
   }
 
   validate(): boolean {
-    return this.key !== "" && this.value !== "";
+    return Boolean(this.key && this.value);
   }
 
   get config(): AuthConfigMeta.TypeToConfig[Authorization.Type.API_KEY] | null {
@@ -98,7 +98,7 @@ export class BearerTokenAuthorizationConfig implements AuthConfig<Authorization.
   }
 
   validate(): boolean {
-    return this.bearer !== "";
+    return Boolean(this.bearer);
   }
 
   get config(): AuthConfigMeta.TypeToConfig[Authorization.Type.BEARER_TOKEN] | null {
@@ -124,7 +124,7 @@ export class BasicAuthAuthorizationConfig implements AuthConfig<Authorization.Ty
   }
 
   validate(): boolean {
-    return this.username !== "" && this.password !== "";
+    return Boolean(this.username && this.password);
   }
 
   get config(): AuthConfigMeta.TypeToConfig[Authorization.Type.BASIC_AUTH] | null {


### PR DESCRIPTION
auth configs are invalid if empty string or nullish or not complete