### PR TITLE
fix: use the correct contextId in collectionRow

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -34,6 +34,9 @@ import { moveRecordsAcrossWorkspace } from "features/apiClient/commands/records"
 import { getApiClientFeatureContext } from "features/apiClient/commands/store.utils";
 import { useApiClientContext } from "features/apiClient/contexts";
 import { PostmanExportModal } from "../../../../modals/postmanCollectionExportModal/PostmanCollectionExportModal";
+import { useSelector } from "react-redux";
+import { getActiveWorkspace } from "store/slices/workspaces/selectors";
+import { WorkspaceType } from "features/workspaces/types";
 
 export enum ExportType {
   REQUESTLY = "requestly",
@@ -95,6 +98,7 @@ export const CollectionRow: React.FC<Props> = ({
     state.closeTabBySource,
   ]);
   const [getParentChain] = useAPIRecords((state) => [state.getParentChain]);
+  const activeWorkspace = useSelector(getActiveWorkspace);
 
   const handleCollectionExport = useCallback((collection: RQAPI.CollectionRecord, exportType: ExportType) => {
     setCollectionsToExport((prev) => [...prev, collection]);
@@ -225,9 +229,11 @@ export const CollectionRow: React.FC<Props> = ({
           destination,
         });
 
-        oldContextRecords?.forEach((r) => {
-          closeTabBySource(r.id, "request", true);
-        });
+        if (activeWorkspace.workspaceType !== WorkspaceType.SHARED) {
+          oldContextRecords?.forEach((r) => {
+            closeTabBySource(r.id, "request", true);
+          });
+        }
 
         if (!expandedRecordIds.includes(record.id)) {
           const newExpandedRecordIds = [...expandedRecordIds, destination.collectionId];
@@ -244,7 +250,7 @@ export const CollectionRow: React.FC<Props> = ({
         setIsCollectionRowLoading(false);
       }
     },
-    [record.id, expandedRecordIds, closeTabBySource, setExpandedRecordIds]
+    [activeWorkspace.workspaceType, record.id, expandedRecordIds, closeTabBySource, setExpandedRecordIds]
   );
 
   const checkCanDropItem = useCallback(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified context handling in the API Client sidebar collections to use a single feature context for consistent state access.
  * Streamlined internal wiring for drag-and-drop, tab creation, and new-record flows; added workspace-awareness to certain internal behaviors.

* **Chores**
  * Internal updates only; no changes to public APIs.

* **User Impact**
  * No user-facing changes expected; existing behaviors (drag-and-drop, tabs, new records) remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->