### PR TITLE
PLAT-71 Handle missing ApiClient context during tab buffer cleanup

### DIFF
--- a/app/src/features/apiClient/store/apiRecords/Daemon/CollectionVariablesDaemon.tsx
+++ b/app/src/features/apiClient/store/apiRecords/Daemon/CollectionVariablesDaemon.tsx
@@ -1,20 +1,27 @@
 import { VariableScope } from "backend/environment/types";
 import React, { useEffect } from "react";
-import { useApiClientRepository } from "features/apiClient/slices";
+import { useApiClientRepository, useApiClientStore } from "features/apiClient/slices";
 import { useApiClientDispatch } from "features/apiClient/slices/hooks/base.hooks";
-import { apiRecordsActions } from "features/apiClient/slices/apiRecords";
+import { apiRecordsActions, selectRecordById } from "features/apiClient/slices/apiRecords";
 import { RQAPI } from "features/apiClient/types";
 import { mergeSyncedVariablesPreservingLocalValue } from "features/apiClient/slices/utils/syncVariables";
 
 const CollectionVariablesDaemon: React.FC = () => {
   const { environmentVariablesRepository } = useApiClientRepository();
   const dispatch = useApiClientDispatch();
+  const store = useApiClientStore();
 
   useEffect(() => {
     const unsubscribe = environmentVariablesRepository.attachListener({
       scope: VariableScope.COLLECTION,
       callback: (newCollectionVariables) => {
         for (const collectionId in newCollectionVariables) {
+          const record = selectRecordById(store.getState() as any, collectionId);
+          if (!record || record.type !== RQAPI.RecordType.COLLECTION) {
+            // Repository can emit variables for collections not present in current store
+            // (deleted, not yet hydrated, or out-of-sync). Skip instead of throwing.
+            continue;
+          }
           const incoming = newCollectionVariables[collectionId]?.variables ?? {};
 
           dispatch(
@@ -34,7 +41,7 @@ const CollectionVariablesDaemon: React.FC = () => {
     });
 
     return unsubscribe;
-  }, [environmentVariablesRepository, dispatch]);
+  }, [environmentVariablesRepository, dispatch, store]);
 
   return null;
 };


### PR DESCRIPTION
Skip buffer cleanup if ApiClient context is unavailable, such as during workspace or auth transitions. Also prevent errors in CollectionVariablesDaemon
when repository emits variables for collections not present in the store.

<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->