### PR TITLE
[ONCALL-150] fix: TypeError - Failed to construct 'URL': Invalid URL

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/utils.ts
+++ b/app/src/features/apiClient/screens/apiClient/utils.ts
@@ -861,7 +861,13 @@ export const extractPathVariablesFromUrl = (url: string) => {
   }
 
   const urlWithScheme = addUrlSchemeIfMissing(url);
-  const pathname = new URL(urlWithScheme).pathname;
+  let pathname: string = "";
+  try {
+    pathname = new URL(urlWithScheme).pathname;
+  } catch (error) {
+    Logger.log("Invalid URL while extracting path variables:", error);
+    return [];
+  }
 
   // Allow all characters except URL reserved characters: : / ? # [ ] @ ! $ & ' ( ) * + , ; =
   // Also exclude whitespace and control characters for practical reasons


### PR DESCRIPTION
fixes TypeError - Failed to construct 'URL': Invalid URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for URL processing in the API client to enhance application stability. Invalid or malformed URLs are now managed gracefully with proper error logging instead of causing crashes. The API client returns empty results for problematic URLs, ensuring consistent and predictable behavior when handling edge cases and unusual inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->