### PR TITLE
[ONCALL-115] fix: TypeError: (ts.doc || "").split is not a function

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/GraphQLEditor/GraphQLEditor.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/GraphQLEditor/GraphQLEditor.tsx
@@ -29,6 +29,13 @@ type EditorProps = OperationEditorProps | VariablesEditorProps;
 
 const basicExtensions = [basicSetup, vscodeDark, keymap.of([indentWithTab])];
 
+const normalizeDocValue = (doc: any): string => {
+  if (typeof doc === "object" && doc !== null) {
+    return JSON.stringify(doc, null, 2);
+  }
+  return typeof doc === "string" ? doc : "";
+};
+
 export const GraphQLEditor: React.FC<EditorProps> = (props) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -92,17 +99,18 @@ export const GraphQLEditor: React.FC<EditorProps> = (props) => {
       if (updateTimeoutRef.current) {
         clearTimeout(updateTimeoutRef.current);
       }
+      const docValue = normalizeDocValue(props.initialDoc);
 
       // Debounce the update to avoid rapid successive updates
       updateTimeoutRef.current = setTimeout(() => {
         const currentDoc = viewRef.current?.state.doc.toString();
-        if (currentDoc !== props.initialDoc) {
+        if (currentDoc !== docValue) {
           // Only update if the content is actually different
           const transaction = viewRef.current!.state.update({
             changes: {
               from: 0,
               to: viewRef.current!.state.doc.length,
-              insert: props.initialDoc,
+              insert: docValue,
             },
           });
           viewRef.current!.dispatch(transaction);
@@ -139,12 +147,7 @@ export const GraphQLEditor: React.FC<EditorProps> = (props) => {
       extensions.push(json());
     }
 
-    const docValue =
-      typeof initialDocRef.current === "object" && initialDocRef.current !== null
-        ? JSON.stringify(initialDocRef.current, null, 2)
-        : typeof initialDocRef.current === "string"
-        ? initialDocRef.current
-        : "";
+    const docValue = normalizeDocValue(initialDocRef.current);
 
     const state = EditorState.create({
       doc: docValue,


### PR DESCRIPTION
Similar Issue: https://github.com/codemirror/codemirror5/issues/5526

Rogue object here is our variables, variables data from history was being passed as a JavaScript object ({siteId: 954}) instead of a JSON string `('{\n  "siteId": 954\n}')` to the CodeMirror editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL editor now consistently loads the initial document without showing empty content for non-string inputs.
  * Prevents unnecessary updates by normalizing the initial document, reducing flicker and spurious change events.

* **Refactor**
  * Improved handling of initial document values for the GraphQL editor to ensure consistent behavior.
  * Pretty-printed JSON is shown when the initial document is provided as an object, enhancing readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->