### PR TITLE
[ENGG-4489] fix: default state of local workspace support

### DIFF
--- a/app/src/features/apiClient/helpers/modules/sync/useCheckLocalSyncSupport.ts
+++ b/app/src/features/apiClient/helpers/modules/sync/useCheckLocalSyncSupport.ts
@@ -23,7 +23,7 @@ export const useCheckLocalSyncSupport = (options: Props = { skipWorkspaceCheck: 
   const isWorkspaceLocal = options.skipWorkspaceCheck ? true : rawIsWorkspaceLocal;
   const appMode = useSelector(getAppMode);
 
-  const [isLocalSyncSupported, setIsLocalSyncSupported] = useState(true);
+  const [isLocalSyncSupported, setIsLocalSyncSupported] = useState(false);
 
   useEffect(() => {
     if (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local Sync now initializes as not supported until verified, preventing misleading “supported” indicators on first load.
  * Eliminates brief UI flicker and avoids premature display of Local Sync controls or prompts during initial app render.
  * Ensures the interface reflects actual device capability only after a proper check, improving reliability of the first-run experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->