### PR TITLE
PLAT-84 Add bulkActionTypes to BufferSyncRemote and sync all buffers on bulk

### DIFF
--- a/app/src/features/apiClient/slices/buffer/middleware.ts
+++ b/app/src/features/apiClient/slices/buffer/middleware.ts
@@ -26,14 +26,23 @@ type BufferListenerApi = ListenerEffectAPI<ApiClientStoreState, Dispatch<AnyActi
 interface BufferSyncRemote {
   entityTypes: ApiClientEntityType[];
   shouldHandleAction: (action: AnyAction) => boolean;
+  bulkActionTypes: string[];
   extractId: (action: AnyAction) => string | undefined;
   selectData: (state: ApiClientStoreState, id: string) => unknown | undefined;
 }
 
 const getPayloadId = (action: AnyAction): string | undefined => {
   const p = action.payload as any;
-  if (typeof p !== "object" || p === null) return undefined;
-  return p.id ?? p.entityId;
+  if (p == null) return undefined;
+
+  // PayloadAction<string>
+  if (typeof p === "string") return p;
+
+  // Common object payloads across our slices
+  if (typeof p === "object") {
+    return p.id ?? p.entityId ?? p.key ?? p.referenceId;
+  }
+  return undefined;
 };
 
 const recordsRemote: BufferSyncRemote = {
@@ -43,6 +52,11 @@ const recordsRemote: BufferSyncRemote = {
     ApiClientEntityType.GRAPHQL_RECORD,
   ],
   shouldHandleAction: (action) => action.type.startsWith(`${API_CLIENT_RECORDS_SLICE_NAME}/`),
+  bulkActionTypes: [
+    `${API_CLIENT_RECORDS_SLICE_NAME}/upsertRecords`,
+    `${API_CLIENT_RECORDS_SLICE_NAME}/setAllRecords`,
+    `${API_CLIENT_RECORDS_SLICE_NAME}/hydrate`,
+  ],
   extractId: getPayloadId,
   selectData: (state, id) => apiRecordsAdapter.getSelectors().selectById(state.records.records, id),
 };
@@ -54,8 +68,14 @@ const environmentsRemote: BufferSyncRemote = {
     const isGlobalAction =
       action.type === `${API_CLIENT_ENVIRONMENTS_SLICE_NAME}/updateGlobalEnvironment` ||
       action.type === `${API_CLIENT_ENVIRONMENTS_SLICE_NAME}/unsafePatchGlobal`;
-    return isEnvAction && !isGlobalAction;
+    // Selection changes shouldn't resync buffers; it's not a data mutation.
+    const isNonMutatingAction = action.type === `${API_CLIENT_ENVIRONMENTS_SLICE_NAME}/setActiveEnvironment`;
+    return isEnvAction && !isGlobalAction && !isNonMutatingAction;
   },
+  bulkActionTypes: [
+    `${API_CLIENT_ENVIRONMENTS_SLICE_NAME}/environmentsCreated`,
+    `${API_CLIENT_ENVIRONMENTS_SLICE_NAME}/hydrate`,
+  ],
   extractId: getPayloadId,
   selectData: (state, id) => environmentsAdapter.getSelectors().selectById(state.environments.environments, id),
 };
@@ -68,6 +88,7 @@ const globalEnvironmentRemote: BufferSyncRemote = {
       action.type === `${API_CLIENT_ENVIRONMENTS_SLICE_NAME}/unsafePatchGlobal`
     );
   },
+  bulkActionTypes: [],
   extractId: () => GLOBAL_ENVIRONMENT_ID,
   selectData: (state) => state.environments.globalEnvironment,
 };
@@ -75,6 +96,7 @@ const globalEnvironmentRemote: BufferSyncRemote = {
 const runtimeVariablesRemote: BufferSyncRemote = {
   entityTypes: [ApiClientEntityType.RUNTIME_VARIABLES],
   shouldHandleAction: (action) => false,
+  bulkActionTypes: [],
   extractId: () => RUNTIME_VARIABLES_ENTITY_ID,
   selectData: () => undefined,
 };
@@ -82,6 +104,11 @@ const runtimeVariablesRemote: BufferSyncRemote = {
 const runConfigRemote: BufferSyncRemote = {
   entityTypes: [ApiClientEntityType.RUN_CONFIG],
   shouldHandleAction: (action) => action.type.startsWith(`${API_CLIENT_RUNNER_CONFIG_SLICE_NAME}/`),
+  bulkActionTypes: [
+    `${API_CLIENT_RUNNER_CONFIG_SLICE_NAME}/upsertConfigs`,
+    `${API_CLIENT_RUNNER_CONFIG_SLICE_NAME}/setAllConfigs`,
+    `${API_CLIENT_RUNNER_CONFIG_SLICE_NAME}/removeConfigsForCollection`,
+  ],
   extractId: getPayloadId,
   selectData: (state, id) => runConfigAdapter.getSelectors().selectById(state.runnerConfig.configs, id),
 };
@@ -93,6 +120,18 @@ const remotes: BufferSyncRemote[] = [
   runtimeVariablesRemote,
   runConfigRemote,
 ];
+
+function syncAllOpenBuffersForRemote(listenerApi: BufferListenerApi, remote: BufferSyncRemote) {
+  const state = listenerApi.getState();
+  const bufferState = state[BUFFER_SLICE_NAME];
+
+  const entries = Object.values(bufferState.entities);
+  for (const entry of entries) {
+    if (!entry?.referenceId) continue;
+    if (!remote.entityTypes.includes(entry.entityType)) continue;
+    performBufferSync(listenerApi, remote, entry.referenceId);
+  }
+}
 
 function performBufferSync(
   listenerApi: BufferListenerApi,
@@ -106,7 +145,16 @@ function performBufferSync(
   const buffer = findBufferByReferenceId(bufferState.entities, id);
   if (!buffer || !buffer.referenceId) return;
 
-  const sourceData = overrideData !== undefined ? overrideData : remote.selectData(state, id);
+  const remoteData = remote.selectData(state, id);
+  // When entitySynced sends partial data (e.g. { name } on rename), merge with full remote data
+  // so we don't replace buffer.current with a partial object and lose e.g. variables.
+  const isSpreadableObject = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+  const sourceData =
+    overrideData !== undefined && isSpreadableObject(remoteData) && isSpreadableObject(overrideData)
+      ? { ...remoteData, ...overrideData }
+      : overrideData !== undefined
+      ? overrideData
+      : remoteData;
 
   if (sourceData !== undefined) {
     listenerApi.dispatch(
@@ -147,6 +195,11 @@ startAppListening({
 
     const remote = remotes.find((r) => r.shouldHandleAction(action));
     if (!remote) return;
+
+    if (remote.bulkActionTypes.includes(action.type)) {
+      syncAllOpenBuffersForRemote(listenerApi, remote);
+      return;
+    }
 
     const id = remote.extractId(action);
     if (!id) return;


### PR DESCRIPTION
actions

- Introduce bulkActionTypes to BufferSyncRemote for handling bulk updates
- Sync all open buffers for a remote when a bulk action is dispatched
- Improve getPayloadId to support more payload shapes
- Prevent buffer resync on non-mutating environment actions
- Merge partial overrideData with remote data during buffer sync to avoid data loss

<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->