### PR TITLE
breaking: new breaking versions for windows and macOS

### DIFF
--- a/app/src/config/constants/compatibility.js
+++ b/app/src/config/constants/compatibility.js
@@ -178,7 +178,7 @@ export const FEATURE_COMPATIBLE_VERSION = {
   [FEATURES.COMPATIBLE_DESKTOP_APP]: {
     [GLOBAL_CONSTANTS.APP_MODES.DESKTOP]: {
       macOS: "25.5.20",
-      Windows: "1.4.20", // about to be updated
+      Windows: "25.6.25",
       Linux: "1.4.20",
     },
     [GLOBAL_CONSTANTS.APP_MODES.EXTENSION]: null,
@@ -186,9 +186,8 @@ export const FEATURE_COMPATIBLE_VERSION = {
 
   [FEATURES.NON_BREAKING_DESKTOP_APP]: {
     [GLOBAL_CONSTANTS.APP_MODES.DESKTOP]: {
-      // about to be updated
-      macOS: "1.4.20",
-      Windows: "1.4.20",
+      macOS: "25.5.20",
+      Windows: "25.6.25",
       Linux: "1.4.20",
     },
     [GLOBAL_CONSTANTS.APP_MODES.EXTENSION]: null,


### PR DESCRIPTION
- marking old windows release as unsupported as it can no longer be auto updated
- marking older macos release (before [DR changes](https://github.com/requestly/requestly-desktop-app/pull/162)) as unsupported as a cleanup step. Those users can also not auto update

One can get the latest release either from:
- Github - https://github.com/requestly/requestly-desktop-app/releases
- Website - https://requestly.com/desktop