### PR TITLE
[ONCALL-166] fix: adds null in current local workspace path in API client breadcrumb for multiworkspace view

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/ApiClientBreadCrumb.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/ApiClientBreadCrumb.tsx
@@ -46,7 +46,7 @@ export const MultiViewBreadCrumb: React.FC<Props> = ({ ...props }) => {
 
   const [getParentChain, getData] = useAPIRecords((s) => [s.getParentChain, s.getData]);
 
-  const localWsPath = currentWorkspace.getState().rawWorkspace.rootPath;
+  const localWsPath = currentWorkspace?.getState()?.rawWorkspace?.rootPath ?? "";
   const truncatePath = truncateString(localWsPath, 40);
 
   const parentCollectionNames = useMemo(() => {
@@ -57,7 +57,7 @@ export const MultiViewBreadCrumb: React.FC<Props> = ({ ...props }) => {
       .reverse()
       .map((id) => {
         return {
-          label: getData(id).name,
+          label: getData(id)?.name,
           pathname: "",
           isEditable: false,
         };
@@ -76,14 +76,16 @@ export const MultiViewBreadCrumb: React.FC<Props> = ({ ...props }) => {
       defaultBreadcrumbs={[
         {
           label: (
-            <div>
-              <Tooltip trigger="hover" title={localWsPath} color="var(--requestly-color-black)" placement="bottom">
-                <span className="api-client-local-workspace-path-breadcrumb">
-                  <LuFolderCog className="api-client-local-workspace-icon" />
-                  {truncatePath}
-                </span>
-              </Tooltip>
-            </div>
+            <Conditional condition={!!truncatePath}>
+              <div>
+                <Tooltip trigger="hover" title={localWsPath} color="var(--requestly-color-black)" placement="bottom">
+                  <span className="api-client-local-workspace-path-breadcrumb">
+                    <LuFolderCog className="api-client-local-workspace-icon" />
+                    {truncatePath}
+                  </span>
+                </Tooltip>
+              </div>
+            </Conditional>
           ),
           pathname: PATHS.API_CLIENT.INDEX,
           isEditable: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved breadcrumb stability by ensuring it only displays when data is available, preventing unnecessary rendering of empty states.
  * Enhanced null-safety checks to prevent potential errors in the API Client breadcrumb display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->