### PR TITLE
[PLAT-39] Fix(api-client): Preserve user edits on source data refresh

### DIFF
--- a/app/src/features/apiClient/slices/buffer/slice.ts
+++ b/app/src/features/apiClient/slices/buffer/slice.ts
@@ -10,22 +10,19 @@ import { emitBufferUpdated } from "componentsV2/Tabs/slice";
 import { DeepPartialWithNull, EntityNotFound } from "../types";
 
 const FIELDS_FILTER: {
-  [key in ApiClientEntityType]?: DeepPartialWithNull<Record<string, any>>
+  [key in ApiClientEntityType]?: DeepPartialWithNull<Record<string, any>>;
 } = {
-  [ApiClientEntityType.HTTP_RECORD]:
-    {
-      data: {
-        response: null,
-        testResults: null,
-      }
-    }
-}
-
-
+  [ApiClientEntityType.HTTP_RECORD]: {
+    data: {
+      response: null,
+      testResults: null,
+    },
+  },
+};
 
 export function getPathsToFilter(entityType: ApiClientEntityType) {
   const filter = FIELDS_FILTER[entityType];
-  if(!filter) {
+  if (!filter) {
     return [];
   }
 
@@ -116,7 +113,7 @@ export const bufferSlice = createSlice({
         const operations = objectToSetOperations(command.value);
         for (const { path, value } of operations) {
           set(entry.current as object, path, value);
-          if(isPathPresent(pathFilters, path)) {
+          if (isPathPresent(pathFilters, path)) {
             continue;
           }
           set(entry.diff as object, path, value);
@@ -128,7 +125,7 @@ export const bufferSlice = createSlice({
         const paths = objectToDeletePaths(command.value);
         for (const path of paths) {
           unset(entry.current, path);
-          if(isPathPresent(pathFilters, path)) {
+          if (isPathPresent(pathFilters, path)) {
             continue;
           }
           unset(entry.diff, path);
@@ -136,7 +133,7 @@ export const bufferSlice = createSlice({
         }
       }
 
-      if(!isMutated) {
+      if (!isMutated) {
         return;
       }
 
@@ -162,7 +159,6 @@ export const bufferSlice = createSlice({
       const pathFilters = getPathsToFilter(entry.entityType);
       let isMutated = false;
 
-
       const plain = current(entry.current);
 
       const [_, patches] = produceWithPatches(plain, (draft) => {
@@ -175,7 +171,7 @@ export const bufferSlice = createSlice({
           case "add":
           case "replace":
             set(entry.current as object, path, patch.value);
-            if(isPathPresent(pathFilters, path)) {
+            if (isPathPresent(pathFilters, path)) {
               continue;
             }
             set(entry.diff, path, patch.value);
@@ -183,7 +179,7 @@ export const bufferSlice = createSlice({
             break;
           case "remove":
             unset(entry.current as object, path);
-            if(isPathPresent(pathFilters, path)) {
+            if (isPathPresent(pathFilters, path)) {
               continue;
             }
             unset(entry.diff, path);
@@ -192,7 +188,7 @@ export const bufferSlice = createSlice({
         }
       }
 
-      if(!isMutated) {
+      if (!isMutated) {
         return;
       }
 
@@ -213,16 +209,19 @@ export const bufferSlice = createSlice({
       }>
     ) {
       const entry = findBufferByReferenceId(state.entities, action.payload.referenceId);
-      if (!entry) throw new EntityNotFound(action.payload.referenceId,"buffer");
+      if (!entry) throw new EntityNotFound(action.payload.referenceId, "buffer");
 
+      const userEdits = cloneDeep(entry.diff);
       entry.current = cloneDeep(action.payload.sourceData);
 
-      const operations = objectToSetOperations(entry.diff);
-      for (const { path } of operations) {
-        const value = get(entry.current, path);
-        if (value === undefined ) {
+      const operations = objectToSetOperations(userEdits);
+      for (const { path, value } of operations) {
+        // const value = get(entry.current, path);
+        if (value === undefined) {
+          unset(entry.current, path);
           unset(entry.diff as object, path);
         } else {
+          set(entry.current as object, path, value);
           set(entry.diff as object, path, value);
         }
       }
@@ -232,17 +231,17 @@ export const bufferSlice = createSlice({
       state,
       action: PayloadAction<{
         id: string;
-        savedData?: unknown,
+        savedData?: unknown;
         referenceId?: string;
       }>
     ) {
       const entry = state.entities[action.payload.id];
       if (!entry) return;
 
-      if(action.payload.referenceId) {
+      if (action.payload.referenceId) {
         entry.referenceId = action.payload.referenceId;
       }
-      if(action.payload.savedData) {
+      if (action.payload.savedData) {
         entry.current = action.payload.savedData;
       }
       entry.diff = {};


### PR DESCRIPTION
Closes issue: [PLAT-39](https://linear.app/requestly/issue/PLAT-39)

📜 **Summary of changes:**
This pull request addresses a bug where unsaved user edits were being lost when the underlying source data was updated. The `sourceDataUpdated` reducer was incorrectly trying to re-apply edits using values from the new data, rather than the original user-edited values. The fix ensures user edits are cached before the source data is updated and then correctly re-applied, preserving the user's unsaved work.

🎥 **Demo Video:**
Video/Demo: *(Add link or upload demo)*

✅ **Checklist:**
- [ ] Linting and unit tests pass
- [ ] No install/build warnings introduced
- [ ] UI verified in browser
- [ ] Analytics updated (if applicable)
- [ ] Extension tested in Chrome & Firefox (if applicable)
- [ ] Unit tests added/updated
- [ ] Docs updated (if applicable)
- [ ] Demo video added (if applicable)

🧪 **Test instructions:**
- *(Add clear test steps here)*

🔗 **Other references:**
*   `app/src/features/apiClient/slices/buffer/slice.ts`:
    *   Modified the `sourceDataUpdated` reducer to correctly re-apply unsaved user edits after the source data has been refreshed.