### PR TITLE
Enable local workspaces for windows

### DIFF
--- a/app/src/config/constants/compatibility.js
+++ b/app/src/config/constants/compatibility.js
@@ -144,7 +144,8 @@ export const FEATURE_COMPATIBLE_VERSION = {
   },
   [FEATURES.LOCAL_FILE_SYNC]: {
     [GLOBAL_CONSTANTS.APP_MODES.DESKTOP]: {
-      macOS: "2.0.0",
+      macOS: "25.8.28",
+      Windows: "25.8.28",
     },
     [GLOBAL_CONSTANTS.APP_MODES.EXTENSION]: null,
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local File Sync now supported on Windows desktop (minimum version 25.8.28).
  * Updated macOS desktop compatibility for Local File Sync to minimum version 25.8.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->