### PR TITLE
[ONCALL-60] fix: extension rule application popup not closing

### DIFF
--- a/browser-extension/common/src/custom-elements/test-rule-widget/implicit-test-rule-widget/index.ts
+++ b/browser-extension/common/src/custom-elements/test-rule-widget/implicit-test-rule-widget/index.ts
@@ -111,7 +111,11 @@ class RQImplicitTestRuleWidget extends RQTestRuleWidget {
   }
 
   resumeWidgetTimer() {
-    this.show();
+    this.#widgetDisplayStartTime = Date.now();
+    this.#widgetDisplayTimerId = setTimeout(() => {
+      super.hide();
+      this.#widgetDisplayRemainingTime = IMPLICIT_WIDGET_DISPLAY_TIME;
+    }, this.#widgetDisplayRemainingTime);
   }
 
   triggerAppliedRuleClickedEvent(detail: any) {


### PR DESCRIPTION
Fixes: https://github.com/requestly/requestly/issues/3538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Test Rule widget’s display timing: when resumed, it now stays visible for the correct remaining duration and auto-hides reliably.
  * Eliminates flicker or premature re-display when resuming, providing smoother, more predictable behavior during pauses and resumes.
  * Ensures consistent visibility timing across interactions, enhancing the overall user experience with the widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->