### PR TITLE
Fix map is not a function error

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/utils.ts
+++ b/app/src/features/apiClient/screens/apiClient/utils.ts
@@ -171,13 +171,17 @@ export const sanitizeEntry = (entry: RQAPI.HttpApiEntry, removeDisabledKeys = tr
     if (!supportsRequestBody(entry.request.method)) {
       sanitizedEntry.request.body = null;
     } else if (entry.request.contentType === RequestContentType.FORM) {
+      // Ensure body is an array before sanitizing
+      const formBody = Array.isArray(entry.request.body) ? entry.request.body : [];
       sanitizedEntry.request.body = sanitizeKeyValuePairs(
-        entry.request.body as RQAPI.RequestFormBody,
+        formBody as RQAPI.RequestFormBody,
         removeDisabledKeys
       );
     } else if (entry.request.contentType === RequestContentType.MULTIPART_FORM) {
+      // Ensure body is an array before sanitizing
+      const multipartBody = Array.isArray(entry.request.body) ? entry.request.body : [];
       sanitizedEntry.request.body = sanitizeKeyValuePairs(
-        entry.request.body as RQAPI.MultipartFormBody,
+        multipartBody as RQAPI.MultipartFormBody,
         removeDisabledKeys
       );
     }
@@ -193,6 +197,11 @@ export const sanitizeKeyValuePairs = <T extends { key: string; isEnabled: boolea
   keyValuePairs: T[],
   removeDisabledKeys = true
 ): T[] => {
+  // Ensure keyValuePairs is an array, default to empty array if not
+  if (!Array.isArray(keyValuePairs)) {
+    return [];
+  }
+  
   return keyValuePairs
     .map((pair) => ({
       ...pair,


### PR DESCRIPTION
Add defensive array checks to `sanitizeKeyValuePairs` and its callers to prevent `TypeError: .map is not a function`.

This fixes a runtime error occurring when `entry.request.body` or `keyValuePairs` are unexpectedly not arrays, ensuring robust handling of potentially malformed or missing data.

---
[Slack Thread](https://requestly.slack.com/archives/C088W7MHD2A/p1755450975658319?thread_ts=1755450975.658319&cid=C088W7MHD2A)

<a href="https://cursor.com/background-agent?bcId=bc-4e9a1d61-9562-4bd2-93ea-12d8c9c51900">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e9a1d61-9562-4bd2-93ea-12d8c9c51900">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

