### PR TITLE
[ENGG-4485] fix: block api client page reload if any tab cannot be closed

### DIFF
--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -40,7 +40,22 @@ export const TabsContainer: React.FC = () => {
 
   const { setUrl } = useSetUrl();
 
-  const hasUnsavedChanges = Array.from(tabs.values()).some((tab) => tab.getState().unsaved || !tab.getState().canCloseTab());
+  const hasUnsavedChanges = Array.from(tabs.values()).some(
+    (tab) => tab.getState().unsaved || !tab.getState().canCloseTab()
+  );
+
+  useEffect(() => {
+    const unloadListener = (e: any) => {
+      e.preventDefault();
+      e.returnValue = "Are you sure?";
+    };
+
+    if (hasUnsavedChanges) {
+      window.addEventListener("beforeunload", unloadListener);
+    }
+
+    return () => window.removeEventListener("beforeunload", unloadListener);
+  }, [hasUnsavedChanges]);
 
   unstable_useBlocker(({ nextLocation }) => {
     const isNextLocationApiClientView = nextLocation.pathname.startsWith("/api-client");

--- a/app/src/hooks/useHasUnsavedChanges.ts
+++ b/app/src/hooks/useHasUnsavedChanges.ts
@@ -6,19 +6,6 @@ export const useHasUnsavedChanges = <T>(currentValue: T, reset = false) => {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   useEffect(() => {
-    const unloadListener = (e: any) => {
-      e.preventDefault();
-      e.returnValue = "Are you sure?";
-    };
-
-    if (hasUnsavedChanges) {
-      window.addEventListener("beforeunload", unloadListener);
-    }
-
-    return () => window.removeEventListener("beforeunload", unloadListener);
-  }, [hasUnsavedChanges]);
-
-  useEffect(() => {
     setHasUnsavedChanges(!isEqual(originalValue.current, currentValue));
   }, [currentValue]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added a browser leave-page warning when there are unsaved changes in tabs, helping prevent accidental data loss.

* **Refactor**
  * Centralized the unsaved-changes leave warning to improve consistency and reduce duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->