### PR TITLE
[PLAT-38] Fix variable row handling for unique IDs and key updates

### DIFF
--- a/app/src/features/apiClient/slices/entities/api-client-variables.ts
+++ b/app/src/features/apiClient/slices/entities/api-client-variables.ts
@@ -37,13 +37,13 @@ export class ApiClientVariables<T, State = ApiClientStoreState> {
     };
     this.unsafePatch((s) => {
       const variables = this.getVariableObject(s);
-      if(!variables[key]) {
+      if (!variables[key]) {
         variables[key] = variable;
       } else {
         variables[key] = {
           ...variables[key],
           ...variable,
-        }
+        };
       }
     });
 
@@ -59,12 +59,30 @@ export class ApiClientVariables<T, State = ApiClientStoreState> {
         return;
       }
       const [oldKey, variable] = entry;
-      lodash.extend(variable, variableData);
-      if (params.key) {
-        if (oldKey !== params.key) {
-          variables[params.key] = variable;
-          delete variables[oldKey];
+
+      if (params.key && oldKey !== params.key) {
+        if (variables[params.key] && variables[params.key]?.id !== params.id) {
+          lodash.extend(variable, variableData);
+          return;
         }
+
+        const newVariables: EnvironmentVariables = {};
+        for (const [key, val] of Object.entries(variables)) {
+          if (key === oldKey) {
+            newVariables[params.key!] = { ...val, ...variableData };
+          } else {
+            newVariables[key] = val;
+          }
+        }
+
+        const parentObject = s as any;
+        if (parentObject.variables === variables) {
+          parentObject.variables = newVariables;
+        } else if (parentObject.data?.variables === variables) {
+          parentObject.data.variables = newVariables;
+        }
+      } else {
+        lodash.extend(variable, variableData);
       }
     });
   }


### PR DESCRIPTION
Closes issue: [PLAT-38](https://linear.app/requestly/issue/PLAT-38)

📜 **Summary of changes:**
This PR addresses a bug in the environment variables list where new rows were not handled correctly, and renaming a variable's key could lead to incorrect state. It replaces the static `__empty__` ID for new rows with a unique UUID to prevent conflicts when adding multiple variables. Additionally, the logic for updating variable keys has been refactored to safely handle renaming and prevent accidentally overwriting an existing variable.

🎥 **Demo Video:**
Video/Demo: *(Add link or upload demo)*

✅ **Checklist:**
- [ ] Linting and unit tests pass
- [ ] No install/build warnings introduced
- [ ] UI verified in browser
- [ ] Analytics updated (if applicable)
- [ ] Extension tested in Chrome & Firefox (if applicable)
- [ ] Unit tests added/updated
- [ ] Docs updated (if applicable)
- [ ] Demo video added (if applicable)

🧪 **Test instructions:**
- *(Add clear test steps here)*

🔗 **Other references:**
*   **`VariablesList.tsx`**
    *   Replaced the hardcoded `__empty__` ID for new variable rows with a unique `uuid` to ensure each new row has a distinct identifier.
    *   Updated logic to check if a variable exists in the backend data to determine if it's a new row, rather than checking for the `__empty__` ID.
    *   Ensured the new `uuid` is passed when creating a new variable.

*   **`features/apiClient/slices/entities/api-client-variables.ts`**
    *   Refactored the `set` method to handle variable key updates more robustly.
    *   Added a check to prevent a variable's key from being changed if the new key is already in use by another variable.
    *   Modified the state update to be immutable when a key is renamed, preventing potential side effects.