### PR TITLE
Fix null reference error in NetworkInspector ContextMenu

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/index.tsx
@@ -160,7 +160,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ children, log = {}, on
       });
     }
 
-    if (!log.requestShellCurl) {
+    if (!log?.requestShellCurl) {
       menuItems.splice(0, 1);
     }
 


### PR DESCRIPTION
Overview

Fix null reference error in NetworkInspector ContextMenu when accessing requestShellCurl property on a null log object. The error occurred when right-clicking on the traffic table before a row was selected, causing the component to throw TypeError: Cannot read properties of null (reading 'requestShellCurl').

Eng Checklist

Independent Item: Use optional chaining to safely access log.requestShellCurl property

Subtask 1: Update property access on line 163 to use optional chaining operator (?.)

Subtask 2: Verify no other unsafe property accesses on log object exist in the component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash in the Network Inspector context menu when accessing certain data properties under specific conditions. This improves stability and prevents runtime errors in traffic inspection workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->