### PR TITLE
[Oncall-58]:  Added fix in API client preview tab

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/FixedRequestLogPane.js
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/FixedRequestLogPane.js
@@ -10,7 +10,7 @@ import Editor, { EditorLanguage } from "componentsV2/CodeEditor";
 import "./FixedRequestLogPane.css";
 import { REQUEST_METHOD_COLORS, REQUEST_METHOD_BACKGROUND_COLORS } from "../../../../../../constants";
 import { RequestMethod } from "features/apiClient/types";
-import { shouldRenderPreview } from "./utils";
+import { shouldRenderPreview } from "utils/CodeEditorUtils";
 
 const { Text } = Typography;
 

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/utils/index.ts
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/utils/index.ts
@@ -215,33 +215,3 @@ export const traverseJsonByPath = (jsonObject: any, path: any) => {
     console.log(e);
   }
 };
-
-// Added 5MB cap to maintain the stability and responsiveness of the app
-const MAX_PREVIEW_SIZE = 5 * 1024 * 1024; // 5 MB
-
-// Regex to match previewable MIME types
-const PREVIEWABLE_MIME_TYPES_REGEX = new RegExp(
-  [
-    "^text/.*", // All text/* types (HTML, plain, CSS, etc.)
-    "^application/javascript", // JavaScript (standard)
-    "^application/x-javascript", // JavaScript (legacy)
-    "^application/json", // JSON data
-    "^application/xml", // XML data
-    "^application/.*\\+json$", // Vendor-specific JSON (e.g., application/vnd.api+json)
-    "^application/.*\\+xml$", // Vendor-specific XML (e.g., application/vnd.api+xml)
-  ].join("|"),
-  "i"
-);
-
-export function shouldRenderPreview(body?: string, contentType?: string): boolean {
-  if (!body || !contentType) return false;
-  // Size check
-  const sizeInBytes = new TextEncoder().encode(body).length;
-  if (sizeInBytes > MAX_PREVIEW_SIZE) return false;
-  // Binary check
-  if (body.includes("\0")) return false;
-  // Extract and normalize MIME type
-  const mime = contentType.split(";")[0].trim().toLowerCase();
-  // Use regex to match previewable MIME types
-  return PREVIEWABLE_MIME_TYPES_REGEX.test(mime);
-}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/response/ResponseBody/ResponseBody.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/response/ResponseBody/ResponseBody.tsx
@@ -7,7 +7,7 @@ import { RQButton } from "lib/design-system-v2/components";
 import { IoMdCopy } from "@react-icons/all-files/io/IoMdCopy";
 import Editor from "componentsV2/CodeEditor";
 import { copyToClipBoard } from "utils/Misc";
-import { shouldRenderPreview } from "components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/utils";
+import { shouldRenderPreview } from "utils/CodeEditorUtils";
 
 interface Props {
   responseText: string;

--- a/app/src/utils/CodeEditorUtils.js
+++ b/app/src/utils/CodeEditorUtils.js
@@ -25,3 +25,33 @@ export const formatJSONString = async (value, tabSize = 0) => {
     }
   }
 };
+
+// Added 5MB cap to maintain the stability and responsiveness of the app
+const MAX_PREVIEW_SIZE = 5 * 1024 * 1024; // 5 MB
+
+// Regex to match previewable MIME types
+const PREVIEWABLE_MIME_TYPES_REGEX = new RegExp(
+  [
+    "^text/.*", // All text/* types (HTML, plain, CSS, etc.)
+    "^application/javascript", // JavaScript (standard)
+    "^application/x-javascript", // JavaScript (legacy)
+    "^application/json", // JSON data
+    "^application/xml", // XML data
+    "^application/.*\\+json$", // Vendor-specific JSON (e.g., application/vnd.api+json)
+    "^application/.*\\+xml$", // Vendor-specific XML (e.g., application/vnd.api+xml)
+  ].join("|"),
+  "i"
+);
+
+export function shouldRenderPreview(body, contentType) {
+  if (!body || !contentType) return false;
+  // Size check
+  const sizeInBytes = new TextEncoder().encode(body).length;
+  if (sizeInBytes > MAX_PREVIEW_SIZE) return false;
+  // Binary check
+  if (body.includes("\0")) return false;
+  // Extract and normalize MIME type
+  const mime = contentType.split(";")[0].trim().toLowerCase();
+  // Use regex to match previewable MIME types
+  return PREVIEWABLE_MIME_TYPES_REGEX.test(mime);
+}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: https://linear.app/requestly/issue/ONCALL-58/typeerror-cannot-destructure-property-from-of-tsss-as-it-is-undefined

## 📜 Summary of changes:

Added safety check in edit and replay of api-client modal

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response preview handling by displaying "Preview not available" for unsupported or non-previewable responses instead of attempting to render them, giving clearer feedback when a response can't be previewed.
  * Prevents attempts to preview very large or binary-like response bodies, reducing failed or broken previews.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->