### PR TITLE
[ONCALL-130] fix: autogenerated store not populated correctly in requestPreparator

### DIFF
--- a/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestPreparationService.ts
+++ b/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestPreparationService.ts
@@ -94,13 +94,13 @@ export class HttpRequestPreparationService {
     const newQueryParams = getAllQueryParams();
 
     const mergedHeaders = new Map();
-    newHeaders.forEach((header) => mergedHeaders.set(header.key, header));
     existingHeaders.forEach((header) => mergedHeaders.set(header.key, header));
+    newHeaders.forEach((header) => mergedHeaders.set(header.key, header));
     const headers = Array.from(mergedHeaders.values()).map((kv, index) => ({ ...kv, id: index, isEnabled: true }));
 
     const mergedQueryParams = new Map();
-    newQueryParams.forEach((param) => mergedQueryParams.set(param.key, param));
     existingQueryParams.forEach((param) => mergedQueryParams.set(param.key, param));
+    newQueryParams.forEach((param) => mergedQueryParams.set(param.key, param));
     const queryParams = Array.from(mergedQueryParams.values()).map((kv, index) => ({
       ...kv,
       id: index,


### PR DESCRIPTION
Fixes #3701


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Initializes auto-generated request values earlier so derived headers and query parameters are populated reliably.
  * Merges newly derived headers and query params with existing ones, ensuring new values take precedence while preserving enabled items.
  * Reduces intermittent missing or incorrect derived values when preparing requests, improving request accuracy and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->