### PR TITLE
[ONCALL-88] fix: activeWorkspace selector returning null

### DIFF
--- a/app/src/store/slices/workspaces/selectors.ts
+++ b/app/src/store/slices/workspaces/selectors.ts
@@ -2,6 +2,7 @@ import { RootState } from "store/types";
 import { workspacesEntityAdapter } from "./slice";
 import { ReducerKeys } from "store/constants";
 import { Workspace } from "features/workspaces/types";
+import { captureException } from "@sentry/react";
 
 const sliceRootState = (state: RootState) => state[ReducerKeys.WORKSPACE];
 
@@ -35,7 +36,15 @@ export const getActiveWorkspace = (state: RootState) => {
     return dummyPersonalWorkspace;
   }
 
-  return getWorkspaceById(activeWorkspaceId)(state);
+  const activeWorkspace = getWorkspaceById(activeWorkspaceId)(state);
+
+  if (!activeWorkspace) {
+    captureException(new Error("Active workspace not found"), {
+      extra: { activeWorkspaceId, activeWorkspace },
+    });
+  }
+
+  return activeWorkspace ?? dummyPersonalWorkspace;
 };
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a selected workspace is unavailable. The app now gracefully falls back to your personal workspace instead of failing, ensuring uninterrupted access.
  * Reduced occurrences of blank or error states after workspace or account changes.
  * Enhanced error reporting to help us detect and resolve workspace selection issues faster, improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->