### PR TITLE
ONCALL-43: Disable desktop onboarding for windows

### DIFF
--- a/app/src/features/onboarding/componentsV2/DesktopOnboardingModal/DesktopOnboardingModal.tsx
+++ b/app/src/features/onboarding/componentsV2/DesktopOnboardingModal/DesktopOnboardingModal.tsx
@@ -31,8 +31,10 @@ export const DesktopOnboardingModal = () => {
   }, [dispatch, user.loggedIn, isLocalSyncSupported]);
 
   useEffect(() => {
-    trackDesktopOnboardingViewed(onboardingStep);
-  }, [onboardingStep]);
+    if (isLocalSyncSupported) {
+      trackDesktopOnboardingViewed(onboardingStep);
+    }
+  }, [onboardingStep, isLocalSyncSupported]);
 
   if (!isLocalSyncSupported) {
     return null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding adapts to device capabilities: if local sync isn’t supported, the onboarding modal is skipped and the flow completes automatically.
  * The onboarding flow now updates in real time when local sync support changes, preventing display of unusable prompts.
  * Analytics for onboarding view are now only recorded when local sync is supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->