### PR TITLE
fix: github student pack connection experience

### DIFF
--- a/app/src/features/onboarding/componentsV2/GithubStudentPack/GithubStudentPack.tsx
+++ b/app/src/features/onboarding/componentsV2/GithubStudentPack/GithubStudentPack.tsx
@@ -78,7 +78,6 @@ export const GithubStudentPack: React.FC = () => {
   }, [appMode, navigate, user.details?.profile?.email]);
 
   const handleAppSignin = useCallback(() => {
-    setIsLoading(true);
     dispatch(
       globalActions.toggleActiveModal({
         modalName: "authModal",
@@ -88,7 +87,6 @@ export const GithubStudentPack: React.FC = () => {
           redirectURL: window.location.href,
           eventSource: "github_student_pack",
           callback: () => {
-            setIsLoading(false);
             handleGithubAuthorization();
           },
         },
@@ -98,8 +96,6 @@ export const GithubStudentPack: React.FC = () => {
   }, [handleGithubAuthorization, dispatch]);
 
   const handleGithubSignIn = useCallback(async () => {
-    setIsLoading(true);
-
     if (!user.loggedIn) {
       handleAppSignin();
       return;

--- a/app/src/features/onboarding/screens/auth/modals/AuthModal/AuthModal.tsx
+++ b/app/src/features/onboarding/screens/auth/modals/AuthModal/AuthModal.tsx
@@ -23,6 +23,7 @@ interface AuthModalProps {
   authMode?: string;
   eventSource: string;
   redirectURL?: string;
+  callback?: () => void;
 }
 
 export const AuthModal: React.FC<AuthModalProps> = ({
@@ -31,6 +32,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
   eventSource = "",
   authMode = APP_CONSTANTS.AUTH.ACTION_LABELS.LOG_IN,
   redirectURL = window.location.href,
+  callback = () => {},
 }) => {
   const navigate = useNavigate();
   const appMode = useSelector(getAppMode);
@@ -50,8 +52,9 @@ export const AuthModal: React.FC<AuthModalProps> = ({
   useEffect(() => {
     if (user.loggedIn) {
       toggleModal(false);
+      callback?.();
     }
-  }, [user.loggedIn, toggleModal]);
+  }, [user.loggedIn, toggleModal, callback]);
 
   useEffect(() => {
     if (!isWebAppSignup && isOpen) {

--- a/app/src/layouts/AppLayout/GlobalModals/index.tsx
+++ b/app/src/layouts/AppLayout/GlobalModals/index.tsx
@@ -25,6 +25,7 @@ export const GlobalModals = () => {
               eventSource={activeModals.authModal.props.eventSource}
               closable={activeModals.authModal.props.closable}
               redirectURL={activeModals.authModal.props.redirectURL}
+              {...activeModals.authModal.props}
             />
           ) : (
             <RQAuthModal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a GitHub sign-in flow to verify GitHub Student Pack eligibility, with clear success/not-eligible outcomes, toasts, and redirect on success.
  * Added a login modal that appears when authorization is started while logged out, then resumes the GitHub flow after login.

* **Style**
  * Updated copy to consistently reference GitHub and simplified messaging.
  * Unified primary action button sizing to large and removed disabled state; “Connect with GitHub” is now always clickable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->