### PR TITLE
[ONCALL-156] fix: prevent escaping of special characters in variables

### DIFF
--- a/app/src/backend/environment/utils.ts
+++ b/app/src/backend/environment/utils.ts
@@ -105,7 +105,7 @@ const processObject = <T extends Record<string, any>>(input: T, variables: Varia
 const processTemplateString = <T extends string>(input: T, variables: Variables): RenderResult<T> => {
   try {
     const { wrappedTemplate, usedVariables } = collectAndEscapeVariablesFromTemplate(input, variables);
-    const hbsTemplate = compile(wrappedTemplate);
+    const hbsTemplate = compile(wrappedTemplate, { noEscape: true });
     const renderedTemplate = hbsTemplate(variables) as T; // since handlebars generic types resolve to any; not string
 
     return {


### PR DESCRIPTION

https://github.com/user-attachments/assets/fcf7b33d-1aa5-476b-add7-2c8a1636bc30



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated template rendering to preserve raw output during variable substitution, potentially affecting how certain content displays in rendered templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->