### PR TITLE
[ONCALL-336] fix: fallback for non-string values in queryParams

### DIFF
--- a/app/src/features/apiClient/screens/BrunoImporter/utils.ts
+++ b/app/src/features/apiClient/screens/BrunoImporter/utils.ts
@@ -66,12 +66,7 @@ const processParams = (params: Bruno.Param[]) => {
     params?.map((param, index) => ({
       id: index,
       key: param.name,
-      value:
-        typeof param.value === "string"
-          ? param.value
-          : typeof param.value === "number" || typeof param.value === "boolean"
-          ? String(param.value)
-          : "",
+      value: param.value != null && typeof param.value !== "object" ? String(param.value) : "",
       isEnabled: param.enabled ?? true,
     })) || []
   );

--- a/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/utils.ts
+++ b/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/utils.ts
@@ -380,12 +380,7 @@ const createApiRecord = (
     request.url?.query?.map((query: any, index: number) => ({
       id: index,
       key: query.key,
-      value:
-        typeof query.value === "string"
-          ? query.value
-          : typeof query.value === "number" || typeof query.value === "boolean"
-          ? String(query.value)
-          : "",
+      value: query.value != null && typeof query.value !== "object" ? String(query.value) : "",
       isEnabled: query?.disabled !== true,
       description: query.description || "",
       dataType: getInferredKeyValueDataType(query.value),

--- a/app/src/features/apiClient/screens/apiClient/components/modals/importModal/utils.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/modals/importModal/utils.ts
@@ -93,12 +93,7 @@ export const processRqImportData = (
         (queryParam: KeyValuePair, index: number) => {
           return {
             ...queryParam,
-            value:
-              typeof queryParam.value === "string"
-                ? queryParam.value
-                : typeof queryParam.value === "number" || typeof queryParam.value === "boolean"
-                ? String(queryParam.value)
-                : "",
+            value: queryParam.value != null && typeof queryParam.value !== "object" ? String(queryParam.value) : "",
             isEnabled: queryParam.isEnabled ?? true,
             id: queryParam.id ?? index,
           };

--- a/app/src/features/apiClient/screens/apiClient/utils.ts
+++ b/app/src/features/apiClient/screens/apiClient/utils.ts
@@ -270,12 +270,7 @@ export const generateKeyValuePairs = (
     for (const value of valueArray) {
       result.push({
         key: key || "",
-        value:
-          typeof value === "string"
-            ? value
-            : typeof value === "number" || typeof value === "boolean"
-            ? String(value)
-            : "",
+        value: value != null && typeof value !== "object" ? String(value) : "",
         id: Math.random(),
         isEnabled: true,
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized non-string parameter and query values across import and API utilities: numbers and booleans are now coerced to strings; null/unsupported object values default to empty strings, ensuring consistent key/value generation and preventing data-type issues during imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->