### PR TITLE
fix: firebase error reporting in sentry

### DIFF
--- a/app/src/backend/apiClient/getApiRecords.ts
+++ b/app/src/backend/apiClient/getApiRecords.ts
@@ -60,6 +60,6 @@ const getApiRecordsFromFirebase = async (
     return { success: true, data: result };
   } catch (error) {
     Logger.error("Error fetching api records!", error);
-    throw error;
+    throw new Error(error.message);
   }
 };

--- a/app/src/backend/environment/index.ts
+++ b/app/src/backend/environment/index.ts
@@ -177,7 +177,7 @@ export const fetchAllEnvironmentDetails = async (ownerId: string) => {
 
     return environmentDetails;
   } catch (e) {
-    captureException(e);
+    throw new Error(e.message);
   }
 };
 


### PR DESCRIPTION
We have reconstuct the firebase error before throwing otherwise the stack trace is lost on sentry report