### PR TITLE
[ENGG-5059] fix ts error in HistoryTable.tsx

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/HistoryDrawer/HistoryTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/HistoryDrawer/HistoryTable.tsx
@@ -14,7 +14,7 @@ export const HistoryTable: React.FC<{ onHistoryClick: (result: RunResult) => voi
 
   const [history] = useRunResultStore((s) => [s.history]);
   const formattedHistory = useMemo(() => {
-    const sortedHistory = [...history].sort((a, b) => b.startTime - a.startTime);
+    const sortedHistory = [...history].sort((a, b) => (b.startTime ?? 0) - (a.startTime ?? 0));
     return sortedHistory;
   }, [history]);
 
@@ -37,7 +37,9 @@ export const HistoryTable: React.FC<{ onHistoryClick: (result: RunResult) => voi
       {
         title: "Ran at",
         width: 175,
-        render: (_: any, record: RunResult) => <span>{getFormattedStartTime(record.startTime)}</span>,
+        render: (_: any, record: RunResult) => (
+          <span>{record.startTime ? getFormattedStartTime(record.startTime) : "..."}</span>
+        ),
       },
       {
         title: "Duration",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: https://linear.app/requestly/issue/ENGG-5059/fix-ts-error-in-historytabletsx

## 📜 Summary of changes:

Added null check and fallback to startTime

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * History sorting now properly handles missing timestamps without errors.
  * History display gracefully shows a placeholder indicator when timestamp information is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->