### PR TITLE
Fix web app type error

### DIFF
--- a/app/src/components/common/RuleEditorModal/index.tsx
+++ b/app/src/components/common/RuleEditorModal/index.tsx
@@ -107,8 +107,9 @@ const RuleEditorModal: React.FC<props> = ({ isOpen, handleModalClose, analyticEv
       if (ruleType === RuleType.RESPONSE && prefilledRule.ruleType === RuleType.RESPONSE) {
         // Handling prefill for graphql resource type response rule
         const { GQLDetails } = ruleData.metadata || {};
-        const pair = prefilledRule.pairs[0];
-        const sourceFilters = pair.source.filters;
+        const pair = prefilledRule.pairs?.[0];
+        if (!pair) return;
+        const sourceFilters = pair.source?.filters;
         if (GQLDetails?.operationName) {
           pair.response.resourceType = ResponseRule.ResourceType.GRAPHQL_API;
           pair.source.filters = [

--- a/app/src/components/common/RuleEditorModal/prefill.ts
+++ b/app/src/components/common/RuleEditorModal/prefill.ts
@@ -15,9 +15,14 @@ const updateRulePairSource = <T extends Rule>(data: any, rule: T): T => {
     operator: RuleSourceOperator.EQUALS,
   };
 
+  const firstPair = rule.pairs?.[0];
+  if (!firstPair) {
+    return rule;
+  }
+  
   return {
     ...rule,
-    pairs: [{ ...rule.pairs[0], source: { ...rule.pairs[0].source, ...source } }],
+    pairs: [{ ...firstPair, source: { ...firstPair.source, ...source } }],
   };
 };
 
@@ -28,12 +33,17 @@ const prefillRequestRuleData = <T extends RequestRule.Record>(data: unknown, new
     value: data?.request?.body ?? "",
   };
 
+  const firstPair = updatedRule.pairs?.[0];
+  if (!firstPair) {
+    return updatedRule;
+  }
+  
   return {
     ...updatedRule,
     pairs: [
       {
-        ...updatedRule.pairs[0],
-        request: { ...updatedRule.pairs[0].request, ...updatedRequestData },
+        ...firstPair,
+        request: { ...firstPair.request, ...updatedRequestData },
       },
     ],
   };
@@ -47,12 +57,17 @@ const prefillResponseRuleData = <T extends ResponseRule.Record>(data: unknown, n
     resourceType: ResponseRule.ResourceType.REST_API,
   };
 
+  const firstPair = updatedRule.pairs?.[0];
+  if (!firstPair) {
+    return updatedRule;
+  }
+  
   return {
     ...updatedRule,
     pairs: [
       {
-        ...updatedRule.pairs[0],
-        response: { ...updatedRule.pairs[0].response, ...updatedResponseData },
+        ...firstPair,
+        response: { ...firstPair.response, ...updatedResponseData },
       },
     ],
   };

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/DelayRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/DelayRow/index.js
@@ -12,7 +12,7 @@ const DelayRow = ({ rowIndex, pair, pairIndex, isInputDisabled }) => {
       <Col align="right" span={24} data-tour-id="rule-editor-delay-value">
         <RQInput
           type="text"
-          value={pair.delay}
+          value={pair?.delay || ""}
           placeholder="Time in ms"
           disabled={isInputDisabled}
           className="delay-rule-input display-inline-block"

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/DestinationURLRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/DestinationURLRow/index.js
@@ -161,7 +161,7 @@ const DestinationURLRow = ({ rowIndex, pair, pairIndex, isInputDisabled }) => {
           )
         }
         onBlur={preValidateURL}
-        value={pair.destination}
+        value={pair?.destination || ""}
         disabled={isInputDisabled}
         status={showInputWarning() ? "warning" : null}
       />
@@ -223,7 +223,7 @@ const DestinationURLRow = ({ rowIndex, pair, pairIndex, isInputDisabled }) => {
                 style={{
                   width: 350,
                 }}
-                value={pair.destination}
+                value={pair?.destination || ""}
                 onChange={(e) => {
                   dispatch(
                     globalActions.updateRulePairAtGivenPath({

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ReplacePartRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ReplacePartRow/index.js
@@ -22,12 +22,17 @@ const ReplacePartRow = ({ rowIndex, pair, pairIndex, isInputDisabled }) => {
     [dispatch, pairIndex]
   );
 
+  // Add null check to prevent TypeError when pair is undefined
+  if (!pair) {
+    return null;
+  }
+
   return (
     <Row align="middle" key={rowIndex} span={24} gutter={16} className="margin-top-one">
       <Col span={12} data-tour-id="rule-editor-replace-from">
         <Input
           type="text"
-          value={pair.from}
+          value={pair.from || ""}
           addonBefore="Replace"
           placeholder="This part in URL"
           disabled={isInputDisabled}
@@ -38,7 +43,7 @@ const ReplacePartRow = ({ rowIndex, pair, pairIndex, isInputDisabled }) => {
       <Col span={12} data-tour-id="rule-editor-replace-to">
         <Input
           type="text"
-          value={pair.to}
+          value={pair.to || ""}
           addonBefore="With"
           placeholder="This part"
           disabled={isInputDisabled}

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js
@@ -65,7 +65,7 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
     return (
       <Radio.Group
         onChange={(e) => onChangeRequestType(e.target.value)}
-        value={pair.request.type}
+        value={pair?.request?.type || ""}
         disabled={isInputDisabled}
         data-tour-id="rule-editor-requestbody-types"
         className="response-body-type-radio-group"

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -309,7 +309,7 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
                 );
               }}
               className="rules-pair-input"
-              value={pair.source.value}
+              value={pair?.source?.value || ""}
               disabled={isInputDisabled}
               data-selectionid="source-value"
             />

--- a/browser-extension/common/src/devtools/containers/network/details-tabs/GeneralTabContent/GeneralTabContent.tsx
+++ b/browser-extension/common/src/devtools/containers/network/details-tabs/GeneralTabContent/GeneralTabContent.tsx
@@ -20,11 +20,13 @@ const GeneralTabContent: React.FC<Props> = ({ networkEvent }) => {
     createRule(
       RuleEditorUrlFragment.REDIRECT,
       (rule) => {
-        rule.pairs[0].source = {
-          key: SourceKey.URL,
-          operator: SourceOperator.EQUALS,
-          value: networkEvent.request.url,
-        };
+        if (rule.pairs?.[0]) {
+          rule.pairs[0].source = {
+            key: SourceKey.URL,
+            operator: SourceOperator.EQUALS,
+            value: networkEvent.request.url,
+          };
+        }
         rule.name = generateRuleName("Redirect request");
         rule.description = `Redirect ${getBaseUrl(networkEvent.request.url)}`;
       },
@@ -36,13 +38,15 @@ const GeneralTabContent: React.FC<Props> = ({ networkEvent }) => {
     createRule(
       RuleEditorUrlFragment.REPLACE,
       (rule) => {
-        rule.pairs[0].source = {
-          key: SourceKey.URL,
-          operator: SourceOperator.CONTAINS,
-          value: getBaseUrl(networkEvent.request.url),
-        };
-        // @ts-ignore
-        rule.pairs[0].from = getHostFromUrl(networkEvent.request.url);
+        if (rule.pairs?.[0]) {
+          rule.pairs[0].source = {
+            key: SourceKey.URL,
+            operator: SourceOperator.CONTAINS,
+            value: getBaseUrl(networkEvent.request.url),
+          };
+          // @ts-ignore
+          rule.pairs[0].from = getHostFromUrl(networkEvent.request.url);
+        }
         rule.name = generateRuleName("Replace host");
         rule.description = `Replace host in ${getBaseUrl(networkEvent.request.url)}`;
       },
@@ -54,11 +58,13 @@ const GeneralTabContent: React.FC<Props> = ({ networkEvent }) => {
     createRule(
       RuleEditorUrlFragment.REPLACE,
       (rule) => {
-        rule.pairs[0].source = {
-          key: SourceKey.URL,
-          operator: SourceOperator.CONTAINS,
-          value: getBaseUrl(networkEvent.request.url),
-        };
+        if (rule.pairs?.[0]) {
+          rule.pairs[0].source = {
+            key: SourceKey.URL,
+            operator: SourceOperator.CONTAINS,
+            value: getBaseUrl(networkEvent.request.url),
+          };
+        }
         rule.name = generateRuleName("Modify URL");
         rule.description = `Modify ${getBaseUrl(networkEvent.request.url)}`;
       },
@@ -70,11 +76,13 @@ const GeneralTabContent: React.FC<Props> = ({ networkEvent }) => {
     createRule(
       RuleEditorUrlFragment.CANCEL,
       (rule) => {
-        rule.pairs[0].source = {
-          key: SourceKey.URL,
-          operator: SourceOperator.EQUALS,
-          value: networkEvent.request.url,
-        };
+        if (rule.pairs?.[0]) {
+          rule.pairs[0].source = {
+            key: SourceKey.URL,
+            operator: SourceOperator.EQUALS,
+            value: networkEvent.request.url,
+          };
+        }
         rule.name = generateRuleName("Cancel request");
         rule.description = `Cancel ${getBaseUrl(networkEvent.request.url)}`;
       },
@@ -86,11 +94,13 @@ const GeneralTabContent: React.FC<Props> = ({ networkEvent }) => {
     createRule(
       RuleEditorUrlFragment.DELAY,
       (rule) => {
-        rule.pairs[0].source = {
-          key: SourceKey.URL,
-          operator: SourceOperator.EQUALS,
-          value: networkEvent.request.url,
-        };
+        if (rule.pairs?.[0]) {
+          rule.pairs[0].source = {
+            key: SourceKey.URL,
+            operator: SourceOperator.EQUALS,
+            value: networkEvent.request.url,
+          };
+        }
         rule.name = generateRuleName("Delay request");
         rule.description = `Delay ${getBaseUrl(networkEvent.request.url)}`;
       },

--- a/browser-extension/common/src/devtools/containers/network/details-tabs/HeadersTabContent/HeadersTabContent.tsx
+++ b/browser-extension/common/src/devtools/containers/network/details-tabs/HeadersTabContent/HeadersTabContent.tsx
@@ -74,14 +74,16 @@ const HeadersTabContent: React.FC<Props> = ({ networkEvent }) => {
         RuleEditorUrlFragment.HEADERS,
         (rule) => {
           // @ts-ignore
-          rule.pairs[0].modifications[headerType] = [
-            {
-              type: HeaderModificationType.MODIFY,
-              header: header.name,
-              value: header.value,
-            },
-          ];
-          rule.pairs[0].source = ruleSource;
+          if (rule.pairs?.[0]) {
+            rule.pairs[0].modifications[headerType] = [
+              {
+                type: HeaderModificationType.MODIFY,
+                header: header.name,
+                value: header.value,
+              },
+            ];
+            rule.pairs[0].source = ruleSource;
+          }
           rule.name = generateRuleName(`Override ${headerType} header`);
           rule.description = `Override ${headerType.toLowerCase()} header "${header.name}" for ${ruleSource.value}`;
         },
@@ -98,14 +100,16 @@ const HeadersTabContent: React.FC<Props> = ({ networkEvent }) => {
         RuleEditorUrlFragment.HEADERS,
         (rule) => {
           // @ts-ignore
-          rule.pairs[0].modifications[headerType] = [
-            {
-              type: HeaderModificationType.REMOVE,
-              header: header.name,
-              value: "",
-            },
-          ];
-          rule.pairs[0].source = ruleSource;
+          if (rule.pairs?.[0]) {
+            rule.pairs[0].modifications[headerType] = [
+              {
+                type: HeaderModificationType.REMOVE,
+                header: header.name,
+                value: "",
+              },
+            ];
+            rule.pairs[0].source = ruleSource;
+          }
           rule.name = generateRuleName(`Delete ${headerType} header`);
           rule.description = `Delete ${headerType.toLowerCase()} header "${header.name}" for ${ruleSource.value}`;
         },
@@ -122,14 +126,16 @@ const HeadersTabContent: React.FC<Props> = ({ networkEvent }) => {
         RuleEditorUrlFragment.HEADERS,
         (rule) => {
           // @ts-ignore
-          rule.pairs[0].modifications[headerType] = [
-            {
-              type: HeaderModificationType.ADD,
-              header: "",
-              value: "",
-            },
-          ];
-          rule.pairs[0].source = ruleSource;
+          if (rule.pairs?.[0]) {
+            rule.pairs[0].modifications[headerType] = [
+              {
+                type: HeaderModificationType.ADD,
+                header: "",
+                value: "",
+              },
+            ];
+            rule.pairs[0].source = ruleSource;
+          }
           rule.name = generateRuleName(`Add ${headerType} header`);
           rule.description = `Add new ${headerType.toLowerCase()} header for ${ruleSource.value}`;
         },

--- a/browser-extension/common/src/devtools/containers/network/details-tabs/ResponseTabContent/ResponseTabContent.tsx
+++ b/browser-extension/common/src/devtools/containers/network/details-tabs/ResponseTabContent/ResponseTabContent.tsx
@@ -59,23 +59,26 @@ const ResponseTabContent: React.FC<Props> = ({ networkEvent }) => {
       RuleEditorUrlFragment.RESPONSE,
       (rule) => {
         const baseUrl = getBaseUrl(networkEvent.request.url);
-        rule.pairs[0].source = {
+        if (rule.pairs?.[0]) {
+          rule.pairs[0].source = {
           key: SourceKey.URL,
           operator: SourceOperator.CONTAINS,
           value: baseUrl,
         };
-        // @ts-ignore
-        rule.pairs[0].response = {
-          type: "static",
-          value: response || "{}",
-          resourceType: "restApi",
-          statusCode: "",
-        };
+            // @ts-ignore
+            rule.pairs[0].response = {
+              type: "static",
+              value: response || "{}",
+              resourceType: "restApi",
+              statusCode: "",
+            };
+          }
 
         if (networkEvent?.metadata?.graphQLDetails) {
           const { operationName } = networkEvent.metadata.graphQLDetails;
 
-          rule.pairs[0].source.filters = [
+          if (rule.pairs?.[0]?.source) {
+            rule.pairs[0].source.filters = [
             // @ts-ignore
             {
               requestPayload: {
@@ -85,8 +88,9 @@ const ResponseTabContent: React.FC<Props> = ({ networkEvent }) => {
             },
           ];
 
-          // @ts-ignore
-          rule.pairs[0].response.resourceType = "graphqlApi";
+            // @ts-ignore
+            rule.pairs[0].response.resourceType = "graphqlApi";
+          }
         }
 
         rule.name = generateRuleName("Modify Response Body");


### PR DESCRIPTION
Fixes `TypeError: Cannot destructure property 'from' of 't[r]' as it is undefined` by adding null and undefined checks for rule pair properties.

This error manifested as `t[r]` in minified code and was caused by widespread unsafe access to `rule.pairs[0]` or `pair` properties without validating their existence, leading to attempts to destructure or access properties on `undefined`.

---
[Slack Thread](https://requestly.slack.com/archives/C088W7MHD2A/p1754809034137739?thread_ts=1754809034.137739&cid=C088W7MHD2A)

<a href="https://cursor.com/background-agent?bcId=bc-369108f1-7fa3-4a76-b6ec-b3863d4ab80e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-369108f1-7fa3-4a76-b6ec-b3863d4ab80e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

