### PR TITLE
fix: remove local sync tooltip for copy cURL and copy URL options in network table

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/index.tsx
@@ -57,7 +57,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ children, log = {}, on
     const menuItems: MenuProps["items"] = [
       {
         key: "copy_curl",
-        label: <LocalWorkspaceTooltip featureName="Copy cURL">Copy cURL</LocalWorkspaceTooltip>,
+        label: "Copy cURL",
         onClick: () => {
           copyToClipBoard(log.requestShellCurl, "cURL copied to clipboard");
           trackTrafficTableDropdownClicked("copy_curl");
@@ -66,7 +66,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ children, log = {}, on
       },
       {
         key: "copy_url",
-        label: <LocalWorkspaceTooltip featureName="Copy URL">Copy URL</LocalWorkspaceTooltip>,
+        label: "Copy URL",
         onClick: () => {
           copyToClipBoard(log.url, "URL copied to clipboard");
           trackTrafficTableDropdownClicked("copy_url");


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified context menu labels in the network traffic inspector for improved clarity and consistency when copying network requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->