### PR TITLE
fix: set user role as admin for local workspaces

### DIFF
--- a/app/src/hooks/useCurrentWorkspaceUserRole.ts
+++ b/app/src/hooks/useCurrentWorkspaceUserRole.ts
@@ -1,4 +1,4 @@
-import { WorkspaceMemberRole } from "features/workspaces/types";
+import { WorkspaceMemberRole, WorkspaceType } from "features/workspaces/types";
 import { useSelector } from "react-redux";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
 import { getActiveWorkspace } from "store/slices/workspaces/selectors";
@@ -13,6 +13,10 @@ export const useCurrentWorkspaceUserRole = (): { role: WorkspaceMemberRole | und
 
   // Private workspace
   if (!activeWorkspace?.id) {
+    return { role: WorkspaceMemberRole.admin };
+  }
+
+  if (activeWorkspace?.workspaceType === WorkspaceType.LOCAL) {
     return { role: WorkspaceMemberRole.admin };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Local workspaces now grant full admin permissions by default, enabling full management without account checks.
- Bug Fixes
  - Improved role detection to handle edge cases more gracefully, reducing unexpected permission issues.
  - Ensures users without authentication or workspaces lacking an ID are treated as admins when appropriate, maintaining uninterrupted access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->