### PR TITLE
In-app Share on Linkedin banner

### DIFF
--- a/app/src/componentsV2/AppNotificationBanner/banner.types.ts
+++ b/app/src/componentsV2/AppNotificationBanner/banner.types.ts
@@ -19,6 +19,7 @@ export enum BANNER_ACTIONS {
   CONVERT_TO_ANNUAL_PLAN = "convert_to_annual_plan",
   SEE_PLANS = "see_plans",
   REDIRECT_TO_CHROME_STORE_REVIEWS = "redirect_to_chrome_store_reviews",
+  REDIRECT_TO_LINKEDIN_FORM = "redirect_to_linkedin_form",
 }
 
 export enum BANNER_ID {
@@ -29,6 +30,7 @@ export enum BANNER_ID {
   CONVERT_TO_ANNUAL_PLAN = "convert_to_annual_plan",
   BILLING_TEAM_PLAN_REMINDER = "billing_team_plan_reminder",
   CHROME_STORE_REVIEWS = "chrome_store_reviews",
+  SHARE_ON_LINKEDIN = "share_on_linkedin",
 }
 
 export interface Banner {

--- a/app/src/componentsV2/AppNotificationBanner/hooks/useBannerAction.ts
+++ b/app/src/componentsV2/AppNotificationBanner/hooks/useBannerAction.ts
@@ -62,6 +62,13 @@ export const useBannerAction = (
           dispatch(globalActions.toggleActiveModal({ modalName: "pricingModal", newValue: true }));
         },
       },
+      [BANNER_ACTIONS.REDIRECT_TO_LINKEDIN_FORM]: {
+        label: "Share Now",
+        type: "primary",
+        onClick: () => {
+          redirectToUrl(LINKS.SHARE_ON_LINKEDIN_FORM, true);
+        },
+      },
       [BANNER_ACTIONS.REDIRECT_TO_CHROME_STORE_REVIEWS]: {
         label: "Review Now",
         type: "primary",

--- a/app/src/config/constants/sub/links.js
+++ b/app/src/config/constants/sub/links.js
@@ -163,6 +163,8 @@ const LINKS = {
   DOWNLOAD_CRX: "https://requestly.com/downloads/crx/",
 
   DOWNLOAD_CHROME_EXTENSION_ZIP: "https://rqst.ly/chrome/zip",
+
+  SHARE_ON_LINKEDIN_FORM: "https://app.formbricks.com/s/gsfvea1k3n53is5fit337ibp",
 };
 
 export default LINKS;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a “Share on LinkedIn” notification banner with a primary “Share Now” button that redirects users to a LinkedIn sharing form.
  * Added a dedicated link to the LinkedIn sharing form within the app’s link set for easy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->