### PR TITLE
fix: curl imports breaking when content type is multipart-formdata

### DIFF
--- a/app/src/features/apiClient/store/ApiClientFilesContextProvider.tsx
+++ b/app/src/features/apiClient/store/ApiClientFilesContextProvider.tsx
@@ -2,7 +2,7 @@ import { StoreApi } from "zustand";
 import { ApiClientFile, ApiClientFilesStore, createApiClientFilesStore, FileId } from "./apiClientFilesStore";
 import { createContext, ReactNode, useMemo } from "react";
 import { RequestContentType, RQAPI } from "../types";
-import { isHttpApiRecord } from "../screens/apiClient/utils";
+import { generateKeyValuePairs, isHttpApiRecord } from "../screens/apiClient/utils";
 
 export const ApiClientFilesContext = createContext<StoreApi<ApiClientFilesStore>>(null);
 
@@ -22,9 +22,15 @@ export const ApiClientFilesProvider = ({
     for (const record of records) {
       if (record.type === RQAPI.RecordType.API) {
         if (isHttpApiRecord(record) && record.data.request.contentType === RequestContentType.MULTIPART_FORM) {
-          const requestBody = record.data.request.body as RQAPI.MultipartFormBody;
-          if(!requestBody) {
+          let requestBody = record.data.request.body as RQAPI.MultipartFormBody;
+
+          if (!requestBody) {
             continue;
+          }
+
+          // hotfix for existing requests
+          if (!Array.isArray(requestBody)) {
+            requestBody = generateKeyValuePairs(requestBody);
           }
           for (const bodyEntry of requestBody) {
             const bodyValue = bodyEntry.value as RQAPI.FormDataKeyValuePair["value"];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed parsing of multipart/form-data in the API Client so form fields and file uploads are reliably recognized.
  - Improved cURL import handling for form and multipart content types to generate correct request bodies.
  - Added resilience to malformed or non-array request bodies to prevent errors and ensure smooth execution.
  - Stabilized file detection and collection within requests for more accurate uploads.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->