### PR TITLE
[ENGG-4459] fix: make test result title and test tab titles consistent

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -96,10 +96,7 @@ export const CollectionRow: React.FC<Props> = ({
   const [collectionsToExport, setCollectionsToExport] = useState([]);
   const { onNewClickV2 } = useApiClientContext();
   const context = useApiClientFeatureContext();
-  const [openTab, activeTabSource] = useTabServiceWithSelector((state) => [
-    state.openTab,
-    state.activeTabSource,
-  ]);
+  const [openTab, activeTabSource] = useTabServiceWithSelector((state) => [state.openTab, state.activeTabSource]);
 
   const [getParentChain, getRecordStore] = useAPIRecords((state) => [state.getParentChain, state.getRecordStore]);
   const activeWorkspace = useSelector(getActiveWorkspace);
@@ -190,7 +187,7 @@ export const CollectionRow: React.FC<Props> = ({
           label: (
             <div className="collection-row-option">
               <MdOutlineVideoLibrary />
-              Run tests
+              Run
             </div>
           ),
           onClick: (itemInfo) => {
@@ -267,8 +264,6 @@ export const CollectionRow: React.FC<Props> = ({
           recordsToMove: [item.record],
           destination,
         });
-
-
 
         if (!expandedRecordIds.includes(record.id)) {
           const newExpandedRecordIds = [...expandedRecordIds, destination.collectionId];

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultContainer/RunResultContainer.tsx
@@ -27,8 +27,8 @@ import { RQTooltip } from "lib/design-system-v2/components";
 
 enum RunResultTabKey {
   ALL = "all",
-  SUCCESS = "success",
-  FAIL = "fail",
+  PASSED = "passed",
+  FAILED = "failed",
   SKIPPED = "skipped",
 }
 
@@ -37,7 +37,7 @@ const testResultListEmptyStateMessage: Record<RunResultTabKey, { title: string; 
     title: "No tests found",
     description: "No tests to show.",
   },
-  [RunResultTabKey.FAIL]: {
+  [RunResultTabKey.FAILED]: {
     title: "No failed tests",
     description: "No tests failed in this run.",
   },
@@ -45,7 +45,7 @@ const testResultListEmptyStateMessage: Record<RunResultTabKey, { title: string; 
     title: "No skipped tests",
     description: "No tests skipped in this run.",
   },
-  [RunResultTabKey.SUCCESS]: {
+  [RunResultTabKey.PASSED]: {
     title: "No successful tests",
     description: "No tests passed in this run.",
   },
@@ -285,14 +285,14 @@ export const RunResultContainer: React.FC<{
         children: <TestResultList tabKey={RunResultTabKey.ALL} results={summary.totalTests} />,
       },
       {
-        key: RunResultTabKey.SUCCESS,
-        label: <TestResultTabTitle title="Success" count={summary.successTestsCounts} loading={running} />,
-        children: <TestResultList tabKey={RunResultTabKey.SUCCESS} results={summary.successTests} />,
+        key: RunResultTabKey.PASSED,
+        label: <TestResultTabTitle title="Passed" count={summary.successTestsCounts} loading={running} />,
+        children: <TestResultList tabKey={RunResultTabKey.PASSED} results={summary.successTests} />,
       },
       {
-        key: RunResultTabKey.FAIL,
-        label: <TestResultTabTitle title="Fail" count={summary.failedTestsCounts} loading={running} />,
-        children: <TestResultList tabKey={RunResultTabKey.FAIL} results={summary.failedTests} />,
+        key: RunResultTabKey.FAILED,
+        label: <TestResultTabTitle title="Failed" count={summary.failedTestsCounts} loading={running} />,
+        children: <TestResultList tabKey={RunResultTabKey.FAILED} results={summary.failedTests} />,
       },
       {
         key: RunResultTabKey.SKIPPED,

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultView.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultView.tsx
@@ -31,7 +31,7 @@ export const RunResultView: React.FC = () => {
   return (
     <div className="run-result-view-container">
       <div className="run-result-view-header">
-        <span className="header">Result</span>
+        <span className="header">Test results</span>
         <RQButton
           size="small"
           type="transparent"

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/response/ApiClientBottomSheet/ApiClientBottomSheet.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/response/ApiClientBottomSheet/ApiClientBottomSheet.tsx
@@ -84,7 +84,7 @@ export const ApiClientBottomSheet: React.FC<Props> = ({
       },
       {
         key: BOTTOM_SHEET_TAB_KEYS.TEST_RESULTS,
-        label: <>Tests {testResultsStats}</>,
+        label: <>Test results {testResultsStats}</>,
         children: <TestsView testResults={testResults} handleTestResultRefresh={handleTestResultRefresh} />,
       },
     ];


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated terminology across test result views: tabs now labeled “All”, “Passed”, and “Failed” (replacing “Success”/“Fail”).
  * Header updated from “Result” to “Test results” for clarity.
  * Bottom sheet tab label changed to “Test results {stats}” for consistency.
  * Collection options menu label shortened from “Run tests” to “Run”.
  * Minor spacing and formatting polish; no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->