### PR TITLE
[ONCALL-192]: TypeError: Cannot read properties of undefined (reading…

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultipartFormRowTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultipartFormRowTable.tsx
@@ -206,7 +206,7 @@ export const MultiEditableCell: React.FC<React.PropsWithChildren<EditableCellPro
 
             {dataIndex === "value" &&
               record?.type === FormDropDownOptions.FILE &&
-              (!Array.isArray(record?.value) || record?.value.length === 0) && (
+              (!Array.isArray(record?.value) || record?.value?.length === 0) && (
                 <RQButton
                   size="small"
                   type="secondary"


### PR DESCRIPTION
… 'length')

<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: https://linear.app/requestly/issue/ONCALL-192/typeerror-cannot-read-properties-of-undefined-reading-length

## 📜 Summary of changes:

Added optional chaining

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request form handling to avoid runtime errors when certain input values are missing, preventing potential crashes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->