### PR TITLE
style: add message to restart the app in desktop error boundary

### DIFF
--- a/app/src/features/apiClient/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/src/features/apiClient/components/ErrorBoundary/ErrorBoundary.tsx
@@ -8,6 +8,8 @@ import { NativeError } from "errors/NativeError";
 import { useSelector } from "react-redux";
 import { getActiveWorkspace } from "store/slices/workspaces/selectors";
 import { WorkspaceType } from "types";
+import { isDesktopMode } from "utils/AppUtils";
+import { Alert } from "antd";
 
 interface Props {
   children: React.ReactNode;
@@ -143,6 +145,7 @@ class ApiClientErrorBoundary extends React.Component<Props, State> {
               </div>
             </div>
             {this.getCustomError(error)}
+            {isDesktopMode() ? <Alert type="warning" message="Try restarting the app to fix this issue." /> : null}
             <div className="error-boundary__contact">
               If the issue persists, contact <a href="mailto:contact@requestly.io">support</a>
             </div>

--- a/app/src/features/apiClient/components/ErrorBoundary/errorboundary.scss
+++ b/app/src/features/apiClient/components/ErrorBoundary/errorboundary.scss
@@ -47,4 +47,14 @@
       gap: 16px;
     }
   }
+
+  .ant-alert {
+    padding: 8px;
+    margin-bottom: 8px;
+
+    &-message {
+      font-size: var(--requestly-font-size-sm);
+      color: var(--requestly-color-warning-500);
+    }
+  }
 }


### PR DESCRIPTION
<img width="3014" height="1734" alt="CleanShot 2025-08-21 at 19 52 37@2x" src="https://github.com/user-attachments/assets/6339b313-c9ba-4976-b4ff-734e7b5b4bb7" />
