### PR TITLE
[ENGG-5078] fix ts error in collectionRunResult/utils.ts

### DIFF
--- a/app/src/features/apiClient/store/collectionRunResult/utils.ts
+++ b/app/src/features/apiClient/store/collectionRunResult/utils.ts
@@ -61,7 +61,7 @@ export function getAllTestSummary(result: RunResultState["iterations"]) {
     successTestsCounts += success.length;
     failedTestsCounts += failed.length;
     skippedTestsCounts += skipped.length;
-    totalDuration += executionResult.runDuration;
+    totalDuration += executionResult.runDuration ?? 0;
 
     totalTests.set(iteration, [...(totalTests.get(iteration) ?? []), { requestExecutionResult: executionResult }]);
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: https://linear.app/requestly/issue/ENGG-5078/fix-ts-error-in-collectionrunresultutilsts

## 📜 Summary of changes:

Added testDuration fallback value as 0

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential issue where null or undefined duration values could cause improper duration accumulation, ensuring a zero default is applied when expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->