### PR TITLE
[ENGG-4500] chore: Improve Error Boundary - Part4

### DIFF
--- a/app/src/components/misc/PageError/RouterError.tsx
+++ b/app/src/components/misc/PageError/RouterError.tsx
@@ -1,11 +1,10 @@
 import { Button, Typography } from "antd";
 import React, { useEffect } from "react";
-import * as Sentry from "@sentry/react";
 import "./pageError.scss";
 import LINKS from "config/constants/sub/links";
 import { trackErrorBoundaryShown } from "modules/analytics/events/common/error-boundaries";
 import { useRouteError } from "react-router-dom";
-import { prepareError, sendErrorToSentry } from "features/apiClient/components/ErrorBoundary/utils";
+import { sendErrorToSentry } from "features/apiClient/components/ErrorBoundary/utils";
 import { ErrorSeverity } from "errors/types";
 
 interface Props {}
@@ -16,7 +15,7 @@ const RouterError: React.FC<Props> = () => {
   useEffect(() => {
     console.log("RouterError", error);
     trackErrorBoundaryShown(error.toString(), "");
-    sendErrorToSentry(prepareError(error, ErrorSeverity.FATAL), "react-router-error-boundary");
+    sendErrorToSentry(error, "react-router-error-boundary", `reactRouter`, ErrorSeverity.FATAL, true, {});
   }, [error]);
 
   return (

--- a/app/src/errors/NativeError.ts
+++ b/app/src/errors/NativeError.ts
@@ -2,8 +2,9 @@ import { ErrorCode, ErrorSeverity } from "./types";
 
 export class NativeError<T extends Record<string, any> = Record<string, any>> extends Error {
   public errorCode: ErrorCode = ErrorCode.UNKNOWN;
-  public severity: ErrorSeverity = ErrorSeverity.DEBUG;
+  public severity: ErrorSeverity = ErrorSeverity.ERROR;
   private _context: Partial<T> = {};
+  public showBoundary: boolean = false;
 
   constructor(message: string) {
     super(message);
@@ -18,6 +19,11 @@ export class NativeError<T extends Record<string, any> = Record<string, any>> ex
 
   setSeverity(severity: ErrorSeverity) {
     this.severity = severity;
+    return this;
+  }
+
+  setShowBoundary(showBoundary: boolean) {
+    this.showBoundary = showBoundary;
     return this;
   }
 

--- a/app/src/errors/RenderableError.tsx
+++ b/app/src/errors/RenderableError.tsx
@@ -4,7 +4,8 @@ import { ErrorSeverity } from "./types";
 
 export abstract class RenderableError<T = any> extends NativeError<T> {
   public severity: ErrorSeverity = ErrorSeverity.WARNING;
-  
+  public showBoundary: boolean = true;
+
   abstract render(): React.ReactNode;
   abstract getErrorHeading(): string;
 }

--- a/app/src/errors/types.ts
+++ b/app/src/errors/types.ts
@@ -3,9 +3,11 @@ export enum ErrorCode {
   UNKNOWN = "unknown",
 }
 
+// Contains the value from Sentry.SeverityLevel
 export enum ErrorSeverity {
-  FATAL = "fatal", // Shows Blocking UI
-  WARNING = "warning", // Shows Non-Blocking UI/Notification
-  DEBUG = "debug", // Captured but not shown to the user (To be triaged)
-  INFO = "info", // Captured but not shown to the user (Can be ignored)
+  FATAL = "fatal",
+  ERROR = "error",
+  WARNING = "warning",
+  INFO = "info",
+  DEBUG = "debug",
 }


### PR DESCRIPTION
- Link severity to Sentry.SeverityLevels
- Capture `unhandled` for NativeError Captured through Error Boundary
    - RenderableError: handled
    - Non RenderableError: unhandled
- Bubble Pure Error to global exception handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new error severity level for improved error categorization
  * Enhanced error boundary display control capabilities

* **Bug Fixes**
  * Improved handling of React component errors and unhandled promise rejections
  * Better error reporting with enhanced contextual information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->