### PR TITLE
ONCALL-286 Add drag region header to frameless desktop mode in settings UI

### DIFF
--- a/app/src/features/settings/components/SettingsIndex/index.scss
+++ b/app/src/features/settings/components/SettingsIndex/index.scss
@@ -6,6 +6,21 @@
   overflow-y: hidden;
 }
 
+.settings-index-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  &.app-mode-desktop {
+    .settings-header-draggable {
+      -webkit-app-region: drag;
+      height: 40px;
+      flex-shrink: 0;
+    }
+  }
+}
+
 .settings-content-wrapper {
   display: flex;
   justify-content: center;

--- a/app/src/features/settings/components/SettingsIndex/index.tsx
+++ b/app/src/features/settings/components/SettingsIndex/index.tsx
@@ -7,6 +7,10 @@ import PATHS from "config/constants/sub/paths";
 import { redirectToGlobalSettings, redirectToProfileSettings } from "utils/RedirectionUtils";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
 import { useSelector } from "react-redux";
+import { isDesktopMode } from "utils/AppUtils";
+import { isFeatureCompatible } from "utils/CompatibilityUtils";
+import FEATURES from "config/constants/sub/features";
+import { getUserOS } from "utils/osUtils";
 import "./index.scss";
 
 const SettingsIndex: React.FC = () => {
@@ -29,15 +33,24 @@ const SettingsIndex: React.FC = () => {
     }
   }, [navigate, location.pathname, user.details?.profile?.uid]);
 
+  const isDesktopFramelessMode = isDesktopMode() && isFeatureCompatible(FEATURES.FRAMELESS_DESKTOP_APP);
+
   return (
-    <div className="settings-index">
-      <SettingsPrimarySidebar />
-      <Col className="settings-content-wrapper">
-        <Col className="settings-content">
-          <Outlet />
-          <br />
+    <div
+      className={`settings-index-wrapper ${
+        isDesktopFramelessMode ? `app-mode-desktop app-mode-desktop-${getUserOS()}` : ""
+      }`}
+    >
+      {isDesktopFramelessMode && <div className="settings-header-draggable" />}
+      <div className="settings-index">
+        <SettingsPrimarySidebar />
+        <Col className="settings-content-wrapper">
+          <Col className="settings-content">
+            <Outlet />
+            <br />
+          </Col>
         </Col>
-      </Col>
+      </div>
     </div>
   );
 };

--- a/app/src/features/settings/components/SettingsPrimarySidebar/index.scss
+++ b/app/src/features/settings/components/SettingsPrimarySidebar/index.scss
@@ -4,10 +4,6 @@
   background: var(--requestly-color-surface-0);
   border-right: 1px solid var(--requestly-color-surface-2);
   height: 100vh;
-
-  &.app-mode-desktop {
-    padding-top: 40px;
-  }
 }
 
 .settings-primary-sidebar-title-icon {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned settings interface styling to better support desktop applications with improved layout structure.
  * Added draggable header functionality for frameless desktop mode, enhancing window management and usability.
  * Optimized spacing and responsive design for an improved desktop user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->