### PR TITLE
[ONCALL-94] fix: badge style in testResults

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/response/TestsView/testsView.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/response/TestsView/testsView.scss
@@ -65,7 +65,7 @@
           font-size: var(--requestly-font-size-xs);
           position: relative;
           top: -1px;
-          line-height: 1.1rem;
+          line-height: 1rem;
         }
       }
     }


### PR DESCRIPTION
<img width="1468" height="753" alt="Screenshot 2025-10-10 at 7 09 22 AM" src="https://github.com/user-attachments/assets/99f0160b-6d18-4193-b777-909352762f8f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the appearance of count badges in the test results header for improved visual consistency.
  - Adjusted dimensions, padding, and line-height to ensure consistent sizing and better vertical alignment.
  - Enhances readability of badges across different values and screen densities.
  - Delivers a cleaner, more polished look without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->