### PR TITLE
refactor: Stores aggregator for apiClient

### DIFF
--- a/app/src/backend/environment/types.ts
+++ b/app/src/backend/environment/types.ts
@@ -1,4 +1,7 @@
+// TODO: move all in types "features/apiClient"
 export type VariableValueType = string | number | boolean;
+
+export type EnvironmentVariableKey = string;
 
 export interface EnvironmentVariableValue {
   localValue?: VariableValueType;
@@ -7,7 +10,7 @@ export interface EnvironmentVariableValue {
   id: number;
 }
 
-export type EnvironmentVariables = Record<string, EnvironmentVariableValue>;
+export type EnvironmentVariables = Record<EnvironmentVariableKey, EnvironmentVariableValue>;
 
 export interface EnvironmentData {
   id: string;
@@ -25,7 +28,7 @@ export enum EnvironmentVariableType {
 }
 
 export type VariableExport = EnvironmentVariableValue & {
-  key: string;
+  key: EnvironmentVariableKey;
 };
 
 export enum VariableScope {

--- a/app/src/features/apiClient/helpers/modules/sync/cloud/services/FirebaseEnvSync.ts
+++ b/app/src/features/apiClient/helpers/modules/sync/cloud/services/FirebaseEnvSync.ts
@@ -55,6 +55,7 @@ export class FirebaseEnvSync implements EnvironmentInterface<ApiClientCloudMeta>
     return createNonGlobalEnvironmentInDB(this.getPrimaryId(), environmentName);
   }
   async createGlobalEnvironment(): Promise<EnvironmentData> {
+    // this is incorrectly implemented but isn't used anywhere
     return createNonGlobalEnvironmentInDB(this.getPrimaryId(), "Global Environment");
   }
 

--- a/app/src/features/apiClient/helpers/modules/sync/interfaces.ts
+++ b/app/src/features/apiClient/helpers/modules/sync/interfaces.ts
@@ -4,6 +4,7 @@ import { ErroredRecord, FileType } from "./local/services/types";
 
 export interface EnvironmentInterface<Meta extends Record<string, any>> {
   meta: Meta;
+  // implementors of getAllEnvironments are responsible to ensure creation of the globalEnvironment if doesn't already exist
   getAllEnvironments(): Promise<{
     success: boolean;
     data: { environments: EnvironmentMap; erroredRecords: ErroredRecord[] };
@@ -15,7 +16,7 @@ export interface EnvironmentInterface<Meta extends Record<string, any>> {
     data: EnvironmentData | null;
   }>;
   createNonGlobalEnvironment(environmentName: string): Promise<EnvironmentData>;
-  createGlobalEnvironment(): Promise<EnvironmentData>;
+  createGlobalEnvironment(): Promise<EnvironmentData>; // fix-me: should be removed from this interface
   createEnvironments(environments: EnvironmentData[]): Promise<EnvironmentData[]>;
   deleteEnvironment(envId: string): Promise<{ success: boolean; message?: string }>;
   updateEnvironment(
@@ -76,6 +77,7 @@ export interface ApiClientRecordsInterface<Meta extends Record<string, any>> {
 }
 
 export interface ApiClientRepositoryInterface {
+  // todo: rename to recordsRepository and environmentsRepository
   environmentVariablesRepository: EnvironmentInterface<Record<string, any>>;
   apiClientRecordsRepository: ApiClientRecordsInterface<Record<string, any>>;
 }

--- a/app/src/features/apiClient/store/APIStoresAggregator/Daemon.tsx
+++ b/app/src/features/apiClient/store/APIStoresAggregator/Daemon.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+export const Daemon: React.FC = () => {
+  // todo
+  return null;
+};

--- a/app/src/features/apiClient/store/APIStoresAggregator/hooks.ts
+++ b/app/src/features/apiClient/store/APIStoresAggregator/hooks.ts
@@ -1,0 +1,51 @@
+import { ApiRecordsState } from "features/apiClient/store/apiRecords/apiRecords.store";
+import { EnvironmentsStore } from "features/apiClient/store/environments/environments.store";
+import { ApiClientStoresContext } from "features/apiClient/store/APIStoresAggregator";
+import { useContext } from "react";
+import { useStore } from "zustand";
+import { useShallow } from "zustand/shallow";
+
+export function useApiClientStores() {
+  const repository = useContext(ApiClientStoresContext);
+  if (!repository) {
+    throw new Error("No API Client repository in context!");
+  }
+
+  return repository;
+}
+
+export function useAPIRecordsV2<T>(selector: (state: ApiRecordsState) => T) {
+  const { records } = useContext(ApiClientStoresContext);
+  if (!records) {
+    throw new Error("records store not found!");
+  }
+
+  return useStore(records, useShallow(selector));
+}
+
+export function useAPIRecordStoreV2() {
+  const { records } = useContext(ApiClientStoresContext);
+  if (!records) {
+    throw new Error("records store not found!");
+  }
+
+  return records;
+}
+
+export function useAPIEnvironmentV2<T>(selector: (state: EnvironmentsStore) => T) {
+  const { environments } = useContext(ApiClientStoresContext);
+  if (!environments) {
+    throw new Error("environments store not found!");
+  }
+
+  return useStore(environments, useShallow(selector));
+}
+
+export function useAPIEnvironmentStoreV2() {
+  const { environments } = useContext(ApiClientStoresContext);
+  if (!environments) {
+    throw new Error("environments store not found!");
+  }
+
+  return environments;
+}

--- a/app/src/features/apiClient/store/APIStoresAggregator/index.tsx
+++ b/app/src/features/apiClient/store/APIStoresAggregator/index.tsx
@@ -1,0 +1,148 @@
+import React, { createContext, ReactNode, useEffect, useMemo, useState } from "react";
+import { useApiClientRepository } from "../../helpers/modules/sync/useApiClientSyncRepo";
+import { notification } from "antd";
+import { ApiClientLoadingView } from "../../screens/apiClient/components/clientView/components/ApiClientLoadingView/ApiClientLoadingView";
+import { RQAPI } from "../../types";
+import { ErroredRecord } from "../../helpers/modules/sync/local/services/types";
+import { ApiRecordsState, createApiRecordsStore } from "../apiRecords/apiRecords.store";
+import { StoreApi } from "zustand";
+import { EnvironmentData, EnvironmentMap } from "backend/environment/types";
+import { ApiClientProvider } from "../../contexts";
+import { Daemon } from "./Daemon";
+
+import { createEnvironmentsStore, EnvironmentsStore } from "../environments/environments.store";
+
+type StorePool = {
+  records: StoreApi<ApiRecordsState>;
+  environments: StoreApi<EnvironmentsStore>;
+};
+
+type FetchedData<T> = { records: T; erroredRecords: ErroredRecord[] };
+type FetchedStoreData = {
+  records: FetchedData<RQAPI.Record[]>;
+  environments: { global: EnvironmentData; nonGlobalEnvironments: FetchedData<EnvironmentMap> };
+};
+
+export const ApiClientStoresContext = createContext<StorePool>(null);
+
+type AssemblerProps = {
+  children?: React.ReactNode;
+  data: FetchedStoreData;
+};
+const APIStoresAssembler: React.FC<AssemblerProps> = ({ children, data: { environments, records } }) => {
+  // todo: pass global separately
+  // pass errors to error store separately
+  const environmentStore = createEnvironmentsStore({
+    environments: environments.nonGlobalEnvironments.records,
+    erroredRecords: environments.nonGlobalEnvironments.erroredRecords,
+  });
+  const apiRecordsStore = createApiRecordsStore(records);
+
+  return (
+    <ApiClientStoresContext.Provider
+      value={{
+        records: apiRecordsStore,
+        environments: environmentStore,
+      }}
+    >
+      <Daemon />
+      <ApiClientProvider>{children}</ApiClientProvider>
+    </ApiClientStoresContext.Provider>
+  );
+};
+
+const APIStoresAggregator: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const { apiClientRecordsRepository, environmentVariablesRepository } = useApiClientRepository();
+
+  const [records, setRecords] = useState<FetchedStoreData["records"]>(null);
+  const [environments, setEnvironments] = useState<FetchedStoreData["environments"]>(null);
+
+  const [loadingStates, setLoadingStates] = useState<{ records: boolean; variables: boolean }>({
+    records: false,
+    variables: false,
+  });
+  const isLoading = useMemo(() => {
+    return loadingStates.records || loadingStates.variables;
+  }, [loadingStates]);
+
+  useEffect(() => {
+    setLoadingStates((prev) => {
+      return { ...prev, records: true };
+    });
+    apiClientRecordsRepository
+      .getAllRecords()
+      .then((result) => {
+        if (!result.success) {
+          notification.error({
+            message: "Could not fetch records!",
+            description: result?.message,
+            placement: "bottomRight",
+          });
+          return;
+        }
+        setRecords(result.data);
+      })
+      .catch((e) => {
+        notification.error({
+          message: "Could not fetch records!",
+          description: e.message,
+          placement: "bottomRight",
+        });
+        return;
+      })
+      .finally(() => {
+        setLoadingStates((prev) => {
+          return { ...prev, records: false };
+        });
+      });
+  }, [apiClientRecordsRepository]);
+
+  useEffect(() => {
+    setLoadingStates((prev) => {
+      return { ...prev, variables: true };
+    });
+    environmentVariablesRepository
+      .getAllEnvironments()
+      .then((result) => {
+        if (!result.success) {
+          notification.error({
+            message: "Could not fetch records!",
+            description: " result?.message",
+            placement: "bottomRight",
+          });
+          return;
+        }
+        const allEnvironments = result.data.environments;
+        const globalEnvId = environmentVariablesRepository.getGlobalEnvironmentId();
+
+        const { [globalEnvId]: globalEnv, ...otherEnvs } = allEnvironments;
+        if (!globalEnv) throw new Error("Global Environment doesn't exist");
+
+        setEnvironments({
+          global: globalEnv,
+          nonGlobalEnvironments: {
+            records: otherEnvs,
+            erroredRecords: result.data.erroredRecords,
+          },
+        });
+      })
+      .catch((e) => {
+        notification.error({
+          message: "Could not fetch records!",
+          description: e.message,
+        });
+        return;
+      })
+      .finally(() => {
+        setLoadingStates((prev) => {
+          return { ...prev, variables: true };
+        });
+      });
+  }, [environmentVariablesRepository]);
+
+  if (isLoading) return <ApiClientLoadingView />; // todo: decide if we need a new loader
+
+  return <APIStoresAssembler data={{ records, environments }}>{children}</APIStoresAssembler>;
+};
+
+export default APIStoresAggregator;

--- a/app/src/features/apiClient/store/apiRecords/ApiRecordsContextProvider.tsx
+++ b/app/src/features/apiClient/store/apiRecords/ApiRecordsContextProvider.tsx
@@ -14,7 +14,7 @@ import { ExampleCollectionsDaemon } from "features/apiClient/exampleCollections/
 
 export const ApiRecordsStoreContext = createContext<StoreApi<ApiRecordsState>>(null);
 
-// to be replaced and encapsulated within StoreProvider
+// to be replaced and encapsulated within APIStoresAggregator
 export const ApiRecordsProvider = ({ children }: { children: ReactNode }) => {
   const { apiClientRecordsRepository } = useApiClientRepository();
   const [data, setData] = useState(null);
@@ -58,7 +58,7 @@ export const ApiRecordsProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
-// to be replaced and encapsulated within APIClientContextHub
+// to be replaced and encapsulated within APIStoresAssembler
 const RecordsProvider = ({
   children,
   data,

--- a/app/src/features/apiClient/store/apiRecords/ApiRecordsContextProvider.tsx
+++ b/app/src/features/apiClient/store/apiRecords/ApiRecordsContextProvider.tsx
@@ -14,6 +14,7 @@ import { ExampleCollectionsDaemon } from "features/apiClient/exampleCollections/
 
 export const ApiRecordsStoreContext = createContext<StoreApi<ApiRecordsState>>(null);
 
+// to be replaced and encapsulated within StoreProvider
 export const ApiRecordsProvider = ({ children }: { children: ReactNode }) => {
   const { apiClientRecordsRepository } = useApiClientRepository();
   const [data, setData] = useState(null);
@@ -57,6 +58,7 @@ export const ApiRecordsProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
+// to be replaced and encapsulated within APIClientContextHub
 const RecordsProvider = ({
   children,
   data,
@@ -72,7 +74,7 @@ const RecordsProvider = ({
     <ApiRecordsStoreContext.Provider value={store}>
       <ExampleCollectionsDaemon store={store} />
       <AutoSyncLocalStoreDaemon />
-      <ApiClientProvider repository={repository}>{children}</ApiClientProvider>
+      <ApiClientProvider>{children}</ApiClientProvider>
     </ApiRecordsStoreContext.Provider>
   );
 };

--- a/app/src/features/apiClient/store/environments/environments.store.ts
+++ b/app/src/features/apiClient/store/environments/environments.store.ts
@@ -18,6 +18,7 @@ type GlobalEnvironment = Environment;
 type EnvironmentsStore = {
   // state
   version: number;
+  erroredRecords: ErroredRecord[];
   activeEnvironment?: Environment;
   globalEnvironment: GlobalEnvironment;
   environments: Map<Environment["id"], Environment>;
@@ -58,6 +59,7 @@ export const createEnvironmentsStore = ({
 
   return create<EnvironmentsStore>()((set, get) => ({
     version: 0,
+    erroredRecords,
     activeEnvironment: null,
     environments: environmentsWithVariableStore,
     globalEnvironment: environmentsWithVariableStore.get("global"), // FIXME: update hard coded id

--- a/app/src/features/apiClient/store/environments/environments.store.ts
+++ b/app/src/features/apiClient/store/environments/environments.store.ts
@@ -1,0 +1,115 @@
+import { EnvironmentMap } from "backend/environment/types";
+import { ErroredRecord } from "features/apiClient/helpers/modules/sync/local/services/types";
+import { create, StoreApi } from "zustand";
+import { createVariablesStore, VariablesStore } from "../variables/variables.store";
+
+type EnvironmentData = {
+  variables: StoreApi<VariablesStore>;
+};
+
+type Environment = {
+  id: string;
+  name: string;
+  data: EnvironmentData;
+};
+
+type GlobalEnvironment = Environment;
+
+type EnvironmentsStore = {
+  // state
+  version: number;
+  activeEnvironment?: Environment;
+  globalEnvironment: GlobalEnvironment;
+  environments: Map<Environment["id"], Environment>;
+
+  // actions
+  delete: (id: string) => void;
+  create: (params: Omit<Environment, "data">) => void;
+  update: (id: string, updates: Pick<Environment, "name">) => void;
+  getEnvironment: (id: string) => Environment;
+  getAll: () => Environment[];
+  setActive: (id?: string) => void;
+  incrementVersion: () => void;
+};
+
+const getEnvironmentsWithVariableStore = (rawEnvironments: EnvironmentMap): EnvironmentsStore["environments"] => {
+  const environmentsWithVariableStore = Object.values(rawEnvironments).map((value) => {
+    return [
+      value.id,
+      {
+        id: value.id,
+        name: value.name,
+        data: { variables: createVariablesStore({ variables: value.variables }) },
+      },
+    ] as [Environment["id"], Environment];
+  });
+
+  return new Map(environmentsWithVariableStore);
+};
+
+export const createEnvironmentsStore = ({
+  environments,
+  erroredRecords,
+}: {
+  environments: EnvironmentMap;
+  erroredRecords: ErroredRecord[];
+}) => {
+  const environmentsWithVariableStore = getEnvironmentsWithVariableStore(environments);
+
+  return create<EnvironmentsStore>()((set, get) => ({
+    version: 0,
+    activeEnvironment: null,
+    environments: environmentsWithVariableStore,
+    globalEnvironment: environmentsWithVariableStore.get("global"), // FIXME: update hard coded id
+
+    delete(id) {
+      const { environments } = get();
+      environments.delete(id);
+      set({ environments });
+      get().incrementVersion();
+    },
+
+    create({ id, name }) {
+      const { environments } = get();
+      environments.set(id, { id, name, data: { variables: createVariablesStore({ variables: {} }) } });
+      set({ environments });
+      get().incrementVersion();
+    },
+
+    update(id, updates) {
+      const { environments } = get();
+      const existingValue = environments.get(id);
+      const updatedValue = { ...existingValue, name: updates.name };
+      environments.set(id, updatedValue);
+
+      set({ environments });
+      get().incrementVersion();
+    },
+
+    getEnvironment(id) {
+      const { environments } = get();
+      return environments.get(id);
+    },
+
+    getAll() {
+      const { environments } = get();
+      return Object.values(environments).filter((env) => env.id !== "global");
+    },
+
+    setActive(id) {
+      if (!id) {
+        set({ activeEnvironment: null });
+        return;
+      }
+
+      set({ activeEnvironment: get().getEnvironment(id) });
+      get().incrementVersion();
+    },
+
+    incrementVersion() {
+      set({
+        version: get().version + 1,
+      });
+    },
+  }));
+};

--- a/app/src/features/apiClient/store/environments/environments.store.ts
+++ b/app/src/features/apiClient/store/environments/environments.store.ts
@@ -15,7 +15,7 @@ type Environment = {
 
 type GlobalEnvironment = Environment;
 
-type EnvironmentsStore = {
+export type EnvironmentsStore = {
   // state
   version: number;
   erroredRecords: ErroredRecord[];

--- a/app/src/features/apiClient/store/variables/variables.store.ts
+++ b/app/src/features/apiClient/store/variables/variables.store.ts
@@ -2,8 +2,10 @@ import { EnvironmentVariableKey, EnvironmentVariables, EnvironmentVariableValue 
 import { create } from "zustand";
 
 export type VariablesStore = {
+  // state
   data: Map<EnvironmentVariableKey, EnvironmentVariableValue>;
 
+  // actions
   delete: (key: EnvironmentVariableKey) => void;
   add: (key: EnvironmentVariableKey, variable: EnvironmentVariableValue) => void;
   update: (key: EnvironmentVariableKey, updates: Omit<EnvironmentVariableValue, "id">) => void;

--- a/app/src/features/apiClient/store/variables/variables.store.ts
+++ b/app/src/features/apiClient/store/variables/variables.store.ts
@@ -1,0 +1,57 @@
+import { EnvironmentVariableKey, EnvironmentVariables, EnvironmentVariableValue } from "backend/environment/types";
+import { create } from "zustand";
+
+export type VariablesStore = {
+  data: Map<EnvironmentVariableKey, EnvironmentVariableValue>;
+
+  delete: (key: EnvironmentVariableKey) => void;
+  add: (key: EnvironmentVariableKey, variable: EnvironmentVariableValue) => void;
+  update: (key: EnvironmentVariableKey, updates: Omit<EnvironmentVariableValue, "id">) => void;
+  get: (key: EnvironmentVariableKey) => EnvironmentVariableValue;
+  getAll: () => Map<EnvironmentVariableKey, EnvironmentVariableValue>;
+  search: (value: string) => Map<EnvironmentVariableKey, EnvironmentVariableValue>;
+};
+
+export const createVariablesStore = ({ variables }: { variables: EnvironmentVariables }) => {
+  // Need a way to tell parent that variable is updated
+  return create<VariablesStore>()((set, get) => ({
+    data: new Map(Object.entries(variables)),
+
+    delete(key) {
+      const { data } = get();
+      data.delete(key);
+      set({ data });
+    },
+
+    add(key, variable) {
+      const { data } = get();
+      data.set(key, variable);
+      set({ data });
+    },
+
+    update(key, updates) {
+      const { data } = get();
+      const existingValue = data.get(key);
+      const updatedValue = { ...existingValue, ...updates };
+
+      data.set(key, updatedValue);
+      set({ data });
+    },
+
+    get(key) {
+      const { data } = get();
+      return data.get(key);
+    },
+
+    getAll() {
+      const { data } = get();
+      return data;
+    },
+
+    search(value) {
+      const { data } = get();
+      const searchResults = Object.entries(data).filter(([key]) => key.toLowerCase().includes(value.toLowerCase()));
+      return new Map(searchResults);
+    },
+  }));
+};


### PR DESCRIPTION
builds on top of https://github.com/requestly/requestly/pull/3280 but still expects the following changes there:
- a store for errored recoreds
- updates to the `createEnvironmentStore` definition to allow passing global records