### PR TITLE
fix: auto-focus on environment/collection name input when creating ne…

### DIFF
--- a/app/src/features/apiClient/contexts/apiClient.tsx
+++ b/app/src/features/apiClient/contexts/apiClient.tsx
@@ -244,6 +244,7 @@ export const ApiClientProvider: React.FC<ApiClientProviderProps> = ({ children }
               source: new EnvironmentViewTabSource({
                 id: newEnvironment.id,
                 title: newEnvironment.name,
+                isNewTab: true,
                 context: {
                   id: context.workspaceId,
                 },

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/apiClientSidebarHeader/components/CreateEnvironmentPopup/CreateEnvironmentPopup.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/apiClientSidebarHeader/components/CreateEnvironmentPopup/CreateEnvironmentPopup.tsx
@@ -50,6 +50,7 @@ export const CreateEnvironmentPopup: React.FC = () => {
           source: new EnvironmentViewTabSource({
             id,
             title: name,
+            isNewTab: true,
             context: { id: context.workspaceId },
             isGlobal: false,
           }),

--- a/app/src/lib/design-system-v2/components/RQBreadcrumb/RQBreadcrumb.tsx
+++ b/app/src/lib/design-system-v2/components/RQBreadcrumb/RQBreadcrumb.tsx
@@ -66,8 +66,6 @@ export const RQBreadcrumb: React.FC<Props> = ({
       autoFocusRef.current = true;
       setIsEditRecord(true);
     }
-
-    return () => setIsEditRecord(false);
   }, [autoFocus]);
 
   const breadcrumbs: ({


### PR DESCRIPTION
…w record

The name input was not getting focused when creating a new environment or collection because the buffer's isNew flag was being reset by syncFromSource before the RQBreadcrumb could persist the edit state.

- Remove useEffect cleanup in RQBreadcrumb that was reverting edit mode when autoFocus prop changed from true to false
- Add missing isNewTab flag in environment creation paths (sidebar button, dropdown, and no-environments popup)

<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->

## 📜 Summary of changes:

<!-- Summarize your changes -->

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->