### PR TITLE
fix: replace single quotes with double quotes in npm scripts for Windows compatibility

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,9 +29,9 @@
     "type-check": "tsc --noEmit",
     "build": "vite build",
     "preview": "npm run build && vite preview",
-    "start": "concurrently --kill-others --names '@requestly/shared, @requestly/app' 'cd ../shared && npm run watch' 'vite'",
-    "dev": "concurrently --kill-others --names '@requestly/shared, @requestly/app' 'cd ../shared && npm run watch' 'cross-env REACT_APP_ENV=DEV vite'",
-    "emulated-dev": "concurrently --kill-others --names '@requestly/shared, @requestly/app' 'cd ../shared && npm run watch' 'cross-env REACT_APP_ENV=EMULATOR vite --mode dev-emulator'",
+    "start": "concurrently --kill-others --names \"@requestly/shared, @requestly/app\" \"cd ../shared && npm run watch\" \"vite\"",
+    "dev": "concurrently --kill-others --names \"@requestly/shared, @requestly/app\" \"cd ../shared && npm run watch\" \"cross-env REACT_APP_ENV=DEV vite\"",
+    "emulated-dev": "concurrently --kill-others --names \"@requestly/shared, @requestly/app\" \"cd ../shared && npm run watch\" \"cross-env REACT_APP_ENV=EMULATOR vite --mode dev-emulator\"",
     "emulated-start": "cross-env REACT_APP_ENV=EMULATOR vite --mode dev-emulator"
   },
   "browserslist": [


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: https://github.com/requestly/requestly/issues/3673

## 📜 Summary of changes:

- `package.json`: Updated npm script quote formatting for Windows compatibility

### Solution
- Replaced single quotes with double quotes in `concurrently` command arguments
- Updated `start`, `dev`, and `emulated-dev` scripts for cross-platform compatibility
- Ensures proper shell command parsing on both Unix and Windows environments

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

Clone the requestly repo in a Windows machine and verify if npm start in /app dir is working as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized quoting in development and start scripts to ensure consistent behavior across different environments and shells.
  * Improved script readability and reduced potential for command parsing issues during local development and emulated runs.
  * No changes to the actual commands or execution order.
  * No user-facing functionality affected; this update focuses on smoother developer workflows and more reliable script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->