### PR TITLE
[ONCALL-8] fix: close corrupted tabs

### DIFF
--- a/app/src/componentsV2/Tabs/helpers/baseTabSource.ts
+++ b/app/src/componentsV2/Tabs/helpers/baseTabSource.ts
@@ -48,7 +48,7 @@ export class BaseTabSource implements AbstractTabSource {
   }
 
   getIsValidTab(): boolean {
-    throw new NativeError("getIsValidTab not implemented!");
+    throw new NativeError("getIsValidTab is not implemented!");
   }
 
   getTabContext() {

--- a/app/src/componentsV2/Tabs/helpers/baseTabSource.ts
+++ b/app/src/componentsV2/Tabs/helpers/baseTabSource.ts
@@ -2,6 +2,8 @@ import React from "react";
 import { AbstractTabSource } from "./tabSource";
 import { TabSourceMetadata } from "../types";
 import { ContextId } from "features/apiClient/contexts/contextId.context";
+import { NativeError } from "errors/NativeError";
+import { getApiClientFeatureContext } from "features/apiClient/commands/store.utils";
 
 export class BaseTabSource implements AbstractTabSource {
   component: NonNullable<React.ReactNode>;
@@ -43,5 +45,20 @@ export class BaseTabSource implements AbstractTabSource {
 
   getIsNewTab(): boolean {
     return this.metadata.isNewTab ?? false;
+  }
+
+  getIsValidTab(): boolean {
+    throw new NativeError("getIsValidTab not implemented!");
+  }
+
+  getTabContext() {
+    const contextId = this.metadata.context?.id;
+    const context = getApiClientFeatureContext(contextId);
+
+    if (!context) {
+      throw new NativeError("Tab context does not exist!").addContext({ metadata: this.metadata });
+    }
+
+    return context;
   }
 }

--- a/app/src/componentsV2/Tabs/helpers/baseTabSource.ts
+++ b/app/src/componentsV2/Tabs/helpers/baseTabSource.ts
@@ -47,6 +47,10 @@ export class BaseTabSource implements AbstractTabSource {
   }
 
   getIsValidTab(ctx: unknown): boolean {
-    throw new NativeError("getIsValidTab is not implemented!").addContext({ ctx });
+    throw new NativeError("getIsValidTab is not implemented!").addContext({
+      ctx,
+      metadata: this.metadata,
+      sourceType: this.type,
+    });
   }
 }

--- a/app/src/componentsV2/Tabs/helpers/baseTabSource.ts
+++ b/app/src/componentsV2/Tabs/helpers/baseTabSource.ts
@@ -3,7 +3,6 @@ import { AbstractTabSource } from "./tabSource";
 import { TabSourceMetadata } from "../types";
 import { ContextId } from "features/apiClient/contexts/contextId.context";
 import { NativeError } from "errors/NativeError";
-import { getApiClientFeatureContext } from "features/apiClient/commands/store.utils";
 
 export class BaseTabSource implements AbstractTabSource {
   component: NonNullable<React.ReactNode>;
@@ -47,18 +46,7 @@ export class BaseTabSource implements AbstractTabSource {
     return this.metadata.isNewTab ?? false;
   }
 
-  getIsValidTab(): boolean {
-    throw new NativeError("getIsValidTab is not implemented!");
-  }
-
-  getTabContext() {
-    const contextId = this.metadata.context?.id;
-    const context = getApiClientFeatureContext(contextId);
-
-    if (!context) {
-      throw new NativeError("Tab context does not exist!").addContext({ metadata: this.metadata });
-    }
-
-    return context;
+  getIsValidTab(ctx: unknown): boolean {
+    throw new NativeError("getIsValidTab is not implemented!").addContext({ ctx });
   }
 }

--- a/app/src/componentsV2/Tabs/helpers/tabSource.ts
+++ b/app/src/componentsV2/Tabs/helpers/tabSource.ts
@@ -1,5 +1,6 @@
 import React from "react";
 import { TabSourceMetadata } from "../types";
+import { ApiClientFeatureContext } from "features/apiClient/store/apiClientFeatureContext/apiClientFeatureContext.store";
 
 export abstract class AbstractTabSource {
   abstract component: NonNullable<React.ReactNode>;
@@ -15,4 +16,6 @@ export abstract class AbstractTabSource {
   abstract getUrlPath(): string;
   abstract getIcon(): React.ReactNode;
   abstract getIsNewTab(): boolean;
+  abstract getIsValidTab(): boolean;
+  abstract getTabContext(): ApiClientFeatureContext;
 }

--- a/app/src/componentsV2/Tabs/helpers/tabSource.ts
+++ b/app/src/componentsV2/Tabs/helpers/tabSource.ts
@@ -1,6 +1,5 @@
 import React from "react";
 import { TabSourceMetadata } from "../types";
-import { ApiClientFeatureContext } from "features/apiClient/store/apiClientFeatureContext/apiClientFeatureContext.store";
 
 export abstract class AbstractTabSource {
   abstract component: NonNullable<React.ReactNode>;
@@ -16,6 +15,5 @@ export abstract class AbstractTabSource {
   abstract getUrlPath(): string;
   abstract getIcon(): React.ReactNode;
   abstract getIsNewTab(): boolean;
-  abstract getIsValidTab(): boolean;
-  abstract getTabContext(): ApiClientFeatureContext;
+  abstract getIsValidTab(ctx: unknown): boolean;
 }

--- a/app/src/componentsV2/Tabs/store/tabServiceStore.ts
+++ b/app/src/componentsV2/Tabs/store/tabServiceStore.ts
@@ -52,6 +52,7 @@ type TabActions = {
   getTabIdBySource: (sourceId: SourceId, sourceName: SourceName) => TabId | undefined;
   getTabStateBySource: (sourceId: SourceId, sourceName: SourceName) => TabState | undefined;
   consumeIgnorePath: () => boolean;
+  setIgnorePath: (ignorePath: boolean) => void;
 };
 
 export type TabServiceStore = TabServiceState & TabActions;
@@ -74,6 +75,10 @@ const createTabServiceStore = () => {
     persist(
       (set, get) => ({
         ...initialState,
+
+        setIgnorePath(ignorePath) {
+          set({ ignorePath });
+        },
 
         consumeIgnorePath() {
           const { ignorePath } = get();

--- a/app/src/features/apiClient/commands/context/index.ts
+++ b/app/src/features/apiClient/commands/context/index.ts
@@ -1,3 +1,3 @@
 export { refreshContext } from "./refreshContext.command";
-export { setupContext, _setupContext } from "./setupContext.command";
-export { setupContextWithRepo, _setupContextWithRepo } from "./setupContextWithRepo.command";
+export { setupContext, setupContextWithoutMarkingLoaded } from "./setupContext.command";
+export { setupContextWithRepo, setupContextWithRepoWithoutMarkingLoaded } from "./setupContextWithRepo.command";

--- a/app/src/features/apiClient/commands/context/index.ts
+++ b/app/src/features/apiClient/commands/context/index.ts
@@ -1,3 +1,3 @@
 export { refreshContext } from "./refreshContext.command";
-export { setupContext } from "./setupContext.command";
-export { setupContextWithRepo } from "./setupContextWithRepo.command";
+export { setupContext, _setupContext } from "./setupContext.command";
+export { setupContextWithRepo, _setupContextWithRepo } from "./setupContextWithRepo.command";

--- a/app/src/features/apiClient/commands/context/setupContext.command.ts
+++ b/app/src/features/apiClient/commands/context/setupContext.command.ts
@@ -1,5 +1,5 @@
 import localStoreRepository from "features/apiClient/helpers/modules/sync/localStore/ApiClientLocalStorageRepository";
-import { setupContextWithRepo } from "./setupContextWithRepo.command";
+import { _setupContextWithRepo, setupContextWithRepo } from "./setupContextWithRepo.command";
 import { ApiClientLocalRepository } from "features/apiClient/helpers/modules/sync/local";
 import { ApiClientCloudRepository } from "features/apiClient/helpers/modules/sync/cloud";
 import { ApiClientFeatureContext } from "features/apiClient/store/apiClientFeatureContext/apiClientFeatureContext.store";
@@ -28,5 +28,14 @@ export const setupContext = async (
 ): Promise<{ id: ApiClientFeatureContext["id"]; name?: string }> => {
   const repository = createRepository(workspace, user);
   const id = await setupContextWithRepo(workspace.id, repository);
+  return { id };
+};
+
+export const _setupContext = async (
+  workspace: Workspace,
+  user: UserDetails
+): Promise<{ id: ApiClientFeatureContext["id"]; name?: string }> => {
+  const repository = createRepository(workspace, user);
+  const id = await _setupContextWithRepo(workspace.id, repository);
   return { id };
 };

--- a/app/src/features/apiClient/commands/context/setupContext.command.ts
+++ b/app/src/features/apiClient/commands/context/setupContext.command.ts
@@ -1,5 +1,5 @@
 import localStoreRepository from "features/apiClient/helpers/modules/sync/localStore/ApiClientLocalStorageRepository";
-import { _setupContextWithRepo, setupContextWithRepo } from "./setupContextWithRepo.command";
+import { setupContextWithRepoWithoutMarkingLoaded, setupContextWithRepo } from "./setupContextWithRepo.command";
 import { ApiClientLocalRepository } from "features/apiClient/helpers/modules/sync/local";
 import { ApiClientCloudRepository } from "features/apiClient/helpers/modules/sync/cloud";
 import { ApiClientFeatureContext } from "features/apiClient/store/apiClientFeatureContext/apiClientFeatureContext.store";
@@ -31,11 +31,11 @@ export const setupContext = async (
   return { id };
 };
 
-export const _setupContext = async (
+export const setupContextWithoutMarkingLoaded = async (
   workspace: Workspace,
   user: UserDetails
 ): Promise<{ id: ApiClientFeatureContext["id"]; name?: string }> => {
   const repository = createRepository(workspace, user);
-  const id = await _setupContextWithRepo(workspace.id, repository);
+  const id = await setupContextWithRepoWithoutMarkingLoaded(workspace.id, repository);
   return { id };
 };

--- a/app/src/features/apiClient/commands/context/setupContextWithRepo.command.ts
+++ b/app/src/features/apiClient/commands/context/setupContextWithRepo.command.ts
@@ -22,7 +22,7 @@ export type ContextSetupData = {
   erroredRecords: { apiErroredRecords: ErroredRecord[]; environmentErroredRecords: ErroredRecord[] };
 };
 
-export const _setupContextWithRepo = async (
+export const setupContextWithRepoWithoutMarkingLoaded = async (
   workspaceId: ApiClientFeatureContext["workspaceId"],
   repoForWorkspace: ApiClientRepositoryInterface
 ) => {
@@ -63,7 +63,7 @@ export async function setupContextWithRepo(
   workspaceId: ApiClientFeatureContext["workspaceId"],
   repoForWorkspace: ApiClientRepositoryInterface
 ) {
-  const result = await _setupContextWithRepo(workspaceId, repoForWorkspace);
+  const result = await setupContextWithRepoWithoutMarkingLoaded(workspaceId, repoForWorkspace);
   markWorkspaceLoaded();
   return result;
 }

--- a/app/src/features/apiClient/commands/context/setupContextWithRepo.command.ts
+++ b/app/src/features/apiClient/commands/context/setupContextWithRepo.command.ts
@@ -64,8 +64,6 @@ export async function setupContextWithRepo(
   repoForWorkspace: ApiClientRepositoryInterface
 ) {
   const result = await _setupContextWithRepo(workspaceId, repoForWorkspace);
-
   markWorkspaceLoaded();
-
   return result;
 }

--- a/app/src/features/apiClient/commands/context/setupContextWithRepo.command.ts
+++ b/app/src/features/apiClient/commands/context/setupContextWithRepo.command.ts
@@ -14,6 +14,7 @@ import {
   apiClientMultiWorkspaceViewStore,
   ApiClientViewMode,
 } from "features/apiClient/store/multiWorkspaceView/multiWorkspaceView.store";
+import { markWorkspaceLoaded } from "../multiView";
 
 export type ContextSetupData = {
   apiClientRecords: { records: RQAPI.ApiClientRecord[]; erroredRecords: ErroredRecord[] }; // old api expects errors to also be passed in
@@ -21,7 +22,7 @@ export type ContextSetupData = {
   erroredRecords: { apiErroredRecords: ErroredRecord[]; environmentErroredRecords: ErroredRecord[] };
 };
 
-export const setupContextWithRepo = async (
+export const _setupContextWithRepo = async (
   workspaceId: ApiClientFeatureContext["workspaceId"],
   repoForWorkspace: ApiClientRepositoryInterface
 ) => {
@@ -55,6 +56,16 @@ export const setupContextWithRepo = async (
   }
 
   apiClientFeatureContextProviderStore.getState().addContext(context);
-  apiClientMultiWorkspaceViewStore.getState().setIsLoaded(true);
   return context.id;
 };
+
+export async function setupContextWithRepo(
+  workspaceId: ApiClientFeatureContext["workspaceId"],
+  repoForWorkspace: ApiClientRepositoryInterface
+) {
+  const result = await _setupContextWithRepo(workspaceId, repoForWorkspace);
+
+  markWorkspaceLoaded();
+
+  return result;
+}

--- a/app/src/features/apiClient/commands/multiView/index.ts
+++ b/app/src/features/apiClient/commands/multiView/index.ts
@@ -1,3 +1,4 @@
 export { addWorkspaceToView } from "./addWorkspaceToView.command";
 export { removeWorkspaceFromView } from "./removeWorkspaceFromView.command";
 export { resetToSingleView } from "./resetToSingleView.command";
+export { markWorkspaceLoaded } from "./markWorkspaceLoaded.command";

--- a/app/src/features/apiClient/commands/multiView/loadPendingWorkspaces.command.ts
+++ b/app/src/features/apiClient/commands/multiView/loadPendingWorkspaces.command.ts
@@ -1,5 +1,5 @@
 import { apiClientMultiWorkspaceViewStore } from "features/apiClient/store/multiWorkspaceView/multiWorkspaceView.store";
-import { _setupContext } from "../context";
+import { setupContextWithoutMarkingLoaded } from "../context";
 import { markWorkspaceLoaded } from "./markWorkspaceLoaded.command";
 
 export async function loadWorkspaces(userId?: string) {
@@ -13,7 +13,7 @@ export async function loadWorkspaces(userId?: string) {
       .getState()
       .setStateForSelectedWorkspace(workspace.id, { loading: true, errored: false });
     try {
-      await _setupContext(workspace.rawWorkspace, {
+      await setupContextWithoutMarkingLoaded(workspace.rawWorkspace, {
         loggedIn: !!userId,
         uid: userId ?? "",
       });

--- a/app/src/features/apiClient/commands/multiView/loadPendingWorkspaces.command.ts
+++ b/app/src/features/apiClient/commands/multiView/loadPendingWorkspaces.command.ts
@@ -1,5 +1,6 @@
 import { apiClientMultiWorkspaceViewStore } from "features/apiClient/store/multiWorkspaceView/multiWorkspaceView.store";
-import { setupContext } from "../context";
+import { _setupContext } from "../context";
+import { markWorkspaceLoaded } from "./markWorkspaceLoaded.command";
 
 export async function loadWorkspaces(userId?: string) {
   const workspacesToLoad = apiClientMultiWorkspaceViewStore
@@ -12,10 +13,11 @@ export async function loadWorkspaces(userId?: string) {
       .getState()
       .setStateForSelectedWorkspace(workspace.id, { loading: true, errored: false });
     try {
-      await setupContext(workspace.rawWorkspace, {
+      await _setupContext(workspace.rawWorkspace, {
         loggedIn: !!userId,
         uid: userId ?? "",
       });
+
       apiClientMultiWorkspaceViewStore
         .getState()
         .setStateForSelectedWorkspace(workspace.id, { loading: false, errored: false });
@@ -31,6 +33,7 @@ export async function loadWorkspaces(userId?: string) {
   });
 
   const result = await Promise.allSettled(tasks);
-  apiClientMultiWorkspaceViewStore.getState().setIsLoaded(true);
+
+  markWorkspaceLoaded();
   return result;
 }

--- a/app/src/features/apiClient/commands/multiView/markWorkspaceLoaded.command.ts
+++ b/app/src/features/apiClient/commands/multiView/markWorkspaceLoaded.command.ts
@@ -1,0 +1,7 @@
+import { apiClientMultiWorkspaceViewStore } from "features/apiClient/store/multiWorkspaceView/multiWorkspaceView.store";
+import { closeCorruptedTabs } from "../tabs";
+
+export function markWorkspaceLoaded() {
+  closeCorruptedTabs();
+  apiClientMultiWorkspaceViewStore.getState().setIsLoaded(true);
+}

--- a/app/src/features/apiClient/commands/tabs/closeCorruptedTabs.ts
+++ b/app/src/features/apiClient/commands/tabs/closeCorruptedTabs.ts
@@ -29,7 +29,5 @@ export function closeCorruptedTabs() {
     });
   } catch (e) {
     Sentry.captureException(e);
-  } finally {
-    setIgnorePath(false);
   }
 }

--- a/app/src/features/apiClient/commands/tabs/closeCorruptedTabs.ts
+++ b/app/src/features/apiClient/commands/tabs/closeCorruptedTabs.ts
@@ -4,9 +4,9 @@ import { getApiClientFeatureContext } from "../store.utils";
 import { NativeError } from "errors/NativeError";
 
 export function closeCorruptedTabs() {
-  try {
-    const { tabs, closeTabBySource, setIgnorePath } = tabServiceStore.getState();
+  const { tabs, closeTabBySource, setIgnorePath } = tabServiceStore.getState();
 
+  try {
     tabs.forEach((tab) => {
       const { source } = tab.getState();
 
@@ -29,5 +29,7 @@ export function closeCorruptedTabs() {
     });
   } catch (e) {
     Sentry.captureException(e);
+  } finally {
+    setIgnorePath(false);
   }
 }

--- a/app/src/features/apiClient/commands/tabs/closeCorruptedTabs.ts
+++ b/app/src/features/apiClient/commands/tabs/closeCorruptedTabs.ts
@@ -1,5 +1,7 @@
 import { tabServiceStore } from "componentsV2/Tabs/store/tabServiceStore";
 import * as Sentry from "@sentry/react";
+import { getApiClientFeatureContext } from "../store.utils";
+import { NativeError } from "errors/NativeError";
 
 export function closeCorruptedTabs() {
   try {
@@ -7,7 +9,15 @@ export function closeCorruptedTabs() {
 
     tabs.forEach((tab) => {
       const { source } = tab.getState();
-      const isValid = source.getIsValidTab();
+
+      const contextId = source.metadata.context?.id;
+      const context = getApiClientFeatureContext(contextId);
+
+      if (!context) {
+        throw new NativeError("Tab context does not exist!").addContext({ metadata: source.metadata });
+      }
+
+      const isValid = source.getIsValidTab(context);
 
       if (!isValid) {
         const sourceId = source.getSourceId();

--- a/app/src/features/apiClient/commands/tabs/closeCorruptedTabs.ts
+++ b/app/src/features/apiClient/commands/tabs/closeCorruptedTabs.ts
@@ -1,0 +1,23 @@
+import { tabServiceStore } from "componentsV2/Tabs/store/tabServiceStore";
+import * as Sentry from "@sentry/react";
+
+export function closeCorruptedTabs() {
+  try {
+    const { tabs, closeTabBySource, setIgnorePath } = tabServiceStore.getState();
+
+    tabs.forEach((tab) => {
+      const { source } = tab.getState();
+      const isValid = source.getIsValidTab();
+
+      if (!isValid) {
+        const sourceId = source.getSourceId();
+        const sourceName = source.getSourceName();
+
+        closeTabBySource(sourceId, sourceName, true);
+        setIgnorePath(true);
+      }
+    });
+  } catch (e) {
+    Sentry.captureException(e);
+  }
+}

--- a/app/src/features/apiClient/commands/tabs/index.ts
+++ b/app/src/features/apiClient/commands/tabs/index.ts
@@ -1,0 +1,1 @@
+export { closeCorruptedTabs } from "./closeCorruptedTabs";

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/collectionViewTabSource.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/collectionViewTabSource.tsx
@@ -4,6 +4,7 @@ import { BaseTabSource } from "componentsV2/Tabs/helpers/baseTabSource";
 import { MatchedTabSource, TabSourceMetadata } from "componentsV2/Tabs/types";
 import { MdOutlineFolder } from "@react-icons/all-files/md/MdOutlineFolder";
 import { getApiClientRecordsStore } from "features/apiClient/commands/store.utils";
+import { ApiClientFeatureContext } from "features/apiClient/store/apiClientFeatureContext/apiClientFeatureContext.store";
 
 interface CollectionViewTabSourceMetadata extends TabSourceMetadata {
   focusBreadcrumb?: boolean;
@@ -31,8 +32,7 @@ export class CollectionViewTabSource extends BaseTabSource {
     return new CollectionViewTabSource({ id: collectionId, title: "Collection", context: {} });
   }
 
-  getIsValidTab(): boolean {
-    const context = this.getTabContext();
+  getIsValidTab(context: ApiClientFeatureContext): boolean {
     const store = getApiClientRecordsStore(context);
     const isExist = store.getState().getData(this.metadata.id);
     return !!isExist;

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/collectionViewTabSource.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/collectionViewTabSource.tsx
@@ -3,6 +3,7 @@ import PATHS from "config/constants/sub/paths";
 import { BaseTabSource } from "componentsV2/Tabs/helpers/baseTabSource";
 import { MatchedTabSource, TabSourceMetadata } from "componentsV2/Tabs/types";
 import { MdOutlineFolder } from "@react-icons/all-files/md/MdOutlineFolder";
+import { getApiClientRecordsStore } from "features/apiClient/commands/store.utils";
 
 interface CollectionViewTabSourceMetadata extends TabSourceMetadata {
   focusBreadcrumb?: boolean;
@@ -28,5 +29,12 @@ export class CollectionViewTabSource extends BaseTabSource {
     }
 
     return new CollectionViewTabSource({ id: collectionId, title: "Collection", context: {} });
+  }
+
+  getIsValidTab(): boolean {
+    const context = this.getTabContext();
+    const store = getApiClientRecordsStore(context);
+    const isExist = store.getState().getData(this.metadata.id);
+    return !!isExist;
   }
 }

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/DraftRequestContainer/draftRequestContainerTabSource.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/DraftRequestContainer/draftRequestContainerTabSource.tsx
@@ -50,4 +50,8 @@ export class DraftRequestContainerTabSource extends BaseTabSource {
         return <MdOutlineSyncAlt />;
     }
   }
+
+  getIsValidTab(): boolean {
+    return true; // Always a valid tab, on reload we get new draft tab
+  }
 }

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/RequestView/requestViewTabSource.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/RequestView/requestViewTabSource.tsx
@@ -7,6 +7,7 @@ import { MdOutlineSyncAlt } from "@react-icons/all-files/md/MdOutlineSyncAlt";
 import { GrGraphQl } from "@react-icons/all-files/gr/GrGraphQl";
 import { ReactNode } from "react";
 import { getApiClientRecordsStore } from "features/apiClient/commands/store.utils";
+import { ApiClientFeatureContext } from "features/apiClient/store/apiClientFeatureContext/apiClientFeatureContext.store";
 
 interface RequestViewTabSourceMetadata extends TabSourceMetadata {
   apiEntryDetails?: RQAPI.ApiRecord;
@@ -47,8 +48,7 @@ export class RequestViewTabSource extends BaseTabSource {
     }
   }
 
-  getIsValidTab(): boolean {
-    const context = this.getTabContext();
+  getIsValidTab(context: ApiClientFeatureContext): boolean {
     const store = getApiClientRecordsStore(context);
     const isExist = store.getState().getData(this.metadata.id);
     return !!isExist;

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/RequestView/requestViewTabSource.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/RequestView/requestViewTabSource.tsx
@@ -6,6 +6,7 @@ import { MatchedTabSource, TabSourceMetadata } from "componentsV2/Tabs/types";
 import { MdOutlineSyncAlt } from "@react-icons/all-files/md/MdOutlineSyncAlt";
 import { GrGraphQl } from "@react-icons/all-files/gr/GrGraphQl";
 import { ReactNode } from "react";
+import { getApiClientRecordsStore } from "features/apiClient/commands/store.utils";
 
 interface RequestViewTabSourceMetadata extends TabSourceMetadata {
   apiEntryDetails?: RQAPI.ApiRecord;
@@ -44,5 +45,12 @@ export class RequestViewTabSource extends BaseTabSource {
       default:
         return <MdOutlineSyncAlt />;
     }
+  }
+
+  getIsValidTab(): boolean {
+    const context = this.getTabContext();
+    const store = getApiClientRecordsStore(context);
+    const isExist = store.getState().getData(this.metadata.id);
+    return !!isExist;
   }
 }

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/HistoryView/historyViewTabSource.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/HistoryView/historyViewTabSource.tsx
@@ -21,4 +21,8 @@ export class HistoryViewTabSource extends BaseTabSource {
   static create(matchedPath: MatchedTabSource["matchedPath"]): HistoryViewTabSource {
     return new HistoryViewTabSource();
   }
+
+  getIsValidTab(): boolean {
+    return true;
+  }
 }

--- a/app/src/features/apiClient/screens/environment/components/RuntimeVariables/runtimevariablesTabSource.tsx
+++ b/app/src/features/apiClient/screens/environment/components/RuntimeVariables/runtimevariablesTabSource.tsx
@@ -21,4 +21,8 @@ export class RuntimeVariablesViewTabSource extends BaseTabSource {
   static create(matchedPath: MatchedTabSource["matchedPath"]): RuntimeVariablesViewTabSource {
     return new RuntimeVariablesViewTabSource();
   }
+
+  getIsValidTab(): boolean {
+    return true;
+  }
 }

--- a/app/src/features/apiClient/screens/environment/components/environmentView/EnvironmentViewTabSource.tsx
+++ b/app/src/features/apiClient/screens/environment/components/environmentView/EnvironmentViewTabSource.tsx
@@ -4,6 +4,7 @@ import PATHS from "config/constants/sub/paths";
 import { MatchedTabSource, TabSourceMetadata } from "componentsV2/Tabs/types";
 import { MdHorizontalSplit } from "@react-icons/all-files/md/MdHorizontalSplit";
 import { getApiClientEnvironmentsStore } from "features/apiClient/commands/store.utils";
+import { ApiClientFeatureContext } from "features/apiClient/store/apiClientFeatureContext/apiClientFeatureContext.store";
 
 interface EnvironmentViewTabSourceMetadata extends TabSourceMetadata {
   focusBreadcrumb?: boolean;
@@ -31,8 +32,7 @@ export class EnvironmentViewTabSource extends BaseTabSource {
     return new EnvironmentViewTabSource({ id: envId, title: "Environment", context: {} });
   }
 
-  getIsValidTab(): boolean {
-    const context = this.getTabContext();
+  getIsValidTab(context: ApiClientFeatureContext): boolean {
     const store = getApiClientEnvironmentsStore(context);
     const isExist = store.getState().getEnvironment(this.metadata.id);
     return !!isExist;

--- a/app/src/features/apiClient/screens/environment/components/environmentView/EnvironmentViewTabSource.tsx
+++ b/app/src/features/apiClient/screens/environment/components/environmentView/EnvironmentViewTabSource.tsx
@@ -3,6 +3,7 @@ import { EnvironmentView } from "./EnvironmentView";
 import PATHS from "config/constants/sub/paths";
 import { MatchedTabSource, TabSourceMetadata } from "componentsV2/Tabs/types";
 import { MdHorizontalSplit } from "@react-icons/all-files/md/MdHorizontalSplit";
+import { getApiClientEnvironmentsStore } from "features/apiClient/commands/store.utils";
 
 interface EnvironmentViewTabSourceMetadata extends TabSourceMetadata {
   focusBreadcrumb?: boolean;
@@ -28,5 +29,12 @@ export class EnvironmentViewTabSource extends BaseTabSource {
     }
 
     return new EnvironmentViewTabSource({ id: envId, title: "Environment", context: {} });
+  }
+
+  getIsValidTab(): boolean {
+    const context = this.getTabContext();
+    const store = getApiClientEnvironmentsStore(context);
+    const isExist = store.getState().getEnvironment(this.metadata.id);
+    return !!isExist;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Tabs gain validation checks so the app can detect and close invalid tabs automatically.
  - Workspace loading now signals readiness via an explicit load marker.
  - Temporary "ignore path" action added for smoother automated tab operations.
  - Drafts, history and runtime-variable tabs are now always treated as valid to preserve availability.

- Bug Fixes
  - Automatically closes corrupted or stale tabs to reduce broken views and improve load reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->