### PR TITLE
[ONCALL-110] fix: convert null & undefined sync value to empty string in postman importer

### DIFF
--- a/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/utils.ts
+++ b/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/utils.ts
@@ -59,7 +59,7 @@ export const processPostmanEnvironmentData = (fileContent: PostmanEnvironmentExp
       acc[variable.key] = {
         id: index,
         isPersisted: true,
-        syncValue: variable.value,
+        syncValue: variable.value ?? "",
         type:
           variable.type === EnvironmentVariableType.Secret
             ? EnvironmentVariableType.Secret


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Postman environment import reliability by defaulting missing variable values to empty strings, preventing crashes or skipped entries.
  * Ensures all environment variables are consistently captured even when values are null or undefined, resulting in smoother imports and fewer surprises.
  * Reduces import interruptions and maintains continuity in workflows, improving overall stability during environment setup from Postman collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

For case, if value is undefined, it indicates that postman imported file is not correct, hence a popup appears to import a correct file
<img width="1732" height="932" alt="image" src="https://github.com/user-attachments/assets/02734938-d571-444d-a9bd-955888f738d7" />
