### PR TITLE
[ENGG-5335] fix: import graphQL requests in its view

### DIFF
--- a/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/utils.ts
+++ b/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/utils.ts
@@ -225,14 +225,7 @@ const processUrlEncodedBody = (urlencoded: any[]): RequestBodyProcessingResult =
   };
 };
 
-/** Parsing GraphQL body from Postman (query, variables, operationName) for creating GraphQL API records */
-export interface PostmanGraphQLBody {
-  operation: string;
-  variables: string;
-  operationName?: string;
-}
-
-export const parseGraphQLBody = (graphql: any): PostmanGraphQLBody => {
+export const parseGraphQLBody = (graphql: any): GraphQLBody => {
   if (!graphql || typeof graphql !== "object") {
     return { operation: "", variables: "" };
   }
@@ -323,7 +316,7 @@ const createGraphQLApiRecord = (
       auth: processAuthorizationOptions(request.auth, parentCollectionId),
       scripts: processScripts(item),
     },
-  } as RQAPI.GraphQLApiRecord;
+  };
 };
 
 const createApiRecord = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GraphQL import support for Postman collections, extracting operation, variables, and operation name.
  * GraphQL imports are now routed through a dedicated GraphQL import path to preserve headers and authentication during import.
  * Improved GraphQL body parsing for more reliable imports.

* **Bug Fixes**
  * Safer URL handling: missing or non-string URLs now default to an empty string to avoid import errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->