### PR TITLE
fix: unsaved changes not visible when only value is added in key-value table

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/http/HttpClientView.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/http/HttpClientView.tsx
@@ -164,7 +164,7 @@ const HttpClientView: React.FC<Props> = ({
 
   // Passing sanitized entry because response and empty key value pairs are saved in DB
   const { hasUnsavedChanges, resetChanges } = useHasUnsavedChanges(
-    sanitizeEntry({ ...entryWithoutResponse, response: null })
+    sanitizeEntry({ ...entryWithoutResponse, response: null }, false)
   );
 
   const isHistoryView = location.pathname.includes(PATHS.API_CLIENT.HISTORY.RELATIVE);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unsaved changes detection in the API Client’s HTTP view, reducing false positives on initial load and after sending requests.
  * Ensures the dirty state considers only user-editable fields (ignoring response data), leading to more reliable reset behavior.
  * Fewer unnecessary prompts when navigating away or resetting requests, providing a smoother workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->