### PR TITLE
chore: add sentry core as dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -76,6 +76,7 @@
     "@requestly/mock-server": "0.1.6",
     "@requestly/requestly-core": "file:..",
     "@requestly/shared": "file:../shared",
+    "@sentry/core": "^10.32.1",
     "@sentry/react": "^10.32.1",
     "@stripe/react-stripe-js": "^2.3.0",
     "@stripe/stripe-js": "^1.24.0",


### PR DESCRIPTION
We rely on `@sentry/core` for `SPAN_STATUS_ERROR`, `SPAN_STATUS_OK` but `@sentry/react` doesn't expose it directly. 

```
error during build:
[vite]: Rollup failed to resolve import "@sentry/core" from "/home/runner/work/requestly-cloud/requestly-cloud/app/src/features/apiClient/screens/apiClient/components/views/http/HttpClientView.tsx".
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal dependency to enhance application monitoring and stability infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->