### PR TITLE
[ONCALL-11] fix: clear tabs when reload or go back is clicked

### DIFF
--- a/app/src/features/apiClient/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/src/features/apiClient/components/ErrorBoundary/ErrorBoundary.tsx
@@ -10,6 +10,7 @@ import { getActiveWorkspace } from "store/slices/workspaces/selectors";
 import { WorkspaceType } from "types";
 import { isDesktopMode } from "utils/AppUtils";
 import { Alert } from "antd";
+import { getTabServiceActions } from "componentsV2/Tabs/tabUtils";
 
 interface Props {
   children: React.ReactNode;
@@ -127,6 +128,7 @@ class ApiClientErrorBoundary extends React.Component<Props, State> {
   }
 
   private handleGoBack = () => {
+    getTabServiceActions().resetTabs(true);
     this.setState({ hasError: false, error: null });
   };
 
@@ -150,7 +152,14 @@ class ApiClientErrorBoundary extends React.Component<Props, State> {
               If the issue persists, contact <a href="mailto:contact@requestly.io">support</a>
             </div>
             <div className="error-boundary__actions">
-              <RQButton onClick={() => window.location.reload()}>Reload</RQButton>
+              <RQButton
+                onClick={() => {
+                  getTabServiceActions().resetTabs(true);
+                  window.location.reload();
+                }}
+              >
+                Reload
+              </RQButton>
               <RQButton type="primary" onClick={this.handleGoBack}>
                 Go Back
               </RQButton>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery in the API Client. “Go Back” and “Reload” now reset open tabs before navigating, preventing stale or stuck states and ensuring a clean restart after failures.
  * Reduces instances of stuck/blank tabs after an error, minimizing the need to manually close tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->