### PR TITLE
Fix: Recognize vendor-specific JSON content types (e.g., application/vnd.api+json) for prettification

### DIFF
--- a/app/src/componentsV2/CodeEditor/types/index.ts
+++ b/app/src/componentsV2/CodeEditor/types/index.ts
@@ -29,6 +29,8 @@ const contentTypeToLanguageMap: { regex: RegExp; language: EditorLanguage }[] = 
   { regex: /^application\/manifest\+json$/, language: EditorLanguage.JSON },
   { regex: /^application\/ld\+json$/, language: EditorLanguage.JSON },
   { regex: /^text\/json$/, language: EditorLanguage.JSON },
+  // Vendor-specific JSON types (e.g., application/vnd.api+json)
+  { regex: /^application\/[\w.-]+\+json$/, language: EditorLanguage.JSON },
 ];
 
 export type EditorCustomToolbar = {


### PR DESCRIPTION
## Summary

Fixes #4202

This PR adds support for vendor-specific JSON content types that use the `+json` suffix (e.g., `application/vnd.api+json`) to be properly recognized and prettified as JSON in the API client response body.

## Changes

- Added a new regex pattern `^application\/[\w.-]+\+json$` to the `contentTypeToLanguageMap` in `app/src/componentsV2/CodeEditor/types/index.ts`
- This pattern matches any vendor-specific JSON content type that follows the RFC 6839 format

## Affected Content Types

The fix now properly handles:
- `application/vnd.api+json` (JSON:API format)
- `application/hal+json` (HAL format)
- `application/problem+json` (RFC 7807 Problem Details)
- `application/vnd.github.v3+json` (GitHub API)
- Any other future vendor JSON types

## Testing

The regex has been tested to correctly:
- Match vendor JSON types like `application/vnd.api+json`
- Not match standard JSON types that have their own specific patterns
- Not match non-JSON content types

## Before

Responses with `Content-Type: application/vnd.api+json` were displayed as raw text without JSON prettification.

## After

Responses with `Content-Type: application/vnd.api+json` (and other vendor-specific JSON types) are now properly prettified as JSON in the API client response body viewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced JSON content type recognition in the code editor to support vendor-specific JSON formats, such as application/vnd.api+json, enabling proper syntax highlighting for a broader range of JSON-based content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->