### PR TITLE
[ENGG-5307] fix: updateDoc having undefined for basicAuth

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/types/AuthConfig.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/types/AuthConfig.ts
@@ -119,8 +119,8 @@ export class BasicAuthAuthorizationConfig implements AuthConfig<Authorization.Ty
   type: Authorization.Type.BASIC_AUTH = Authorization.Type.BASIC_AUTH;
 
   constructor(username?: string, password?: string) {
-    this.username = username;
-    this.password = password;
+    this.username = username ?? "";
+    this.password = password ?? "";
   }
 
   validate(): boolean {


### PR DESCRIPTION
[Sentry Link: FirebaseError
Function updateDoc() called with invalid data. Unsupported field value: undefined (found in field data.auth.authConfigStore.BASIC_AUTH.username in document apis/10xMFoDilnR8ZwBriWHx)
] 
(https://requestly.sentry.io/issues/7243939546/?environment=production&project=4503895961305088&query=updateDoc&referrer=issue-stream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication configuration to properly default missing credentials to empty strings, ensuring consistent handling of authentication parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->