### PR TITLE
[ENGG-5335] fix: added fallback for operationName undefined in loggedIn state

### DIFF
--- a/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/utils.ts
+++ b/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/utils.ts
@@ -310,7 +310,7 @@ const createGraphQLApiRecord = (
         headers,
         operation: operation,
         variables: variables,
-        operationName: operationName,
+        ...(operationName != null && operationName !== "" && { operationName: operationName }),
       },
       response: null,
       auth: processAuthorizationOptions(request.auth, parentCollectionId),


### PR DESCRIPTION
What the change does
- Before: The request object always had an operationName property, even when there was no name:
`operationName: graphqlBody.operationName` -> could be `undefined` or `""`.
undefined values leads to break while saving in firebase

- After: The property is only added when there is a real value
`...(operationName != null && operationName !== "" && { operationName })` → the key is omitted when it’s null, undefined, or empty string
