### PR TITLE
Fix API client collection collapse

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -296,7 +296,7 @@ export const CollectionRow: React.FC<Props> = ({
                   className="collection-name-container"
                   onMouseEnter={() => setHoveredId(record.id)}
                   onMouseLeave={() => setHoveredId("")}
-                  onClick={() => {
+                  onClick={(e) => {
                     const isExpanded = activeKey === record.id;
                     const isAlreadyActive = activeTabSourceId === record.id;
                     
@@ -308,16 +308,19 @@ export const CollectionRow: React.FC<Props> = ({
                           { preview: true }
                         );
                       }
+                      // Don't stop propagation - allow expand
                     } else {
-                      // Collection is expanded - make tab active first, then allow collapse
+                      // Collection is expanded
                       if (!isAlreadyActive) {
+                        // First click - make tab active and prevent collapse
+                        e.stopPropagation();
                         openTab(
                           new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }),
                           { preview: true }
                         );
                       }
+                      // Second click (when already active) - allow collapse by not stopping propagation
                     }
-                    // Don't stop propagation so the collapse/expand functionality also works
                   }}
                   style={{
                     opacity: isDragging ? 0.5 : 1,

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -296,11 +296,16 @@ export const CollectionRow: React.FC<Props> = ({
                   className="collection-name-container"
                   onMouseEnter={() => setHoveredId(record.id)}
                   onMouseLeave={() => setHoveredId("")}
-                  onClick={(e) => {
-                    // Open the collection tab to "select" it
-                    openTab(new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }), {
-                      preview: true,
-                    });
+                  onClick={() => {
+                    const isExpanded = activeKey === record.id;
+                    const isAlreadyActive = activeTabSourceId === record.id;
+                    // Only open a tab if currently collapsed and not already the active tab
+                    if (!isExpanded && !isAlreadyActive) {
+                      openTab(
+                        new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }),
+                        { preview: true }
+                      );
+                    }
                     // Don't stop propagation so the collapse/expand functionality also works
                   }}
                   style={{

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -299,12 +299,23 @@ export const CollectionRow: React.FC<Props> = ({
                   onClick={() => {
                     const isExpanded = activeKey === record.id;
                     const isAlreadyActive = activeTabSourceId === record.id;
-                    // Only open a tab if currently collapsed and not already the active tab
-                    if (!isExpanded && !isAlreadyActive) {
-                      openTab(
-                        new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }),
-                        { preview: true }
-                      );
+                    
+                    if (!isExpanded) {
+                      // Collection is collapsed - open tab and expand
+                      if (!isAlreadyActive) {
+                        openTab(
+                          new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }),
+                          { preview: true }
+                        );
+                      }
+                    } else {
+                      // Collection is expanded - make tab active first, then allow collapse
+                      if (!isAlreadyActive) {
+                        openTab(
+                          new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }),
+                          { preview: true }
+                        );
+                      }
                     }
                     // Don't stop propagation so the collapse/expand functionality also works
                   }}

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -258,7 +258,7 @@ export const CollectionRow: React.FC<Props> = ({
           <Collapse
             activeKey={activeKey}
             onChange={collapseChangeHandler}
-            collapsible={activeKey === record.id ? "icon" : "header"}
+            collapsible="header"
             defaultActiveKey={[record.id]}
             ghost
             className="collections-list-item collection"
@@ -296,10 +296,19 @@ export const CollectionRow: React.FC<Props> = ({
                   className="collection-name-container"
                   onMouseEnter={() => setHoveredId(record.id)}
                   onMouseLeave={() => setHoveredId("")}
-                  onClick={() => {
-                    openTab(new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }), {
-                      preview: true,
-                    });
+                  onClick={(e) => {
+                    // If collection is expanded, allow the collapse functionality to handle the click
+                    // If collection is collapsed, open the tab
+                    if (activeKey === record.id) {
+                      // Collection is expanded, let the collapse handle this click by not stopping propagation
+                      return;
+                    } else {
+                      // Collection is collapsed, open the tab
+                      e.stopPropagation();
+                      openTab(new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }), {
+                        preview: true,
+                      });
+                    }
                   }}
                   style={{
                     opacity: isDragging ? 0.5 : 1,

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -125,7 +125,7 @@ export const CollectionRow: React.FC<Props> = ({
 
       return items;
     },
-    [setIsDeleteModalOpen, updateRecordsToBeDeleted, onExportClick, record.id, record.name]
+    [setIsDeleteModalOpen, updateRecordsToBeDeleted, onExportClick]
   );
 
   const collapseChangeHandler = useCallback(

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -94,21 +94,6 @@ export const CollectionRow: React.FC<Props> = ({
           },
         },
         {
-          key: "view",
-          label: (
-            <div>
-              <MdOutlineFolder style={{ marginRight: 8 }} />
-              View
-            </div>
-          ),
-          onClick: (itemInfo) => {
-            itemInfo.domEvent?.stopPropagation?.();
-            openTab(new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }), {
-              preview: true,
-            });
-          },
-        },
-        {
           key: "1",
           label: (
             <div>
@@ -140,7 +125,7 @@ export const CollectionRow: React.FC<Props> = ({
 
       return items;
     },
-    [setIsDeleteModalOpen, updateRecordsToBeDeleted, onExportClick, openTab, record.id, record.name]
+    [setIsDeleteModalOpen, updateRecordsToBeDeleted, onExportClick, record.id, record.name]
   );
 
   const collapseChangeHandler = useCallback(
@@ -312,8 +297,11 @@ export const CollectionRow: React.FC<Props> = ({
                   onMouseEnter={() => setHoveredId(record.id)}
                   onMouseLeave={() => setHoveredId("")}
                   onClick={(e) => {
-                    // Allow the collapse/expand functionality to handle all clicks
-                    // Remove tab opening to prioritize expand/collapse behavior
+                    // Open the collection tab to "select" it
+                    openTab(new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }), {
+                      preview: true,
+                    });
+                    // Don't stop propagation so the collapse/expand functionality also works
                   }}
                   style={{
                     opacity: isDragging ? 0.5 : 1,

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -94,6 +94,21 @@ export const CollectionRow: React.FC<Props> = ({
           },
         },
         {
+          key: "view",
+          label: (
+            <div>
+              <MdOutlineFolder style={{ marginRight: 8 }} />
+              View
+            </div>
+          ),
+          onClick: (itemInfo) => {
+            itemInfo.domEvent?.stopPropagation?.();
+            openTab(new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }), {
+              preview: true,
+            });
+          },
+        },
+        {
           key: "1",
           label: (
             <div>
@@ -125,7 +140,7 @@ export const CollectionRow: React.FC<Props> = ({
 
       return items;
     },
-    [setIsDeleteModalOpen, updateRecordsToBeDeleted, onExportClick]
+    [setIsDeleteModalOpen, updateRecordsToBeDeleted, onExportClick, openTab, record.id, record.name]
   );
 
   const collapseChangeHandler = useCallback(
@@ -297,18 +312,8 @@ export const CollectionRow: React.FC<Props> = ({
                   onMouseEnter={() => setHoveredId(record.id)}
                   onMouseLeave={() => setHoveredId("")}
                   onClick={(e) => {
-                    // If collection is expanded, allow the collapse functionality to handle the click
-                    // If collection is collapsed, open the tab
-                    if (activeKey === record.id) {
-                      // Collection is expanded, let the collapse handle this click by not stopping propagation
-                      return;
-                    } else {
-                      // Collection is collapsed, open the tab
-                      e.stopPropagation();
-                      openTab(new CollectionViewTabSource({ id: record.id, title: record.name || "New Collection" }), {
-                        preview: true,
-                      });
-                    }
+                    // Allow the collapse/expand functionality to handle all clicks
+                    // Remove tab opening to prioritize expand/collapse behavior
                   }}
                   style={{
                     opacity: isDragging ? 0.5 : 1,


### PR DESCRIPTION
Make API Client collection collapsible by clicking anywhere on the item.

This resolves a conflict between collection collapse and tab opening, allowing the entire header to collapse the item when expanded, while retaining the ability to open the collection in a tab when it is collapsed.

---
[Slack Thread](https://requestly.slack.com/archives/CJQKDQABH/p1754980752939279?thread_ts=1754980752.939279&cid=CJQKDQABH)

<a href="https://cursor.com/background-agent?bcId=bc-08fbdae3-6c9f-44b5-b1e9-e5a976fcebe8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08fbdae3-6c9f-44b5-b1e9-e5a976fcebe8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clicking a collection header now opens the collection in a preview tab (title uses collection name or "New Collection") only when the panel is collapsed and the collection tab isn’t already active, while preserving expand/collapse behavior.
* **Refactor**
  * Collapse behavior standardized to trigger from the header only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->