### PR TITLE
[ENGG-5070] fix ts error in RunResultView.tsx

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultView.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/Collection/components/CollectionRunnerView/components/RunResultView/RunResultView.tsx
@@ -57,10 +57,10 @@ export const RunResultView: React.FC = () => {
         error instanceof RenderableError ? (
           error.render()
         ) : (
-          <DefaultErrorComponent error={error} />
+          error && <DefaultErrorComponent error={error} />
         )
       ) : (
-        <RunResultContainer result={testResults} ranAt={startTime} totalIterationCount={totalIterationCount} />
+        <RunResultContainer result={testResults} ranAt={startTime ?? 0} totalIterationCount={totalIterationCount} />
       )}
       {runStatus === RunStatus.RUNNING ? <TestsRunningLoader /> : null}
       <HistoryDrawer isHistoryDrawerOpen={isHistoryDrawerOpen} setIsHistoryDrawerOpen={setIsHistoryDrawerOpen} />


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: https://linear.app/requestly/issue/ENGG-5070/fix-ts-error-in-runresultviewtsx

## 📜 Summary of changes:

Added check for error and startTime

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error display in API client result view to prevent rendering issues when error handling encounters unexpected states
  * Improved initialization of result timestamps to ensure proper default values when data is unavailable

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->