### PR TITLE
add redirect action for Notion page in banner actions

### DIFF
--- a/app/src/componentsV2/AppNotificationBanner/banner.types.ts
+++ b/app/src/componentsV2/AppNotificationBanner/banner.types.ts
@@ -20,6 +20,7 @@ export enum BANNER_ACTIONS {
   SEE_PLANS = "see_plans",
   REDIRECT_TO_CHROME_STORE_REVIEWS = "redirect_to_chrome_store_reviews",
   REDIRECT_TO_LINKEDIN_FORM = "redirect_to_linkedin_form",
+  REDIRECT_TO_NOTION_PAGE = "redirect_to_notion_page",
 }
 
 export enum BANNER_ID {

--- a/app/src/componentsV2/AppNotificationBanner/hooks/useBannerAction.ts
+++ b/app/src/componentsV2/AppNotificationBanner/hooks/useBannerAction.ts
@@ -62,6 +62,13 @@ export const useBannerAction = (
           dispatch(globalActions.toggleActiveModal({ modalName: "pricingModal", newValue: true }));
         },
       },
+      [BANNER_ACTIONS.REDIRECT_TO_NOTION_PAGE]: {
+        label: "Share Now",
+        type: "primary",
+        onClick: () => {
+          redirectToUrl(LINKS.NOTION_PAGE_FOR_PROMOTION, true);
+        },
+      },
       [BANNER_ACTIONS.REDIRECT_TO_LINKEDIN_FORM]: {
         label: "Share Now",
         type: "primary",

--- a/app/src/config/constants/sub/links.js
+++ b/app/src/config/constants/sub/links.js
@@ -165,6 +165,9 @@ const LINKS = {
   DOWNLOAD_CHROME_EXTENSION_ZIP: "https://rqst.ly/chrome/zip",
 
   SHARE_ON_LINKEDIN_FORM: "https://app.formbricks.com/s/gsfvea1k3n53is5fit337ibp",
+
+  NOTION_PAGE_FOR_PROMOTION:
+    "https://requestly.notion.site/Help-Us-Grow-Requestly-Get-4-Months-Free-25cd193f3c998015ad1dfab733e8cfd2?source=copy_link",
 };
 
 export default LINKS;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Share Now” action to in-app notification banners. Clicking it opens our promotion page in a new tab, guiding users on how to support Requestly and claim extended free access.
  - The new action appears alongside existing banner actions where applicable, without changing current behavior for other actions.
- Documentation
  - Updated internal link configuration to include the promotion page used by the new banner action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->