### PR TITLE
PLAT-100: (local fs race condition)  Increase buildFsManager timeout to 30s and set retryCount to 0

### DIFF
--- a/app/src/services/fsManagerServiceAdapter.ts
+++ b/app/src/services/fsManagerServiceAdapter.ts
@@ -187,7 +187,7 @@ class FsManagerServiceAdapterProvider {
   async get(rootPath: string): Promise<FsManagerServiceAdapter> {
     let lock = this.lockMap.get(rootPath);
     if (!lock) {
-      lock = withTimeout(new Mutex(), 10 * 1000);
+      lock = withTimeout(new Mutex(), 30 * 1000);
       this.lockMap.set(rootPath, lock);
     }
     await lock.acquire();


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace management: create workspace folders, list workspaces, remove workspaces, and reload the workspace manager.

* **Performance**
  * Increased filesystem lock timeout to 30 seconds and enabled fail-fast behavior for build operations to reduce duplicate builds and improve stability during long-running tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->