### PR TITLE
fix: crash due to block screen

### DIFF
--- a/app/src/componentsV2/BlockScreen/hooks/useIsUserBlocked.ts
+++ b/app/src/componentsV2/BlockScreen/hooks/useIsUserBlocked.ts
@@ -34,7 +34,7 @@ export const useIsUserBlocked = () => {
     }
 
     const db = getFirestore(firebaseApp);
-    const unsubscribeListener = onSnapshot(doc(db, "users", undefined), (doc) => {
+    const unsubscribeListener = onSnapshot(doc(db, "users", uid), (doc) => {
       if (doc.exists()) {
         const userDetails = doc.data();
         setUserBlockConfig(userDetails?.["block-config"] || {});


### PR DESCRIPTION
https://requestly.sentry.io/issues/6677372762/?alert_rule_id=15725428&alert_type=issue&environment=production&notification_uuid=e494b85c-1a8f-4e5e-a819-79c6cbb390e5&project=4503895961305088

Somehow the uid is still null even though user is logged in. This fixes it temporarily. 