### PR TITLE
chore: whitelist testing toolkit extension in manifest

### DIFF
--- a/browser-extension/mv3/src/manifest.chrome.json
+++ b/browser-extension/mv3/src/manifest.chrome.json
@@ -20,6 +20,7 @@
     "service_worker": "serviceWorker.js"
   },
   "externally_connectable": {
+    "ids": ["khkpfminnhkjeabcnhpjcfhegbbodpjk"],
     "matches": ["https://*.bsstag.com/*", "https://*.browserstack.com/*"]
   },
   "web_accessible_resources": [


### PR DESCRIPTION
Whiltelist Testing Toolkit extension in manifest so that it can communicate with Requestly Extension,

Extension is only present in chrome store right now. So only added in chrome manifest.