### PR TITLE
[ENGG-9999] fix: prevent layout shift in variable form popover

### DIFF
--- a/app/src/componentsV2/CodeEditor/components/EditorV2/components/VariablePopOver/components/VariableFormFields.tsx
+++ b/app/src/componentsV2/CodeEditor/components/EditorV2/components/VariablePopOver/components/VariableFormFields.tsx
@@ -151,47 +151,43 @@ export const VariableFormFields: React.FC<VariableFormFieldsProps> = ({
       {/* Type */}
       <div className="form-row">
         <label className="form-label">Type</label>
-        <div className="form-input-wrapper">
-          <Select
-            size="small"
-            value={formData.type}
-            onChange={handleTypeChange}
-            options={typeOptions}
-            className="form-select"
-            popupClassName="form-select-dropdown"
-          />
-        </div>
+        <Select
+          size="small"
+          value={formData.type}
+          onChange={handleTypeChange}
+          options={typeOptions}
+          className="form-select"
+          popupClassName="form-select-dropdown"
+        />
       </div>
 
       {/* Scope - Conditionally shown */}
       {showScope && scopeOptions && (
         <div className="form-row">
           <label className="form-label">Scope</label>
-          <div className="form-input-wrapper">
-            <Select
-              size="small"
-              labelInValue
-              value={{
-                value: formData.scope,
-                label: renderScopeOption(scopeOptions.find((o) => o.value === formData.scope) || scopeOptions[0]),
-              }}
-              onChange={(val) => onFormDataChange({ scope: val.value })}
-              className="form-select scope-select"
-              popupClassName="form-select-dropdown"
-              optionLabelProp="label"
-            >
-              {scopeOptions.map((option) => (
-                <Select.Option
-                  key={option.value}
-                  value={option.value}
-                  disabled={option.disabled}
-                  label={renderScopeOption(option)}
-                >
-                  {renderScopeOption(option)}
-                </Select.Option>
-              ))}
-            </Select>
-          </div>
+          <Select
+            size="small"
+            labelInValue
+            value={{
+              value: formData.scope,
+              label: renderScopeOption(scopeOptions.find((o) => o.value === formData.scope) || scopeOptions[0]),
+            }}
+            onChange={(val) => onFormDataChange({ scope: val.value })}
+            className="form-select scope-select"
+            popupClassName="form-select-dropdown"
+            optionLabelProp="label"
+          >
+            {scopeOptions.map((option) => (
+              <Select.Option
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled}
+                label={renderScopeOption(option)}
+              >
+                {renderScopeOption(option)}
+              </Select.Option>
+            ))}
+          </Select>
         </div>
       )}
     </div>

--- a/app/src/componentsV2/CodeEditor/components/EditorV2/components/VariablePopOver/variable-popover.scss
+++ b/app/src/componentsV2/CodeEditor/components/EditorV2/components/VariablePopOver/variable-popover.scss
@@ -81,7 +81,7 @@ div.n-popup {
 
   .variable-info-body {
     display: flex;
-    max-width: 300px;
+    width: 300px;
     min-width: 240px;
     max-height: 480px;
     gap: 8px;
@@ -343,11 +343,6 @@ div.n-popup {
           font-size: var(--requestly-font-size-xs);
           color: var(--requestly-color-text-default);
           border-radius: 4px;
-        }
-
-        .ant-select {
-          width: 100%;
-          min-width: 0;
         }
 
         .ant-input {


### PR DESCRIPTION
Closes issue: [ENGG-9999](https://linear.app/requestly/issue/ENGG-9999)

📜 **Summary of changes:**
This change addresses a layout shift issue observed in the variable editor popover. The `Select` inputs for `Type` and `Scope` did not occupy the full width of their container, causing a visual jump when the popover's content was rendered. By applying a full-width style to the select components, we ensure they render at their final width, eliminating the layout shift.

🎥 **Demo Video:**
Video/Demo: *(Add link or upload demo)*

✅ **Checklist:**
- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised PR to update documentation (if already exists).
- [ ] Added demo video showing the changes in action (if applicable).

🧪 **Test instructions:**
- *(Add clear test steps here)*

🔗 **Other references:**
- **`VariableFormFields.tsx`**: Wrapped the `Type` and `Scope` `Select` components in a `div.form-input-wrapper` to better target them with styles.
- **`variable-popover.scss`**: Added a style to make `.ant-select` components within the popover have `width: 100%`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted variable popover width constraints for consistent layout behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->