### PR TITLE
[ONCALL-9]: fix inherit auth type assigned to root collections

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/utils.ts
+++ b/app/src/features/apiClient/screens/apiClient/utils.ts
@@ -386,7 +386,7 @@ export const createBlankApiRecord = (
     newRecord.type = RQAPI.RecordType.COLLECTION;
     newRecord.data = {
       variables: {},
-      auth: getDefaultAuth(false),
+      auth: getDefaultAuth(!collectionId),
     };
     newRecord.deleted = false;
     newRecord.collectionId = collectionId;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default authentication settings now adapt based on context when creating new API records—behavior varies depending on whether a collection is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->