### PR TITLE
Using existing hooks to respond to abort

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunConfigView/RunConfigView.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunConfigView/RunConfigView.tsx
@@ -106,7 +106,7 @@ const RunCollectionButton: React.FC<{ disabled?: boolean }> = ({ disabled = fals
   }, [runCollection, runContext, executor]);
 
   const handleCancelRunClick = useCallback(() => {
-    runContext.runResultStore.getState().abortController?.abort();
+    runContext.runResultStore.getState().abortController.abort();
   }, [runContext]);
 
   const isRunning = runStatus === RunStatus.RUNNING;

--- a/app/src/features/apiClient/store/collectionRunResult/runResult.store.ts
+++ b/app/src/features/apiClient/store/collectionRunResult/runResult.store.ts
@@ -90,7 +90,7 @@ export type RunResultState = {
   currentlyExecutingRequest: CurrentlyExecutingRequest;
   abortController: AbortController;
 
-  clearAll(): void;
+  reset(): void;
   setCurrentlyExecutingRequest(request: CurrentlyExecutingRequest): void;
   addResult(result: RequestExecutionResult): void;
   setRunStatus(status: RunStatus): void;
@@ -127,7 +127,7 @@ export function createRunResultStore() {
     currentlyExecutingRequest: null,
     abortController: new AbortController(),
 
-    clearAll() {
+    reset() {
       set({
         startTime: null,
         endTime: null,


### PR DESCRIPTION
The larger proposed change is to use the existing groundwork(all the before/after hooks we have) to respond to an abort.
Earlier, we had this code sprinkled in a lot of places, with this PR we aim to consolidated to only a few known areas.