### PR TITLE
feat(api-client): [PLAT-44] Migrate Environment and Collection variable daemons to Redux

### DIFF
--- a/app/src/features/apiClient/slices/utils/syncVariables.ts
+++ b/app/src/features/apiClient/slices/utils/syncVariables.ts
@@ -1,0 +1,23 @@
+import type { EnvironmentVariables } from "backend/environment/types";
+
+/**
+ * Mirrors the old Zustand `resetSyncValues` semantics:
+ * - Take the incoming synced variables as the source of truth for keys (adds/removes)
+ * - Preserve existing `localValue` for keys that already exist locally
+ */
+export function mergeSyncedVariablesPreservingLocalValue(
+  current: EnvironmentVariables,
+  incoming: EnvironmentVariables
+): EnvironmentVariables {
+  const merged: EnvironmentVariables = {};
+
+  for (const key in incoming) {
+    const next = incoming[key];
+    if (!next) continue;
+
+    const prev = current[key];
+    merged[key] = prev ? { ...next, localValue: prev.localValue } : next;
+  }
+
+  return merged;
+}

--- a/app/src/features/apiClient/store/apiRecords/Daemon/CollectionVariablesDaemon.tsx
+++ b/app/src/features/apiClient/store/apiRecords/Daemon/CollectionVariablesDaemon.tsx
@@ -1,22 +1,40 @@
 import { VariableScope } from "backend/environment/types";
 import React, { useEffect } from "react";
-import { useAPIRecordsStore } from "../ApiRecordsContextProvider";
-import { useApiClientRepository } from "features/apiClient/contexts/meta";
+import { useApiClientRepository } from "features/apiClient/slices";
+import { useApiClientDispatch } from "features/apiClient/slices/hooks/base.hooks";
+import { apiRecordsActions } from "features/apiClient/slices/apiRecords";
+import { RQAPI } from "features/apiClient/types";
+import { mergeSyncedVariablesPreservingLocalValue } from "features/apiClient/slices/utils/syncVariables";
 
 const CollectionVariablesDaemon: React.FC = () => {
-  const recordsStore = useAPIRecordsStore();
   const { environmentVariablesRepository } = useApiClientRepository();
+  const dispatch = useApiClientDispatch();
 
   useEffect(() => {
     const unsubscribe = environmentVariablesRepository.attachListener({
       scope: VariableScope.COLLECTION,
       callback: (newCollectionVariables) => {
-        recordsStore.getState().updateCollectionVariables(newCollectionVariables);
+        for (const collectionId in newCollectionVariables) {
+          const incoming = newCollectionVariables[collectionId]?.variables ?? {};
+
+          dispatch(
+            apiRecordsActions.unsafePatch({
+              id: collectionId,
+              patcher: (record) => {
+                if (record.type !== RQAPI.RecordType.COLLECTION) return;
+
+                const current = record.data.variables ?? {};
+                const merged = mergeSyncedVariablesPreservingLocalValue(current, incoming);
+                record.data.variables = merged;
+              },
+            })
+          );
+        }
       },
     });
 
     return unsubscribe;
-  }, [environmentVariablesRepository, recordsStore]);
+  }, [environmentVariablesRepository, dispatch]);
 
   return null;
 };

--- a/app/src/features/apiClient/store/apiRecords/Daemon/EnvironmentDaemon.tsx
+++ b/app/src/features/apiClient/store/apiRecords/Daemon/EnvironmentDaemon.tsx
@@ -1,46 +1,52 @@
-import React, { useEffect } from "react";
-import { useApiClientRepository } from "features/apiClient/contexts/meta";
 import { VariableScope } from "backend/environment/types";
-import { useAPIEnvironment } from "../ApiRecordsContextProvider";
-import { parseEnvVariables } from "../../variables/variables.store";
-
+import { useApiClientRepository } from "features/apiClient/slices";
+import { GLOBAL_ENVIRONMENT_ID } from "features/apiClient/slices/common/constants";
+import { environmentsActions, useActiveEnvironmentId } from "features/apiClient/slices/environments";
+import { useApiClientDispatch } from "features/apiClient/slices/hooks/base.hooks";
+import { mergeSyncedVariablesPreservingLocalValue } from "features/apiClient/slices/utils/syncVariables";
+import React, { useEffect } from "react";
 const EnvironmentDaemon: React.FC = () => {
-  const { globalEnvironement, activeEnvrionment } = useAPIEnvironment((state) => {
-    return {
-      activeEnvrionment: state.activeEnvironment,
-      globalEnvironement: state.globalEnvironment,
-    };
-  });
   const { environmentVariablesRepository } = useApiClientRepository();
+  const dispatch = useApiClientDispatch();
+
+  const activeEnvironmentId = useActiveEnvironmentId();
 
   useEffect(() => {
-    if (!activeEnvrionment) return;
-    const unsusbscribe = environmentVariablesRepository.attachListener({
+    if (!activeEnvironmentId) return;
+
+    const unsubscribe = environmentVariablesRepository.attachListener({
       scope: VariableScope.ENVIRONMENT,
-      id: activeEnvrionment.getState().id,
+      id: activeEnvironmentId,
       callback: (updatedEnvironmentData) => {
-        activeEnvrionment
-          .getState()
-          .data.variables?.getState()
-          .resetSyncValues(parseEnvVariables(updatedEnvironmentData.variables));
+        dispatch(
+          environmentsActions.unsafePatch({
+            id: activeEnvironmentId,
+            patcher: (env) => {
+              env.variables = mergeSyncedVariablesPreservingLocalValue(env.variables, updatedEnvironmentData.variables);
+            },
+          })
+        );
       },
     });
-    return unsusbscribe;
-  }, [environmentVariablesRepository, activeEnvrionment]);
+    return unsubscribe;
+  }, [environmentVariablesRepository, activeEnvironmentId, dispatch]);
 
   useEffect(() => {
     const unsubscribe = environmentVariablesRepository.attachListener({
       scope: VariableScope.GLOBAL,
-      id: globalEnvironement.getState().id,
+      id: GLOBAL_ENVIRONMENT_ID,
       callback: (updatedEnvironmentData) => {
-        globalEnvironement
-          .getState()
-          .data.variables.getState()
-          .resetSyncValues(parseEnvVariables(updatedEnvironmentData.variables));
+        dispatch(
+          environmentsActions.unsafePatchGlobal({
+            patcher: (env) => {
+              env.variables = mergeSyncedVariablesPreservingLocalValue(env.variables, updatedEnvironmentData.variables);
+            },
+          })
+        );
       },
     });
     return unsubscribe;
-  }, [environmentVariablesRepository, globalEnvironement]);
+  }, [environmentVariablesRepository, dispatch]);
   return null;
 };
 

--- a/app/src/features/apiClient/store/apiRecords/Daemon/index.tsx
+++ b/app/src/features/apiClient/store/apiRecords/Daemon/index.tsx
@@ -3,19 +3,23 @@ import { ExampleCollectionsDaemon } from "features/apiClient/exampleCollections/
 import { AutoSyncLocalStoreDaemon } from "features/apiClient/helpers/modules/sync/localStore/components/AutoSyncLocalStoreDaemon";
 import { apiClientContextRegistry } from "features/apiClient/slices";
 import React from "react";
+import EnvironmentDaemon from "./EnvironmentDaemon";
+import CollectionVariablesDaemon from "./CollectionVariablesDaemon";
 
 const Daemon: React.FC = React.memo(() => {
   const contexts = apiClientContextRegistry.getAllContexts();
   const isMulti = contexts.length > 1;
 
+  console.log({ contexts });
+
   const daemons = contexts.map(({ workspaceId: contextId }) => (
-    <WorkspaceProvider workspaceId={contextId}>
+    <WorkspaceProvider workspaceId={contextId} key={contextId}>
       {!isMulti ? (
         <>
           <AutoSyncLocalStoreDaemon />
           <ExampleCollectionsDaemon />
-          {/*<EnvironmentDaemon />*/}
-          {/*<CollectionVariablesDaemon />*/}
+          <EnvironmentDaemon />
+          <CollectionVariablesDaemon />
         </>
       ) : null}
     </WorkspaceProvider>


### PR DESCRIPTION
Closes issue: [PLAT-44](https://linear.app/requestly/issue/PLAT-44)

📜 **Summary of changes:**
This change migrates the `EnvironmentDaemon` and `CollectionVariablesDaemon` to use the new Redux-based API client store, as part of the ongoing Zustand-to-Redux migration. These daemons listen for real-time updates to environment and collection variables from the repository layer and now dispatch Redux actions to update the state.

A new `mergeSyncedVariablesPreservingLocalValue` utility was created to ensure that existing local variable values are preserved during synchronization, maintaining the behavior of the previous implementation.

🎥 **Demo Video:**
Video/Demo: *(Add link or upload demo)*

✅ **Checklist:**
- [ ] Linting and unit tests pass
- [ ] No install/build warnings introduced
- [ ] UI verified in browser
- [ ] Analytics updated (if applicable)
- [ ] Extension tested in Chrome & Firefox (if applicable)
- [ ] Unit tests added/updated
- [ ] Docs updated (if applicable)
- [ ] Demo video added (if applicable)

🧪 **Test instructions:**
- *(Add clear test steps here)*

🔗 **Other references:**
- **`EnvironmentDaemon`**: Migrated to use Redux hooks and actions (`useApiClientDispatch`, `environmentsActions`) to update global and active environment variables.
- **`CollectionVariablesDaemon`**: Refactored to dispatch `apiRecordsActions.unsafePatch` to update collection variables within the Redux store.
- **`utils/syncVariables.ts`**: Introduced a new `mergeSyncedVariablesPreservingLocalValue` utility function to merge incoming variables while preserving local overrides.
- **`Daemon/index.tsx`**: Re-enabled the `EnvironmentDaemon` and `CollectionVariablesDaemon` to activate the new Redux-based synchronization.