### PR TITLE
fix: headers not being disabled in graphql changes

### DIFF
--- a/app/src/features/apiClient/helpers/graphQLRequestExecutor/GraphQLRequestExecutor.ts
+++ b/app/src/features/apiClient/helpers/graphQLRequestExecutor/GraphQLRequestExecutor.ts
@@ -4,6 +4,7 @@ import {
   graphQLEntryToHttpEntryAdapter,
   httpEntryToGraphQLEntryAdapter,
 } from "../../screens/apiClient/components/views/graphql/utils";
+import { sanitizeEntry } from "features/apiClient/screens/apiClient/utils";
 
 export class GraphQLRequestExecutor extends HttpRequestExecutor {
   /**
@@ -29,7 +30,7 @@ export class GraphQLRequestExecutor extends HttpRequestExecutor {
     const httpRequestEntry = graphQLEntryToHttpEntryAdapter(graphQLRequestEntry);
 
     this.updateEntryDetails({
-      entry: httpRequestEntry,
+      entry: sanitizeEntry(httpRequestEntry),
       recordId: record.id,
       collectionId: record.collectionId,
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sanitized GraphQL request entries before saving, preventing invalid or sensitive data from being stored in request history.
  - Reduces errors when loading, displaying, or re-running past requests and ensures cleaner, more consistent records across sessions.
  - Users may notice improved reliability in request history behavior and fewer edge-case failures related to unusual characters or payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->