### PR TITLE
fix: pre request env var missing

### DIFF
--- a/app/src/features/apiClient/helpers/modules/scriptsV2/worker/script-internals/variableScope.spec.ts
+++ b/app/src/features/apiClient/helpers/modules/scriptsV2/worker/script-internals/variableScope.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { VariableScope } from "./variableScope";
+import { LocalScope } from "modules/localScope";
+import { EnvironmentVariableType } from "backend/environment/types";
+
+const createEnvironmentScope = (variableData: Record<string, any>) => {
+  const localScope = new LocalScope({
+    collectionVariables: {},
+    environment: variableData,
+    global: {},
+    request: {} as any,
+    response: null as any,
+    variables: {},
+    secrets: {},
+  });
+
+  return new VariableScope(localScope, "environment");
+};
+
+describe("VariableScope.get", () => {
+  it("should return sync value when local value is empty", () => {
+    const scope = createEnvironmentScope({
+      my_var: {
+        id: 1,
+        type: EnvironmentVariableType.String,
+        localValue: "",
+        syncValue: "test_value",
+        isPersisted: true,
+      },
+    });
+
+    expect(scope.get("my_var")).toBe("test_value");
+  });
+
+  it("should return local boolean false without falling back to sync value", () => {
+    const scope = createEnvironmentScope({
+      my_var: {
+        id: 1,
+        type: EnvironmentVariableType.Boolean,
+        localValue: false,
+        syncValue: true,
+        isPersisted: true,
+      },
+    });
+
+    expect(scope.get("my_var")).toBe(false);
+  });
+
+  it("should return local number 0 without falling back to sync value", () => {
+    const scope = createEnvironmentScope({
+      my_var: {
+        id: 1,
+        type: EnvironmentVariableType.Number,
+        localValue: 0,
+        syncValue: 123,
+        isPersisted: true,
+      },
+    });
+
+    expect(scope.get("my_var")).toBe(0);
+  });
+});

--- a/app/src/features/apiClient/helpers/modules/scriptsV2/worker/script-internals/variableScope.ts
+++ b/app/src/features/apiClient/helpers/modules/scriptsV2/worker/script-internals/variableScope.ts
@@ -1,4 +1,5 @@
 import { LocalScope } from "modules/localScope";
+import { isEmpty } from "lodash";
 
 function sanitizeValue(value: any): string | number | boolean | null | undefined {
   const type = typeof value;
@@ -78,7 +79,18 @@ export class VariableScope {
 
   get(key: string) {
     const variables = this.localScope.get(this.variableScopeName);
-    return variables[key]?.localValue || variables[key]?.syncValue;
+    const variable = variables[key];
+    if (!variable) {
+      return undefined;
+    }
+
+    // Keep fallback behavior aligned with request template rendering:
+    // use current/local value when present, otherwise use initial/sync value.
+    if (typeof variable.localValue === "number" || typeof variable.localValue === "boolean") {
+      return variable.localValue;
+    }
+
+    return isEmpty(variable.localValue) ? variable.syncValue : variable.localValue;
   }
 
   unset(key: string) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: [<!-- Link to Github issue -->](https://github.com/requestly/requestly/issues/4606)

## 📜 Summary of changes:

handle the fallback logic for env var get in script

## 🎥 Demo Video

**Video/Demo:** N/A

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [x] Verified UI in browser.
- [x] For UI changes, added/updated analytics events (if applicable).
- [x] For changes in extension's code, manually tested in Chrome and Firefox.
- [x] Added/updated unit tests for this change.
- [x] Raised pull request to update corresponding documentation (if already exists).
- [x] **Added demo video showing the changes in action** (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable value retrieval to correctly return falsy values (0, false) instead of unexpectedly falling back to alternate values.

* **Tests**
  * Added test suite to verify proper variable value selection behavior across different data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->