### PR TITLE
[ONCALL-23] fix: history tab breaking in multiview

### DIFF
--- a/app/src/componentsV2/Tabs/constants.ts
+++ b/app/src/componentsV2/Tabs/constants.ts
@@ -1,7 +1,7 @@
 import { CollectionViewTabSource } from "features/apiClient/screens/apiClient/components/views/components/Collection/collectionViewTabSource";
 import { DraftRequestContainerTabSource } from "features/apiClient/screens/apiClient/components/views/components/DraftRequestContainer/draftRequestContainerTabSource";
-import { HistoryViewTabSource } from "features/apiClient/screens/apiClient/components/views/components/request/HistoryView/historyViewTabSource";
 import { RequestViewTabSource } from "features/apiClient/screens/apiClient/components/views/components/RequestView/requestViewTabSource";
+import { HistoryViewTabSource } from "features/apiClient/screens/apiClient/components/views/components/request/HistoryView/historyViewTabSource";
 import { EnvironmentViewTabSource } from "features/apiClient/screens/environment/components/environmentView/EnvironmentViewTabSource";
 
 export const TAB_SOURCES_MAP = {

--- a/app/src/features/apiClient/screens/apiClient/clientView/GenericApiClient.tsx
+++ b/app/src/features/apiClient/screens/apiClient/clientView/GenericApiClient.tsx
@@ -10,10 +10,11 @@ type Props = {
   onSaveCallback?: (apiEntryDetails: RQAPI.ApiRecord) => void;
   handleAppRequestFinished?: (entry: RQAPI.ApiEntry) => void;
   isCreateMode: boolean;
+  isOpenInModal?: boolean;
 };
 
 export const GenericApiClient: React.FC<Props> = React.memo(
-  ({ apiEntryDetails, onSaveCallback, handleAppRequestFinished, isCreateMode }) => {
+  ({ apiEntryDetails, onSaveCallback, handleAppRequestFinished, isCreateMode, isOpenInModal = false }) => {
     return (
       <BottomSheetProvider defaultPlacement={BottomSheetPlacement.BOTTOM} isSheetOpenByDefault={true}>
         <div className="api-client-container-content">
@@ -23,6 +24,7 @@ export const GenericApiClient: React.FC<Props> = React.memo(
               handleRequestFinished={handleAppRequestFinished}
               onSaveCallback={onSaveCallback}
               isCreateMode={isCreateMode}
+              isOpenInModal={isOpenInModal}
             />
           </AutogenerateProvider>
         </div>

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/HistoryView/HistoryView.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/HistoryView/HistoryView.tsx
@@ -1,32 +1,45 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { RequestViewTabSource } from "../../RequestView/requestViewTabSource";
 import { useTabServiceWithSelector } from "componentsV2/Tabs/store/tabServiceStore";
 import { RQAPI } from "features/apiClient/types";
 import { useApiClientContext } from "features/apiClient/contexts";
 import { GenericApiClient } from "features/apiClient/screens/apiClient/clientView/GenericApiClient";
+import {
+  ApiClientViewMode,
+  useApiClientMultiWorkspaceView,
+} from "features/apiClient/store/multiWorkspaceView/multiWorkspaceView.store";
 
 export const HistoryView: React.FC = () => {
   const [openTab] = useTabServiceWithSelector((state) => [state.openTab]);
   const { history, addToHistory, setCurrentHistoryIndex, selectedHistoryIndex } = useApiClientContext();
+  const [viewMode] = useApiClientMultiWorkspaceView((s) => [s.viewMode]);
 
-  const entry = {
-    type: RQAPI.RecordType.API,
-    data: { ...history[selectedHistoryIndex] },
-  } as RQAPI.ApiRecord;
+  const entry = useMemo(() => {
+    return {
+      type: RQAPI.RecordType.API,
+      data: { ...history[selectedHistoryIndex] },
+    } as RQAPI.ApiRecord;
+  }, [history, selectedHistoryIndex]);
+
+  const hideSaveBtn = viewMode === ApiClientViewMode.MULTI;
 
   const handleSaveCallback = useCallback(
     (entryDetails: RQAPI.ApiRecord) => {
-      throw new Error("Not implemented!");
-      // openTab(
-      //   new RequestViewTabSource({
-      //     id: entryDetails.id,
-      //     apiEntryDetails: entryDetails,
-      //     title: entryDetails.name || entryDetails.data.request?.url,
-      //   }),
-      //   { preview: false }
-      // );
+      if (hideSaveBtn) {
+        return;
+      }
+
+      openTab(
+        new RequestViewTabSource({
+          id: entryDetails.id,
+          apiEntryDetails: entryDetails,
+          title: entryDetails.name || entryDetails.data.request?.url,
+          context: {},
+        }),
+        { preview: false }
+      );
     },
-    [openTab]
+    [openTab, hideSaveBtn]
   );
 
   const handleAppRequestFinished = useCallback(
@@ -40,6 +53,7 @@ export const HistoryView: React.FC = () => {
   return (
     <GenericApiClient
       isCreateMode
+      isOpenInModal={hideSaveBtn} // TODO: rename isOpenInModal prop with some meaningful name
       onSaveCallback={handleSaveCallback}
       apiEntryDetails={entry}
       handleAppRequestFinished={handleAppRequestFinished}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - In multi-workspace view, requests now open in a modal for focused preview.
  - Opening a history entry creates a new tab with clearer, automatic titles based on the request name or URL.
  - More consistent behavior when opening tabs directly from history.

- Bug Fixes
  - Save action is disabled/hidden in multi-workspace view to prevent unintended saves and ensure consistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->