### PR TITLE
fix: wrap appName filter generator to not crash for non parsable useragent

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
@@ -49,6 +49,7 @@ import { doesStatusCodeMatchLabels, getGraphQLOperationValues } from "./utils";
 import { TRAFFIC_TABLE } from "modules/analytics/events/common/constants";
 import { trackRQDesktopLastActivity } from "utils/AnalyticsUtils";
 import { RQTooltip } from "lib/design-system-v2/components/RQTooltip/RQTooltip";
+import { captureException } from "backend/apiClient/utils";
 
 const CurrentTrafficTable = ({
   logs: propLogs = [],
@@ -489,7 +490,7 @@ const CurrentTrafficTable = ({
   const getLogAvatar = useCallback(
     (key, logName = "", avatarUrl) => {
       const isSelected = trafficTableFilters[key].includes(logName);
-
+      console.log("DG-2: all trafficTableFilters", trafficTableFilters);
       return (
         <RQTooltip mouseEnterDelay={0.3} placement="right" title={logName.length >= 20 ? logName : ""}>
           <Avatar size={18} src={avatarUrl} style={{ display: "inline-block", marginRight: "4px" }} />
@@ -513,10 +514,17 @@ const CurrentTrafficTable = ({
 
   const getApplogAvatar = useCallback(
     (key, logName) => {
-      const logNameURI = decodeURIComponent(logName.trim());
-      const avatarDomain = APPNAMES[logNameURI.split(" ")[0].toLowerCase()];
-      const avatarUrl = `https://www.google.com/s2/favicons?domain=${avatarDomain}`;
-      return getLogAvatar(key, logNameURI, avatarUrl);
+      try {
+        const logNameURI = decodeURIComponent(logName.trim());
+        const avatarDomain = APPNAMES[logNameURI.split(" ")[0].toLowerCase()];
+        const avatarUrl = `https://www.google.com/s2/favicons?domain=${avatarDomain}`;
+        return getLogAvatar(key, logNameURI, avatarUrl);
+      } catch (e) {
+        captureException(e);
+        const avatarUrl = "https://www.google.com/s2/favicons?domain=randooooom.com"; // random url to show the unfound icon
+        const name = `unknown-${key}`;
+        return getLogAvatar(key, name, avatarUrl);
+      }
     },
     [getLogAvatar]
   );

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/index.jsx
@@ -520,6 +520,7 @@ const CurrentTrafficTable = ({
         const avatarUrl = `https://www.google.com/s2/favicons?domain=${avatarDomain}`;
         return getLogAvatar(key, logNameURI, avatarUrl);
       } catch (e) {
+        console.log("faulty logname: ", logName);
         captureException(e);
         const avatarUrl = "https://www.google.com/s2/favicons?domain=randooooom.com"; // random url to show the unfound icon
         const name = `unknown-${key}`;


### PR DESCRIPTION
was leading to `URI malformed` errors. Can be reproduced by having this rule active inside desktop app.

[faulty UA header.json](https://github.com/user-attachments/files/21123783/faulty.UA.header.json)

This does show all such instances of user agent headers under one `unknown app` option in the sidebar filters as such:

![CleanShot 2025-07-08 at 19 52 16@2x](https://github.com/user-attachments/assets/66609d41-9d73-4c1e-9ab1-b0698c28e910)

Adding a manual exception to better understand what types of values are causing this crash