### PR TITLE
fix: add support to resolve url before graphqQL introspection query

### DIFF
--- a/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestExecutor.ts
+++ b/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestExecutor.ts
@@ -47,7 +47,6 @@ enum RequestErrorMessage {
 export class HttpRequestExecutor {
   private abortController: AbortController;
   private entryDetails: RQAPI.HttpApiEntry;
-  private collectionId: RQAPI.ApiClientRecord["collectionId"];
   private internalFunctions: InternalFunctions;
   private renderedVariables: Record<string, unknown> = {};
   constructor(

--- a/app/src/features/apiClient/hooks/useGraphQLIntrospection.ts
+++ b/app/src/features/apiClient/hooks/useGraphQLIntrospection.ts
@@ -2,25 +2,31 @@ import { useGraphQLRecordStore } from "./useGraphQLRecordStore";
 import { fetchGraphQLIntrospectionData } from "../helpers/introspectionQuery";
 import { useSelector } from "react-redux";
 import { getAppMode } from "store/selectors";
+import { renderVariables } from "backend/environment/utils";
+import { useApiClientFeatureContext } from "../contexts/meta";
 
 export const useGraphQLIntrospection = () => {
   const [
+    recordId,
     url,
     setIntrospectionData,
     setIsFetchingIntrospectionData,
     setHasIntrospectionFailed,
   ] = useGraphQLRecordStore((state) => [
+    state.recordId,
     state.entry.request.url,
     state.setIntrospectionData,
     state.setIsFetchingIntrospectionData,
     state.setHasIntrospectionFailed,
   ]);
   const appMode = useSelector(getAppMode);
+  const ctx = useApiClientFeatureContext();
 
   const introspectAndSaveSchema = async () => {
     setIsFetchingIntrospectionData(true);
     try {
-      const introspectionData = await fetchGraphQLIntrospectionData(url, appMode);
+      const { result: renderedUrl } = renderVariables(url, recordId, ctx);
+      const introspectionData = await fetchGraphQLIntrospectionData(renderedUrl, appMode);
       if (!introspectionData) {
         throw new Error("No introspection data received");
       }

--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/GraphQLClientView.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/GraphQLClientView.tsx
@@ -544,7 +544,7 @@ const WithGraphQLRecordProvider = (Component: React.ComponentType<any>) => {
   return (props: any) => {
     return (
       <ErrorBoundary>
-        <GraphQLRecordProvider entry={props.apiEntryDetails.data}>
+        <GraphQLRecordProvider entry={props.apiEntryDetails.data} recordId={props.apiEntryDetails.id}>
           <Component {...props} />
         </GraphQLRecordProvider>
       </ErrorBoundary>

--- a/app/src/features/apiClient/store/apiRecord/base.ts
+++ b/app/src/features/apiClient/store/apiRecord/base.ts
@@ -2,6 +2,7 @@ import { RQAPI } from "features/apiClient/types";
 
 export type BaseApiEntryStoreState<T extends RQAPI.ApiEntry = RQAPI.ApiEntry, TAdditionalData = {}> = {
   entry: T;
+  recordId: RQAPI.ApiRecord["id"];
   hasUnsavedChanges: boolean;
   updateEntryRequest: (patch: Partial<T["request"]>) => void;
   updateEntryResponse: (response: T["response"]) => void;
@@ -15,11 +16,13 @@ export type BaseApiEntryStoreState<T extends RQAPI.ApiEntry = RQAPI.ApiEntry, TA
 
 export const createBaseApiEntryState = <T extends RQAPI.ApiEntry>(
   entry: T,
+  recordId: RQAPI.ApiRecord["id"],
   set: any,
   get: any
 ): BaseApiEntryStoreState<T, {}> => {
   // type a = setType<T>;
   return {
+    recordId,
     entry,
     hasUnsavedChanges: false,
     updateEntryRequest: (patch: Partial<T["request"]>) => {

--- a/app/src/features/apiClient/store/apiRecord/graphqlRecord/GraphQLRecordContextProvider.tsx
+++ b/app/src/features/apiClient/store/apiRecord/graphqlRecord/GraphQLRecordContextProvider.tsx
@@ -5,7 +5,15 @@ import { RQAPI } from "features/apiClient/types";
 
 export const GraphQLRecordStoreContext = createContext<StoreApi<GraphQLRecordState> | null>(null);
 
-export const GraphQLRecordProvider = ({ children, entry }: { children: ReactNode; entry: RQAPI.GraphQLApiEntry }) => {
-  const [store] = useState(() => createGraphQLRecordStore(entry));
+export const GraphQLRecordProvider = ({
+  children,
+  entry,
+  recordId,
+}: {
+  children: ReactNode;
+  entry: RQAPI.GraphQLApiEntry;
+  recordId: RQAPI.ApiRecord["id"];
+}) => {
+  const [store] = useState(() => createGraphQLRecordStore(entry, recordId));
   return <GraphQLRecordStoreContext.Provider value={store}>{children}</GraphQLRecordStoreContext.Provider>;
 };

--- a/app/src/features/apiClient/store/apiRecord/graphqlRecord/graphqlRecord.store.ts
+++ b/app/src/features/apiClient/store/apiRecord/graphqlRecord/graphqlRecord.store.ts
@@ -15,7 +15,7 @@ export type GraphQLRecordState = BaseApiEntryStoreState<RQAPI.GraphQLApiEntry> &
   updateOperationNames: (newNames: string[]) => void;
 };
 
-export function createGraphQLRecordStore(entry: RQAPI.GraphQLApiEntry) {
+export function createGraphQLRecordStore(entry: RQAPI.GraphQLApiEntry, recordId: RQAPI.ApiRecord["id"]) {
   return create<GraphQLRecordState>()((set, get) => ({
     operationNames: extractOperationNames(entry.request.operation),
     introspectionData: null,
@@ -25,6 +25,6 @@ export function createGraphQLRecordStore(entry: RQAPI.GraphQLApiEntry) {
     setHasIntrospectionFailed: (hasFailed: boolean) => set({ hasIntrospectionFailed: hasFailed }),
     setIntrospectionData: (data: any) => set({ introspectionData: data }),
     updateOperationNames: (newNames: string[]) => set({ operationNames: newNames }),
-    ...createBaseApiEntryState(entry, set, get),
+    ...createBaseApiEntryState(entry, recordId, set, get),
   }));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - GraphQL introspection now supports environment-variable rendering, allowing URLs to dynamically adapt to the active record and environment.
  - Improved GraphQL client handling of record identifiers, ensuring the correct record context is applied across views for more reliable querying and introspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->