### PR TITLE
[ONCALL-90] fix: rule table overflowing when app banner is visible

### DIFF
--- a/app/src/componentsV2/AppNotificationBanner/index.tsx
+++ b/app/src/componentsV2/AppNotificationBanner/index.tsx
@@ -24,6 +24,12 @@ export const AppNotificationBanner: React.FC = () => {
   const checkBannerVisibility = useBannerVisibility(banner?.id);
 
   useEffect(() => {
+    if (banner && checkBannerVisibility) {
+      dispatch(globalActions.updateIsAppBannerVisible(true));
+    }
+  }, [banner, checkBannerVisibility, dispatch]);
+
+  useEffect(() => {
     if (banner && isBannerVisible) {
       trackAppNotificationBannerViewed(banner.id);
     }

--- a/app/src/componentsV2/AppNotificationBanner/index.tsx
+++ b/app/src/componentsV2/AppNotificationBanner/index.tsx
@@ -26,6 +26,8 @@ export const AppNotificationBanner: React.FC = () => {
   useEffect(() => {
     if (banner && checkBannerVisibility) {
       dispatch(globalActions.updateIsAppBannerVisible(true));
+    } else {
+      dispatch(globalActions.updateIsAppBannerVisible(false));
     }
   }, [banner, checkBannerVisibility, dispatch]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the app notification banner is consistently recognized as visible when displayed.
  * Improves reliability across navigation and renders so visibility state matches what users see.
  * No visual or interaction changes; this is a behind-the-scenes sync to improve accuracy and tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->