### PR TITLE
fix: add collection variables from store during export

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -105,9 +105,15 @@ export const CollectionRow: React.FC<Props> = ({
     (collection: RQAPI.CollectionRecord, exportType: ExportType) => {
       const collectionRecordState = getRecordStore(record.id).getState() as CollectionRecordState;
       const collectionVariables = collectionRecordState.collectionVariables.getState().data;
+
+      const removeLocalValue = (variables: Map<string, any>): Record<string, any> => {
+        // set localValue to empty before exporting
+        return Object.fromEntries([...variables.entries()].map(([k, v]) => [k, { ...v, localValue: "" }]));
+      };
+
       const exportData: RQAPI.CollectionRecord = {
         ...collection,
-        data: { ...collection.data, variables: Object.fromEntries(collectionVariables.entries()) },
+        data: { ...collection.data, variables: removeLocalValue(collectionVariables) },
       };
       setCollectionsToExport((prev) => [...prev, exportData]);
 
@@ -124,7 +130,6 @@ export const CollectionRow: React.FC<Props> = ({
     },
     [getRecordStore, record.id]
   );
-
 
   const activeTabSourceId = useMemo(() => {
     if (activeTabSource) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Collection exports now include collection-level variables so exported payloads carry variables alongside requests (e.g., Requestly, Postman).

* **Bug Fixes**
  * Resolved cases where collection variables were missing from exported collections, ensuring exports are complete and variables are cleared for export.

* **Refactor**
  * Export logic improved to read up-to-date per-record state and tightened dependency handling for more reliable, consistent exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->