### PR TITLE
Revert "fix: TypeError: Cannot destructure property 'from' of 'ts[ss]' as it …"

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/FixedRequestLogPane.js
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/FixedRequestLogPane.js
@@ -10,7 +10,6 @@ import Editor, { EditorLanguage } from "componentsV2/CodeEditor";
 import "./FixedRequestLogPane.css";
 import { REQUEST_METHOD_COLORS, REQUEST_METHOD_BACKGROUND_COLORS } from "../../../../../../constants";
 import { RequestMethod } from "features/apiClient/types";
-import { canRenderPreview } from "./utils";
 
 const { Text } = Typography;
 
@@ -95,6 +94,41 @@ const BodyTabView = ({ body, requestState, timestamp }) => {
   );
 };
 
+const isPreviewAvailable = (contentType) => {
+  const binaryMIMETypes = [
+    "image/",
+    "video/",
+    "audio/",
+    "application/octet-stream",
+    "application/pdf",
+    "application/zip",
+    "application/x-zip-compressed",
+    "application/x-rar-compressed",
+    "application/x-tar",
+    "application/x-gzip",
+    "application/x-7z-compressed",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument",
+    "application/msword",
+    "application/vnd.ms-powerpoint",
+    "font/",
+    "woff2",
+    "application/x-protobuf",
+    "application/protobuf",
+  ];
+
+  //show values if content type is empty
+  if (contentType === "") return true;
+
+  const normalizedContentType = contentType.toLowerCase();
+
+  // Check if it's a binary type
+  if (binaryMIMETypes.some((type) => normalizedContentType.includes(type))) return false;
+
+  // non binary types are true to be shown in code mirror
+  return true;
+};
+
 const LogPane = ({ log_id, title, requestState, timestamp, data: request_data }) => {
   const [currentTabIndex, setCurrentTabIndex] = useState(0);
   const { queryParams, headers, body } = request_data;
@@ -174,7 +208,7 @@ const LogPane = ({ log_id, title, requestState, timestamp, data: request_data })
       ),
       body: (
         <div className="navigation-panel-wrapper">
-          {canRenderPreview(body, contentType) ? (
+          {isPreviewAvailable(contentType) ? (
             <Editor
               scriptId={`${title}-${log_id}`}
               value={body || ""}

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/utils/index.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/utils/index.ts
@@ -215,37 +215,3 @@ export const traverseJsonByPath = (jsonObject: any, path: any) => {
     console.log(e);
   }
 };
-const MAX_PREVIEW_SIZE = 5 * 1024 * 1024; // 5 MB
-
-const ALLOWED_MIME_TYPES = new Set([
-  "text/plain",
-  "text/html",
-  "text/css",
-  "text/javascript",
-  "application/javascript",
-  "application/x-javascript",
-  "application/json",
-  "application/xml",
-  "text/xml",
-  "application/xhtml+xml",
-  "application/ecmascript",
-]);
-
-export function canRenderPreview(body?: string, contentType?: string): boolean {
-  if (!body || !contentType) return false;
-  // Size check
-  const sizeInBytes = new TextEncoder().encode(body).length;
-  if (sizeInBytes > MAX_PREVIEW_SIZE) return false;
-  // Binary check
-  if (body.includes("\0")) return false;
-  const mime = contentType.split(";")[0].trim().toLowerCase();
-  // Allow all text/*
-  if (mime.startsWith("text/")) return true;
-  // Explicit allowlist
-  if (ALLOWED_MIME_TYPES.has(mime)) return true;
-  // Vendor JSON (application/vnd.*+json)
-  if (mime.endsWith("+json")) return true;
-  // Vendor XML (application/vnd.*+xml)
-  if (mime.endsWith("+xml")) return true;
-  return false;
-}


### PR DESCRIPTION
Reverts requestly/requestly#4112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the preview logic for traffic inspection by refactoring how the system determines which request previews can be displayed, streamlining the validation based on content-type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->