### PR TITLE
ENGG-4224: Team workspace copy change and banner cleanup

### DIFF
--- a/app/src/features/settings/components/SettingsPrimarySidebar/index.tsx
+++ b/app/src/features/settings/components/SettingsPrimarySidebar/index.tsx
@@ -83,12 +83,12 @@ export const SettingsPrimarySidebar: React.FC = () => {
           },
           {
             id: "workspaces",
-            name: "Workspaces",
+            name: "Team workspaces",
             path: PATHS.SETTINGS.WORKSPACES.RELATIVE,
           },
           {
             id: "my-plan",
-            name: "My Plan",
+            name: "My plan",
             path: PATHS.SETTINGS.MY_PLAN.RELATIVE,
             ishidden: !user.loggedIn,
           },

--- a/app/src/features/settings/components/WorkspaceSettings/components/MyTeams/MyTeams.jsx
+++ b/app/src/features/settings/components/WorkspaceSettings/components/MyTeams/MyTeams.jsx
@@ -3,13 +3,12 @@ import { Card } from "reactstrap";
 import ManageTeams from "../../../Profile/ManageTeams";
 import TeamWideAnimation from "components/misc/LottieAnimation/TeamWideAnimation";
 import { Col } from "antd";
-import { ManageBillingTeamAlert } from "../ManageBillingTeamAlert/ManageBillingTeamAlert";
 import "./index.scss";
 
 const MyTeams = () => {
   return (
     <div className="workspace-settings-page">
-      <ManageBillingTeamAlert />
+      {/* <ManageBillingTeamAlert /> */}
       <Col className="workspace-settings-container">
         {/* Page content */}
         <Card className="mt-4">

--- a/app/src/layouts/DashboardLayout/MenuHeader/HeaderUser.jsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/HeaderUser.jsx
@@ -78,7 +78,7 @@ export default function HeaderUser() {
         onClick: () => redirectToProfileSettings(navigate, window.location.pathname, "header"),
       },
       {
-        label: "Manage Workspaces",
+        label: "Manage team workspaces",
         onClick: () => redirectToWorkspaceSettings(navigate, window.location.pathname, "header"),
       },
       {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated labels in Settings: “Workspaces” → “Team workspaces” and “My Plan” → “My plan.”
  * Updated header menu label: “Manage Workspaces” → “Manage team workspaces.”
* **Chores**
  * Removed the ManageBillingTeamAlert from the My Teams page (alert no longer displayed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->