### PR TITLE
[ENGG-4579] : Replace contact sales redirect with Freshchat widget

### DIFF
--- a/app/src/components/sections/Footer/index.tsx
+++ b/app/src/components/sections/Footer/index.tsx
@@ -128,6 +128,15 @@ const AppFooter: React.FC = () => {
     trackFooterClicked(key);
   };
 
+  const openFreshChat = () => {
+    if (window.fcWidget && typeof window.fcWidget.open === "function") {
+      window.fcWidget.open();
+    } else {
+      redirectToUrl(APP_CONSTANTS.LINKS.BOOK_A_DEMO, true);
+    }
+    trackFooterClicked(FOOTER_LINKS.CONTACT_SALES);
+  };
+
   if (PAGES_WITHOUT_FOOTER.some((path) => pathname.includes(path))) return null;
 
   return (
@@ -159,15 +168,6 @@ const AppFooter: React.FC = () => {
       </Footer>
     </>
   );
-};
-
-export const openFreshChat = () => {
-  if (window.fcWidget && typeof window.fcWidget.open === "function") {
-    window.fcWidget.open();
-  } else {
-    redirectToUrl(APP_CONSTANTS.LINKS.BOOK_A_DEMO, true);
-  }
-  trackFooterClicked(FOOTER_LINKS.CONTACT_SALES);
 };
 
 export default AppFooter;


### PR DESCRIPTION
Closes issue: #3789

## 📜 Summary of changes:

<!-- Summarize your changes -->

## 🎥 Demo Video:


https://github.com/user-attachments/assets/53ffe1f1-11ea-4d52-b308-56a3247d643f



## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [x] Verified UI in browser.
- [x] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [x] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer "Contact Sales" now opens the Freshchat support widget when available.
  * Clicks are tracked as contact-sales events for analytics.
  * If Freshchat is unavailable, users are redirected to the "Book a Demo" flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->