### PR TITLE
fix: variables used in autogenerated store are unresolved after request preparation

### DIFF
--- a/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestPreparationService.ts
+++ b/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestPreparationService.ts
@@ -103,7 +103,10 @@ export class HttpRequestPreparationService {
     workingEntry.request.queryParams = updateRequestWithAuthOptions(workingEntry.request.queryParams, queryParams);
 
     const { renderedVariables, result: renderedEntry } = this.renderVariables(workingEntry, recordId, this.ctx);
-    workingEntry.request.url = this.renderPathVariables(renderedEntry.request.url, renderedEntry.request.pathVariables);
+    renderedEntry.request.url = this.renderPathVariables(
+      renderedEntry.request.url,
+      renderedEntry.request.pathVariables
+    );
 
     renderedEntry.request.url = addUrlSchemeIfMissing(renderedEntry.request.url);
 


### PR DESCRIPTION
The variables were being resolved before fetching from autogenerated store. This PR resolves the variables after autogenerated store headers are added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the internal sequence for preparing HTTP requests so variable rendering and path substitution occur after authentication-related header and query parameter updates. This yields more consistent URL construction and more reliable authorization handling when sending requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->