### PR TITLE
fix: update the active workspace when switching from single to multiview

### DIFF
--- a/app/src/features/apiClient/container.tsx
+++ b/app/src/features/apiClient/container.tsx
@@ -49,6 +49,7 @@ const ApiClientFeatureContainer: React.FC = () => {
       });
       await setupContextWithRepo(activeWorkspace.id, repository);
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- not adding `activeWorkspace` to control reactivity
   }, [user, activeWorkspace?.id, viewMode]);
 
   if (!isLoaded) {

--- a/app/src/features/mocks/container.tsx
+++ b/app/src/features/mocks/container.tsx
@@ -5,11 +5,17 @@ import { SecondarySidebarLayout } from "componentsV2/SecondarySidebar";
 import { MocksContextProvider } from "./contexts";
 import { LocalFirstComingSoon } from "componentsV2/Nudge/views/LocalFirstComingSoon/LocalFirstComingSoon";
 import { useCheckLocalSyncSupport } from "features/apiClient/helpers/modules/sync/useCheckLocalSyncSupport";
+import {
+  ApiClientViewMode,
+  useApiClientMultiWorkspaceView,
+} from "features/apiClient/store/multiWorkspaceView/multiWorkspaceView.store";
 
 const MocksFeatureContainer: React.FC = () => {
   const isLocalSyncEnabled = useCheckLocalSyncSupport();
+  const viewMode = useApiClientMultiWorkspaceView((s) => s.viewMode);
 
-  if (isLocalSyncEnabled) {
+  // fixme: rethink when expanding multi view to cloud workspaces
+  if (isLocalSyncEnabled || viewMode === ApiClientViewMode.MULTI) {
     return (
       <LocalFirstComingSoon
         featureName="Mock Server"

--- a/app/src/features/rules/container.tsx
+++ b/app/src/features/rules/container.tsx
@@ -22,11 +22,15 @@ import { getAppMode } from "store/selectors";
 import { LocalFirstComingSoon } from "componentsV2/Nudge/views/LocalFirstComingSoon/LocalFirstComingSoon";
 import { useCheckLocalSyncSupport } from "features/apiClient/helpers/modules/sync/useCheckLocalSyncSupport";
 import clientRuleStorageService from "services/clientStorageService/features/rule";
+import {
+  ApiClientViewMode,
+  useApiClientMultiWorkspaceView,
+} from "features/apiClient/store/multiWorkspaceView/multiWorkspaceView.store";
 
 const RulesFeatureContainer = () => {
   const appMode = useSelector(getAppMode);
   const isLocalSyncEnabled = useCheckLocalSyncSupport();
-
+  const viewMode = useApiClientMultiWorkspaceView((s) => s.viewMode);
   useEffect(() => {
     PageScriptMessageHandler.addMessageListener("ruleSaveError", (message: any) => {
       notification.warn({
@@ -80,7 +84,8 @@ const RulesFeatureContainer = () => {
     });
   }, [appMode]);
 
-  if (isLocalSyncEnabled) {
+  // fixme: rethink when expanding multi view to cloud workspaces
+  if (isLocalSyncEnabled || viewMode === ApiClientViewMode.MULTI) {
     return (
       <LocalFirstComingSoon
         featureName="HTTP Rules"

--- a/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/WorkspaceListItem.tsx
@@ -114,7 +114,7 @@ const LocalWorkspaceActions = ({
     s.getAllSelectedWorkspaces,
   ]);
 
-  const handleMultiworkspaceCheckbox = useCallback(
+  const handleMultiWorkspaceCheckbox = useCallback(
     async (isChecked: boolean) => {
       const handleWorkspaceSelection = async () => {
         const isFirstSelectedWorkspace = getViewMode() === ApiClientViewMode.SINGLE;
@@ -182,7 +182,7 @@ const LocalWorkspaceActions = ({
           checked={isSelected}
           className="local-workspace-actions__checkbox"
           onChange={(e) => {
-            handleMultiworkspaceCheckbox(e.target.checked);
+            handleMultiWorkspaceCheckbox(e.target.checked);
           }}
         />
       </div>

--- a/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/WorkspaceSelector/components/WorkspacesOverlay/components/WorkspaceListItem/WorkspaceListItem.tsx
@@ -25,6 +25,7 @@ import { toast } from "utils/Toast";
 import { addWorkspaceToView, removeWorkspaceFromView } from "features/apiClient/commands/multiView";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
 import { getActiveWorkspace } from "store/slices/workspaces/selectors";
+import { workspaceActions } from "store/slices/workspaces/slice";
 
 type WorkspaceItemProps =
   | {
@@ -105,6 +106,7 @@ const LocalWorkspaceActions = ({
   const navigate = useNavigate();
   const user = useSelector(getUserAuthDetails);
   const activeWorkspace = useSelector(getActiveWorkspace);
+  const dispatch = useDispatch();
 
   const [selectedWorkspaces, getViewMode, getAllSelectedWorkspaces] = useApiClientMultiWorkspaceView((s) => [
     s.selectedWorkspaces,
@@ -116,6 +118,9 @@ const LocalWorkspaceActions = ({
     async (isChecked: boolean) => {
       try {
         if (isChecked) {
+          if (getViewMode() === ApiClientViewMode.SINGLE) {
+            dispatch(workspaceActions.setActiveWorkspaceIds([workspace.id]));
+          }
           await addWorkspaceToView(workspace, user.details?.profile?.uid);
           trackMultiWorkspaceSelected("workspace_selector_dropdown");
         } else {
@@ -131,7 +136,7 @@ const LocalWorkspaceActions = ({
         toast.error(e.message);
       }
     },
-    [workspace, user.details?.profile?.uid, getViewMode, getAllSelectedWorkspaces, switchWorkspace]
+    [dispatch, workspace, user.details?.profile?.uid, getViewMode, getAllSelectedWorkspaces, switchWorkspace]
   );
 
   const isSelected = useMemo(() => selectedWorkspaces.some((w) => w.getState().id === workspace.id), [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mocks and Rules now show the “Local First: Coming Soon” banner when Multi-Workspace view is active (in addition to when local sync is enabled).
  * Workspace selection UX improved: first selection can set the active workspace automatically; deselecting the last item in Multi view switches the active workspace. Errors surface as toasts.
  * Added tracking and a slight delay to ensure workspace additions align with the first switch.

* **Chores**
  * Suppressed a hooks dependency lint warning with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->