### PR TITLE
fix: auto-focus on name input when creating new environment/collection

### DIFF
--- a/app/src/features/apiClient/contexts/apiClient.tsx
+++ b/app/src/features/apiClient/contexts/apiClient.tsx
@@ -244,6 +244,7 @@ export const ApiClientProvider: React.FC<ApiClientProviderProps> = ({ children }
               source: new EnvironmentViewTabSource({
                 id: newEnvironment.id,
                 title: newEnvironment.name,
+                isNewTab: true,
                 context: {
                   id: context.workspaceId,
                 },

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/apiClientSidebarHeader/components/CreateEnvironmentPopup/CreateEnvironmentPopup.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/apiClientSidebarHeader/components/CreateEnvironmentPopup/CreateEnvironmentPopup.tsx
@@ -50,6 +50,7 @@ export const CreateEnvironmentPopup: React.FC = () => {
           source: new EnvironmentViewTabSource({
             id,
             title: name,
+            isNewTab: true,
             context: { id: context.workspaceId },
             isGlobal: false,
           }),

--- a/app/src/lib/design-system-v2/components/RQBreadcrumb/RQBreadcrumb.tsx
+++ b/app/src/lib/design-system-v2/components/RQBreadcrumb/RQBreadcrumb.tsx
@@ -66,8 +66,6 @@ export const RQBreadcrumb: React.FC<Props> = ({
       autoFocusRef.current = true;
       setIsEditRecord(true);
     }
-
-    return () => setIsEditRecord(false);
   }, [autoFocus]);
 
   const breadcrumbs: ({


### PR DESCRIPTION
## Summary
- Fixed the name input not getting auto-focused when creating a new environment or collection
- Root cause: the buffer's `isNew` flag was being reset by `syncFromSource` (middleware) before the `RQBreadcrumb` component could persist its edit state. The `useEffect` cleanup in `RQBreadcrumb` was reverting `isEditRecord` to `false` when `autoFocus` changed from `true` → `false`
- For environments, this was consistently reproducible when creating the first environment because `environmentCreated` sets `activeEnvironmentId` which triggers additional state changes
- For collections, the same race condition caused intermittent failures depending on timing

## Changes
- Removed `useEffect` cleanup in `RQBreadcrumb` that was incorrectly resetting edit mode when the `autoFocus` prop changed
- Added missing `isNewTab: true` in two environment creation paths (sidebar header context handler and no-environments popup)

## Test plan
- [ ] Create a new environment when no environments exist — name input should be focused
- [ ] Create a new environment when environments already exist — name input should be focused
- [ ] Create a new environment from sidebar "+" button — name input should be focused
- [ ] Create a new environment from dropdown — name input should be focused
- [ ] Create a new collection — name input should be focused
- [ ] Verify blurring the input (clicking away or pressing Enter) correctly exits edit mode
- [ ] Verify switching between tabs doesn't leave name inputs in edit mode unexpectedly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment tabs now track when they are newly created or opened for improved identification.

* **Bug Fixes**
  * Corrected edit mode state handling in breadcrumb navigation to maintain proper lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->