### PR TITLE
fix: keep queryParams attribute as the source of truth for queryParams

### DIFF
--- a/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestPreparationService.ts
+++ b/app/src/features/apiClient/helpers/httpRequestExecutor/httpRequestPreparationService.ts
@@ -188,6 +188,7 @@ export class HttpRequestPreparationService {
     const workingEntry = cloneDeep(sanitizeEntry(entry));
 
     workingEntry.testResults = [];
+    workingEntry.request.url = workingEntry.request.url.split("?")[0];
 
     // This ensures encoded auth headers (like Basic Auth) are regenerated with updated variables
     if (!isEmpty(executionContext)) {


### PR DESCRIPTION
affects how query params are expected to be fetched and rendered after an execution. 
first faced in https://github.com/requestly/requestly/pull/4210

This would also fix `rq.request.queryParams` being empty in scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted API request URL handling so the base URL is retained separately from query parameters; query parameters are no longer cleared during this preparation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->