### PR TITLE
chore: update compatibility check

### DIFF
--- a/app/src/config/constants/compatibility.js
+++ b/app/src/config/constants/compatibility.js
@@ -144,7 +144,7 @@ export const FEATURE_COMPATIBLE_VERSION = {
   },
   [FEATURES.LOCAL_FILE_SYNC]: {
     [GLOBAL_CONSTANTS.APP_MODES.DESKTOP]: {
-      macOS: "25.8.28",
+      macOS: "2.0.0",
       Windows: "25.8.28",
     },
     [GLOBAL_CONSTANTS.APP_MODES.EXTENSION]: null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Chores
  - Updated macOS compatibility for Local File Sync in the Desktop app to version 2.0.0. Windows remains at 25.8.28. No other platforms or features are affected. macOS users may need to update the app to use Local File Sync.

- Documentation
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->