### PR TITLE
[CLEANUP] Error: Editor defaultValue must be a string

### DIFF
--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor.tsx
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor.tsx
@@ -74,14 +74,6 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
       editorViewRef.current = null;
     }
 
-    if (typeof defaultValue !== "string") {
-      Sentry.captureException(new Error("Editor defaultValue must be a string"), {
-        extra: {
-          defaultValue,
-        },
-      });
-    }
-
     if (!editorRef.current) return;
     /*
     CodeMirror uses extensions to configure DOM interactions.


### PR DESCRIPTION
Already handled here: https://github.com/requestly/requestly/pull/4308/changes#diff-8f29338cf60cc287544419c4dd7e8047bafec05dc2d63e7e9ac41e43e56086feL94

It logs error on sentry when we go on bearer or API key auth 
default Value in those cases are `undefined`, but it does not break, since this is handled
In one of the sentry logs, defaultValue was `[]', it did not break but still logs the error 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed runtime validation error logging from the SingleLineEditor component. The component now handles invalid input values gracefully without raising exceptions, improving overall reliability while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->