### PR TITLE
[PLAT-17] Feat: Enhance buffer slice with Immer for patch management

### DIFF
--- a/app/src/features/apiClient/slices/buffer/slice.ts
+++ b/app/src/features/apiClient/slices/buffer/slice.ts
@@ -98,8 +98,8 @@ export const bufferSlice = createSlice({
       if (command.type === "DELETE") {
         const paths = objectToDeletePaths(command.value);
         for (const path of paths) {
-          unset(entry.current as object, path);
-          unset(entry.diff as object, path);
+          unset(entry.current, path);
+          unset(entry.diff, path);
         }
       }
 
@@ -136,10 +136,10 @@ export const bufferSlice = createSlice({
         switch (patch.op) {
           case "add":
           case "replace":
-            set(entry.diff as object, path, patch.value);
+            set(entry.diff, path, patch.value);
             break;
           case "remove":
-            unset(entry.diff as object, path);
+            unset(entry.diff, path);
             break;
         }
       }


### PR DESCRIPTION
Closes issue: [PLAT-17](https://linear.app/requestly/issue/PLAT-17)

📜 **Summary of changes:**
This pull request enhances the `buffer` slice by integrating Immer's `produceWithPatches` functionality for more robust state management. The `updateBuffer` reducer is refactored to automatically generate diffs based on changes to the `current` state, eliminating the previous manual and potentially unsafe synchronization between the `current` and `diff` objects. This ensures greater accuracy and safety when tracking changes.

🎥 **Demo Video:**
Video/Demo: *(Add link or upload demo)*

✅ **Checklist:**
- [ ] Linting and unit tests pass
- [ ] No install/build warnings introduced
- [ ] UI verified in browser
- [ ] Analytics updated (if applicable)
- [ ] Extension tested in Chrome & Firefox (if applicable)
- [ ] Unit tests added/updated
- [ ] Docs updated (if applicable)
- [ ] Demo video added (if applicable)

🧪 **Test instructions:**
- *(Add clear test steps here)*

🔗 **Other references:**
- **`features/apiClient/slices/buffer`**
  - Refactored the `updateBuffer` reducer to use `immer/produceWithPatches` for safer and more reliable diff generation.
  - Updated the `applyPatch` reducer to use `unset` for delete operations on the diff object for consistency.