### PR TITLE
[ENGG-4496] feat: virtualization in collection runner result view

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/HistoryDrawer/historyDrawer.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/HistoryDrawer/historyDrawer.scss
@@ -35,16 +35,31 @@
 
     .ant-drawer-body {
       padding: 0;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
     }
   }
 
   .history-drawer-result-container {
     position: relative;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
 
     .back-btn {
       position: absolute;
       top: 2px;
       left: 2px;
+      z-index: 1;
+    }
+
+    .run-result-view-details {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
     }
   }
 

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/HistoryDrawer/historyDrawer.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/HistoryDrawer/historyDrawer.scss
@@ -52,14 +52,6 @@
       position: absolute;
       top: 2px;
       left: 2px;
-      z-index: 1;
-    }
-
-    .run-result-view-details {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
     }
   }
 
@@ -67,6 +59,16 @@
     .result-header {
       margin-left: 34px;
       padding: var(--space-4, 10px) var(--space-6, 16px) var(--space-4, 8px) var(--space-2, 4px);
+    }
+
+    .ant-tabs-content {
+      height: 100%;
+    }
+
+    .ant-tabs-tabpane {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
     }
 
     .ant-tabs-nav {

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
@@ -247,7 +247,6 @@ const TestResultList: React.FC<{
 
   // Virtualized list for multiple iterations
   const rowRenderer = ({ index, key, style, parent }: any) => {
-    console.log("!!!debug", "rendering now", index);
     const [iteration, details] = resultsToShow[index];
     const isCurrentIteration = iteration === currentlyExecutingRequest?.iteration;
 

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
@@ -481,7 +481,7 @@ export const RunResultContainer: React.FC<{
               items={tabItems}
               animated={false}
               activeKey={activeTab}
-              destroyInactiveTabPane={false}
+              destroyInactiveTabPane={true}
               onChange={(activeKey) => setActiveTab(activeKey as RunResultTabKey)}
               className="test-result-tabs"
             />

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
@@ -180,7 +180,7 @@ const TestResultList: React.FC<{
 }> = ({ tabKey, results, iterations }) => {
   const [currentlyExecutingRequest] = useRunResultStore((s) => [s.currentlyExecutingRequest]);
 
-  const COLLAPSED_HEIGHT = 28; // Fixed height for collapsed iteration header
+  const COLLAPSED_HEIGHT = 26.5; // Fixed height for collapsed iteration header
 
   // Track the measured expanded height (all expanded rows have same height)
   const expandedHeightRef = useRef<number | null>(null);
@@ -275,17 +275,7 @@ const TestResultList: React.FC<{
 
           return (
             <div
-              ref={(node) => {
-                registerChild(node);
-
-                // Measure on first render if expanded and height not yet cached
-                const isExpanded = expandedStateRef.current.has(iteration);
-                if (node && isExpanded && expandedHeightRef.current === null) {
-                  measure();
-                  const rowHeight = cacheRef.current.rowHeight({ index });
-                  expandedHeightRef.current = rowHeight;
-                }
-              }}
+              ref={registerChild}
               style={style}
               className="test-result-collapse-container"
               onTransitionEnd={handleTransitionEnd}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
@@ -164,7 +164,7 @@ const TestDetails: React.FC<{
       ) : (
         <div className="results-list">
           {requestExecutionResult.testResults?.map((test) => {
-            return <TestResultItem testResult={test} key={test.name} />;
+            return <TestResultItem testResult={test} />;
           })}
         </div>
       )}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
@@ -1,13 +1,48 @@
 .run-result-view-details {
   user-select: none;
   height: 100%;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+
+  .virtualized-test-results-container {
+    flex: 1;
+    height: 0; // Important: Forces flex child to respect flex layout
+    display: flex;
+    flex-direction: column;
+
+    .ReactVirtualized__List {
+      outline: none;
+
+      &::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: var(--requestly-color-surface-0, #1a1a1a);
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background: var(--requestly-color-white-t-10, rgba(255, 255, 255, 0.1));
+        border-radius: 4px;
+
+        &:hover {
+          background: var(--requestly-color-white-t-20, rgba(255, 255, 255, 0.2));
+        }
+      }
+    }
+
+    .test-result-collapse-container {
+      margin: 0;
+      padding: 0;
+    }
+  }
 
   .result-header {
     display: flex;
     align-items: center;
     gap: var(--space-8, 24px);
     padding: var(--space-4, 8px) var(--space-6, 16px);
+    flex-shrink: 0;
 
     .run-metric {
       flex-shrink: 0;
@@ -28,7 +63,32 @@
   }
 
   .result-tabs-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0; // Allows flex child to shrink
+
     .ant-tabs {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+
+      .ant-tabs-content-holder {
+        flex: 1;
+        min-height: 0; // Allows flex child to shrink
+        overflow: auto; // Enable scrolling
+      }
+
+      .ant-tabs-content {
+        height: 100%;
+      }
+
+      .ant-tabs-tabpane {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+
       .ant-tabs-nav-wrap {
         display: flex;
         padding: var(--space-4, 8px) 0;
@@ -104,12 +164,28 @@
       }
     }
 
-    .test-result-collapse-container.tests-results-view-container {
-      padding-bottom: 0;
-      margin-top: 0;
-      margin-bottom: 2px;
+    .test-result-collapse-container {
+      margin: 0 !important;
+      padding: 0 !important;
+      border-bottom: 1px solid var(--requestly-color-white-t-10, rgba(255, 255, 255, 0.06));
+
+      &:last-child {
+        border-bottom: none;
+      }
 
       .ant-collapse {
+        background: transparent;
+        border: none;
+
+        .ant-collapse-item {
+          border: none !important;
+          margin-bottom: 0 !important;
+
+          &:last-child {
+            margin-bottom: 0 !important;
+          }
+        }
+
         .ant-collapse-expand-icon {
           width: 12px;
 
@@ -143,18 +219,29 @@
 
           border-radius: 0;
           background: var(--requestly-color-surface-0, #212121);
+          margin: 0 !important;
+          border: none;
+        }
+
+        .ant-collapse-content {
+          border: none;
+          margin: 0;
         }
 
         .ant-collapse-content-box {
           padding: 0;
+          margin: 0;
         }
       }
     }
 
     .tests-results-view-container {
       height: 100%;
-      overflow-y: auto;
-      padding-bottom: 25px;
+      overflow-y: hidden;
+
+      &:not(.virtualized-test-results-container) {
+        padding-bottom: 25px;
+      }
 
       .test-details-container {
         display: flex;

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
@@ -4,24 +4,11 @@
   display: flex;
   flex-direction: column;
 
-  .virtualized-test-results-container {
-    flex: 1;
-    height: 0; // Important: Forces flex child to respect flex layout
-    display: flex;
-    flex-direction: column;
-
-    .test-result-collapse-container {
-      margin: 0;
-      padding: 0;
-    }
-  }
-
   .result-header {
     display: flex;
     align-items: center;
     gap: var(--space-8, 24px);
     padding: var(--space-4, 8px) var(--space-6, 16px);
-    flex-shrink: 0;
 
     .run-metric {
       flex-shrink: 0;
@@ -51,22 +38,6 @@
       height: 100%;
       display: flex;
       flex-direction: column;
-
-      .ant-tabs-content-holder {
-        flex: 1;
-        min-height: 0; // Allows flex child to shrink
-        overflow: auto; // Enable scrolling
-      }
-
-      .ant-tabs-content {
-        height: 100%;
-      }
-
-      .ant-tabs-tabpane {
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-      }
 
       .ant-tabs-nav-wrap {
         display: flex;
@@ -144,9 +115,9 @@
     }
 
     .test-result-collapse-container {
-      margin: 0 !important;
-      padding: 0 !important;
-      border-bottom: 1px solid var(--requestly-color-white-t-10, rgba(255, 255, 255, 0.06));
+      margin: 0;
+      padding: 0;
+      margin-bottom: 2px;
 
       &:last-child {
         border-bottom: none;
@@ -157,12 +128,7 @@
         border: none;
 
         .ant-collapse-item {
-          border: none !important;
-          margin-bottom: 0 !important;
-
-          &:last-child {
-            margin-bottom: 0 !important;
-          }
+          border: none;
         }
 
         .ant-collapse-expand-icon {
@@ -198,19 +164,15 @@
 
           border-radius: 0;
           background: var(--requestly-color-surface-0, #212121);
-          margin: 0 !important;
-          border: none;
         }
 
         .ant-collapse-content {
           border: none;
-          margin: 0;
           background: transparent;
         }
 
         .ant-collapse-content-box {
           padding: 0;
-          margin: 0;
         }
       }
     }
@@ -218,10 +180,6 @@
     .tests-results-view-container {
       height: 100%;
       overflow-y: hidden;
-
-      &:not(.virtualized-test-results-container) {
-        padding-bottom: 25px;
-      }
 
       .test-details-container {
         display: flex;

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
@@ -226,6 +226,7 @@
         .ant-collapse-content {
           border: none;
           margin: 0;
+          background: transparent;
         }
 
         .ant-collapse-content-box {

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
@@ -115,13 +115,9 @@
     }
 
     .test-result-collapse-container {
-      margin: 0;
-      padding: 0;
+      padding-bottom: 0;
+      margin-top: 0;
       margin-bottom: 2px;
-
-      &:last-child {
-        border-bottom: none;
-      }
 
       .ant-collapse {
         background: transparent;
@@ -180,6 +176,7 @@
     .tests-results-view-container {
       height: 100%;
       overflow-y: hidden;
+      padding-bottom: 25px;
 
       .test-details-container {
         display: flex;

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/runResultContainer.scss
@@ -10,27 +10,6 @@
     display: flex;
     flex-direction: column;
 
-    .ReactVirtualized__List {
-      outline: none;
-
-      &::-webkit-scrollbar {
-        width: 8px;
-      }
-
-      &::-webkit-scrollbar-track {
-        background: var(--requestly-color-surface-0, #1a1a1a);
-      }
-
-      &::-webkit-scrollbar-thumb {
-        background: var(--requestly-color-white-t-10, rgba(255, 255, 255, 0.1));
-        border-radius: 4px;
-
-        &:hover {
-          background: var(--requestly-color-white-t-20, rgba(255, 255, 255, 0.2));
-        }
-      }
-    }
-
     .test-result-collapse-container {
       margin: 0;
       padding: 0;


### PR DESCRIPTION
Major challenged faced was in calculating the height. Antd takes some time to collapse/expand due to which virtualised list was calculating wrong heights if calculated immediately on click. 

## Solution
- Some delay was introduced in calculating the heights. Heights were calculated after transition animation was completed. But this introduced some jitter when collapsing/expanding
- To solve the jitter, we have made use of the fact that for a particular iteration the collapsed and expanded height would be same.
- As all the iterations are expanded by default, we cache the expanded height on ref load and this height is used to resize immediately on click. The collapsed height is hardcoded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtualized test results for multi-iteration runs, improving performance and responsiveness.
  * Dynamic row heights with smoother expand/collapse transitions.
  * Tabs now free resources when inactive for better memory usage.

* **Style**
  * Updated to a full-height, flexible column layout across the results and history views.
  * Improved scrolling behavior and content sizing to prevent clipping.
  * Cleaner collapse styling with transparent backgrounds and reduced borders.

* **Refactor**
  * Reduced unnecessary re-renders and more accurate iteration counting.
  * Preserves existing behavior for single-iteration results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->