### PR TITLE
[ONCALL-174] fix: null handling when fetching collections in runner view

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunConfigView/RunConfigOrderedRequests/ReorderableList/CollectionChain.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunConfigView/RunConfigOrderedRequests/ReorderableList/CollectionChain.tsx
@@ -37,7 +37,7 @@ export const CollectionChain: React.FC<Props> = ({ recordId }) => {
     const parentIds = getParentChain(recordId);
     const parents = parentIds
       .map((id) => getData(id))
-      .filter((record): record is RQAPI.ApiClientRecord => Boolean(record))
+      .filter((record): record is RQAPI.CollectionRecord => Boolean(record))
       .reverse();
 
     return parents;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection chain construction to exclude invalid or missing entries (falsy results) from parent lookups before processing and reversal. This ensures only valid collection items are included, preventing downstream errors. Public interfaces and return types remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->