### PR TITLE
[ONCALL-284] API Request Failed: Unexpected token 'catch'

### DIFF
--- a/app/src/features/apiClient/helpers/modules/scriptsV2/worker/script-internals/scriptExecutionWorker/scriptExecutionWorker.ts
+++ b/app/src/features/apiClient/helpers/modules/scriptsV2/worker/script-internals/scriptExecutionWorker/scriptExecutionWorker.ts
@@ -67,7 +67,9 @@ export class ScriptExecutionWorker implements ScriptExecutionWorkerInterface {
       "use strict";
       ${globalScript}
       try {
-      return (async () => { ${userScript} })();
+      return (async () => {
+        ${userScript}
+      })();
       } catch (error) {
         console.error(\`\${error.name}: \${error.message}\`);
         throw error;


### PR DESCRIPTION
Reasoning:
The old code was:
`return (async () => { ${userScript} })();`

When `userScript = console.log("test");\n\n// ty`, it becomes:
```
return (async () => { console.log("test");

// ty })(); 

```

See the problem? The comment // ty is on the same line as })();, which means:
Everything after // on that line becomes a comment
So })(); gets commented out!
The async function never closes
This creates invalid syntax

New code:
```
return (async () => {
  ${userScript}
})();

```
Now with the same userScript:
```
return (async () => {
  console.log("test");

// ty
})();

```
Now it works because:
${userScript} is on its own line(s)
The comment // ty is on its own line
})(); is on the NEXT line, so it's NOT commented out
The async function closes properly 

Conclusion
Before (broken):
`return (async () => { console.log("test"); // ty })(); ← Everything after // is a comment!`

After (fixed):

```
return (async () => {
  console.log("test");
  // ty
})(); ← This is on its own line, not commented out!
```