### PR TITLE
fix: HTTP request prep service breaking when rendering path variables

### DIFF
--- a/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestPreparationService.ts
+++ b/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestPreparationService.ts
@@ -18,6 +18,10 @@ export class HttpRequestPreparationService {
   private renderPathVariables(url: string, pathVariables: RQAPI.PathVariable[]): string {
     const variableValues: Record<RQAPI.PathVariable["key"], RQAPI.PathVariable["value"]> = {};
 
+    if (!pathVariables || pathVariables.length === 0) {
+      return url;
+    }
+
     pathVariables.forEach((variable) => {
       variableValues[variable.key] = variable.value;
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling for API requests without path variables, preventing errors by leaving the URL unchanged when variables are missing or empty.
  * Reduces unexpected request failures (e.g., 404s) and improves reliability of API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->