### PR TITLE
[ENGG-4267]: Workspace selector UX fixes

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/useWorkspaceSwitcher.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/useWorkspaceSwitcher.tsx
@@ -143,6 +143,14 @@ export const useWorkspaceSwitcher = () => {
   );
 
   const handleSwitchToPrivateWorkspace = useCallback(async () => {
+    const viewMode = getViewMode();
+
+    if (viewMode === ApiClientViewMode.SINGLE) {
+      if (activeWorkspace?.id === null) {
+        toast.info("Workspace already selected!");
+        return;
+      }
+    }
     setIsWorkspaceLoading(true);
     return clearCurrentlyActiveWorkspace(dispatch, appMode)
       .then(() => {
@@ -156,7 +164,7 @@ export const useWorkspaceSwitcher = () => {
       .finally(() => {
         setIsWorkspaceLoading(false);
       });
-  }, [appMode, dispatch]);
+  }, [appMode, dispatch, activeWorkspace?.id, getViewMode]);
 
   return {
     handleWorkspaceSwitch,

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/multiWorkspaceSidebar.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/multiWorkspaceSidebar.scss
@@ -163,9 +163,12 @@
         padding: 0;
         border-radius: 4px;
 
-        &:hover,
+        &:hover {
+          background-color: var(--requestly-color-white-t-10);
+        }
+
         &.ant-tabs-tab-active {
-          background-color: var(--requestly-color-surface-1);
+          background-color: var(--requestly-color-white-t-20);
         }
 
         .ant-tabs-tab-btn,
@@ -188,10 +191,6 @@
           svg {
             width: 16px;
             height: 16px;
-          }
-
-          &:hover {
-            background-color: var(--requestly-color-surface-1);
           }
         }
       }

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/multiWorkspaceSidebar.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/multiWorkspaceSidebar.scss
@@ -169,6 +169,10 @@
 
         &.ant-tabs-tab-active {
           background-color: var(--requestly-color-white-t-20);
+
+          svg {
+            color: var(--requestly-color-text-default);
+          }
         }
 
         .ant-tabs-tab-btn,

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/SingleWorkspaceSidebar/singleWorkspaceSidebar.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/SingleWorkspaceSidebar/singleWorkspaceSidebar.scss
@@ -161,9 +161,12 @@
         padding: 0;
         border-radius: 4px;
 
-        &:hover,
+        &:hover {
+          background-color: var(--requestly-color-white-t-10);
+        }
+
         &.ant-tabs-tab-active {
-          background-color: var(--requestly-color-surface-1);
+          background-color: var(--requestly-color-white-t-20);
         }
 
         .ant-tabs-tab-btn,
@@ -186,10 +189,6 @@
           svg {
             width: 16px;
             height: 16px;
-          }
-
-          &:hover {
-            background-color: var(--requestly-color-surface-1);
           }
         }
       }

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/SingleWorkspaceSidebar/singleWorkspaceSidebar.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/SingleWorkspaceSidebar/singleWorkspaceSidebar.scss
@@ -167,6 +167,10 @@
 
         &.ant-tabs-tab-active {
           background-color: var(--requestly-color-white-t-20);
+
+          svg {
+            color: var(--requestly-color-text-default);
+          }
         }
 
         .ant-tabs-tab-btn,

--- a/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/WorkSpaceSelector.css
+++ b/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/WorkSpaceSelector.css
@@ -17,6 +17,11 @@
   font-style: normal;
   font-weight: 500;
   line-height: var(--requestly-font-line-height-sm);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
 }
 
 .workspace-selector-dropdown__content .local-workspace-avatar {
@@ -50,8 +55,6 @@
   color: var(--requestly-color-text-default);
   max-width: 25ch;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   margin-left: 2px;
 }
 

--- a/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspaceDropdown.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspaceDropdown.tsx
@@ -19,6 +19,7 @@ import {
 import { MultiWorkspaceAvatarGroup } from "../MultiWorkspaceAvatarGroup";
 import LocalWorkspaceAvatar from "features/workspaces/components/LocalWorkspaceAvatar";
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
+import { getUserAuthDetails } from "store/slices/global/user/selectors";
 
 const prettifyWorkspaceName = (workspaceName: string) => {
   // if (workspaceName === APP_CONSTANTS.TEAM_WORKSPACES.NAMES.PRIVATE_WORKSPACE)
@@ -29,6 +30,7 @@ const prettifyWorkspaceName = (workspaceName: string) => {
 const WorkSpaceDropDown = ({ teamInvites }: { teamInvites: Invite[] }) => {
   // Global State
   const appMode = useSelector(getAppMode);
+  const user = useSelector(getUserAuthDetails);
   const activeWorkspace = useSelector(getActiveWorkspace);
   const viewMode = useApiClientMultiWorkspaceView((s) => s.viewMode);
   const isActiveWorkspaceNotPrivate = useSelector(isActiveWorkspaceShared);
@@ -36,7 +38,11 @@ const WorkSpaceDropDown = ({ teamInvites }: { teamInvites: Invite[] }) => {
   // Local State
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-  const activeWorkspaceName = isActiveWorkspaceNotPrivate ? activeWorkspace?.name : "Workspaces";
+  const activeWorkspaceName = isActiveWorkspaceNotPrivate
+    ? activeWorkspace?.name
+    : user.loggedIn
+    ? "Private Workspace"
+    : "Workspaces";
 
   const handleWorkspaceDropdownClick = (open: boolean) => {
     setIsDropdownOpen(open);

--- a/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/WorkspaceListItem.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import { Workspace } from "features/workspaces/types";
 import WorkspaceAvatar from "features/workspaces/components/WorkspaceAvatar";
 import { WorkspaceType } from "types";
-import { Checkbox, Tooltip, Typography } from "antd";
+import { Checkbox, Tag, Tooltip, Typography } from "antd";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdOutlineSettings } from "@react-icons/all-files/md/MdOutlineSettings";
 import { redirectToTeam } from "utils/RedirectionUtils";
@@ -24,6 +24,7 @@ import {
 import { toast } from "utils/Toast";
 import { addWorkspaceToView, removeWorkspaceFromView } from "features/apiClient/commands/multiView";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
+import { getActiveWorkspace } from "store/slices/workspaces/selectors";
 
 type WorkspaceItemProps =
   | {
@@ -47,6 +48,7 @@ const ShareWorkspaceActions = ({
 }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const activeWorkspace = useSelector(getActiveWorkspace);
 
   const handleSendInvites = () => {
     dispatch(
@@ -62,6 +64,7 @@ const ShareWorkspaceActions = ({
 
   return (
     <>
+      {activeWorkspace.id === workspaceId ? <Tag className="workspace-list-item-active-tag">CURRENT</Tag> : null}
       <div className="shared-workspace-actions">
         <RQButton
           type="transparent"
@@ -98,6 +101,8 @@ const LocalWorkspaceActions = ({
 }) => {
   const navigate = useNavigate();
   const user = useSelector(getUserAuthDetails);
+  const activeWorkspace = useSelector(getActiveWorkspace);
+
   const [selectedWorkspaces, getViewMode, getAllSelectedWorkspaces] = useApiClientMultiWorkspaceView((s) => [
     s.selectedWorkspaces,
     s.getViewMode,
@@ -132,30 +137,35 @@ const LocalWorkspaceActions = ({
   ]);
 
   return (
-    <div className="local-workspace-actions" onClick={(e) => e.stopPropagation()}>
-      <Tooltip title="Settings" color="#000">
-        <RQButton
-          className="local-workspace-actions__settings-btn"
-          type="transparent"
-          icon={<MdOutlineSettings />}
-          size="small"
-          onClick={(e) => {
-            e.stopPropagation();
-            trackManageWorkspaceClicked("workspace_selector_dropdown");
-            redirectToTeam(navigate, workspace.id);
-            toggleDropdown();
+    <>
+      {activeWorkspace.id === workspace.id && getViewMode() === ApiClientViewMode.SINGLE ? (
+        <Tag className="workspace-list-item-active-tag">CURRENT</Tag>
+      ) : null}
+      <div className="local-workspace-actions" onClick={(e) => e.stopPropagation()}>
+        <Tooltip title="Settings" color="#000">
+          <RQButton
+            className="local-workspace-actions__settings-btn"
+            type="transparent"
+            icon={<MdOutlineSettings />}
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              trackManageWorkspaceClicked("workspace_selector_dropdown");
+              redirectToTeam(navigate, workspace.id);
+              toggleDropdown();
+            }}
+          />
+        </Tooltip>
+
+        <Checkbox
+          checked={isSelected}
+          className="local-workspace-actions__checkbox"
+          onChange={(e) => {
+            handleMultiworkspaceAdder(e.target.checked);
           }}
         />
-      </Tooltip>
-
-      <Checkbox
-        checked={isSelected}
-        className="local-workspace-actions__checkbox"
-        onChange={(e) => {
-          handleMultiworkspaceAdder(e.target.checked);
-        }}
-      />
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/WorkspaceListItem.tsx
@@ -49,6 +49,7 @@ const ShareWorkspaceActions = ({
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const activeWorkspace = useSelector(getActiveWorkspace);
+  const [viewMode] = useApiClientMultiWorkspaceView((s) => [s.viewMode]);
 
   const handleSendInvites = () => {
     dispatch(
@@ -64,7 +65,9 @@ const ShareWorkspaceActions = ({
 
   return (
     <>
-      {activeWorkspace.id === workspaceId ? <Tag className="workspace-list-item-active-tag">CURRENT</Tag> : null}
+      {activeWorkspace.id === workspaceId && viewMode === ApiClientViewMode.SINGLE ? (
+        <Tag className="workspace-list-item-active-tag">CURRENT</Tag>
+      ) : null}
       <div className="shared-workspace-actions">
         <RQButton
           type="transparent"

--- a/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/workspaceListItem.scss
+++ b/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/workspaceListItem.scss
@@ -15,6 +15,12 @@
     .ant-avatar {
       border-radius: 50%;
     }
+
+    &:hover {
+      .workspace-list-item-active-tag {
+        display: none;
+      }
+    }
   }
 
   &--shared:hover {
@@ -68,6 +74,18 @@
     }
   }
 
+  .workspace-list-item-active-tag {
+    border-radius: 4px;
+    background: var(--requestly-color-success-darker, #104b2f);
+    border: none;
+    color: var(--requestly-color-success-text, #6fdaa6);
+    font-size: 9px;
+    font-weight: var(--requestly-font-weight-medium);
+    line-height: var(--line-height-2xs, 13px); /* 144.444% */
+    letter-spacing: 1px;
+    padding: var(--space-1, 2px) var(--space-2, 4px);
+  }
+
   .shared-workspace-actions {
     display: none;
     align-items: center;
@@ -96,6 +114,14 @@
     .local-workspace-actions__checkbox,
     .local-workspace-actions__settings-btn {
       display: none;
+    }
+  }
+
+  &.single-mode {
+    &:hover {
+      .local-workspace-actions {
+        display: flex;
+      }
     }
   }
 


### PR DESCRIPTION
* Added current badge in shared workspace list and local workspace list (single mode only)
* Fix ellipsis issue for big workspace names
* Prevent switching to currently active workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Display a “CURRENT” badge next to the active workspace in lists.
  - Workspace selector title adapts: shows workspace name, “Private Workspace,” or “Workspaces” based on context and login state.

- Bug Fixes
  - Prevents redundant switching in single view and shows a “Workspace already selected!” toast when applicable.

- Style
  - Active workspace name now ellipsis-truncated; avatar label truncation adjusted.
  - New badge styles and refined hover behavior for local/single-mode items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->