### PR TITLE
fix: network traffic table scroll jump and last row clipping

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/VirtualTableV2.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/VirtualTableV2.tsx
@@ -1,5 +1,5 @@
 import { Table } from "@devtools-ds/table";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ContextMenu } from "../ContextMenu";
 import { ITEM_SIZE } from ".";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -21,8 +21,18 @@ const VirtualTableV2: React.FC<Props> = ({ logs = [], header, renderLogRow, sele
   const [selected, setSelected] = useState<string | null>(null);
   const [lastKnownBottomIndex, setLastKnownBottomIndex] = useState<number | null>(null);
   const [isScrollToBottomEnabled, setIsScrollToBottomEnabled] = useState(true);
+  const [headerHeight, setHeaderHeight] = useState(0);
   const mounted = useRef(false);
   const parentRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const thead = parentRef.current?.querySelector("thead");
+    if (!thead) return;
+    setHeaderHeight(thead.offsetHeight);
+    const observer = new ResizeObserver(() => setHeaderHeight(thead.offsetHeight));
+    observer.observe(thead);
+    return () => observer.disconnect();
+  }, []);
 
   // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled
   const isListAtBottom = useCallback(() => {
@@ -46,6 +56,7 @@ const VirtualTableV2: React.FC<Props> = ({ logs = [], header, renderLogRow, sele
     count: mounted.current ? logs.length : 100,
     getScrollElement: () => parentRef.current,
     estimateSize: () => ITEM_SIZE,
+    scrollMargin: headerHeight,
     onChange: (virtualizer) => {
       requestAnimationFrame(() => {
         const isScrollToBottomEnabled = isListAtBottom();
@@ -61,19 +72,25 @@ const VirtualTableV2: React.FC<Props> = ({ logs = [], header, renderLogRow, sele
 
   // https://github.com/bvaughn/react-window/issues/60#issuecomment-781540658
   const items = rowVirtualizer.getVirtualItems();
-  const paddingTop = items.length > 0 ? items[0].start : 0;
-  const paddingBottom = items.length > 0 ? rowVirtualizer.getTotalSize() - items[items.length - 1].end : 0;
+  const paddingTop = items.length > 0 ? items[0].start - headerHeight : 0;
+  const paddingBottom =
+    items.length > 0 ? headerHeight + rowVirtualizer.getTotalSize() - items[items.length - 1].end : 0;
 
   const scrollToBottom = useCallback(() => {
-    if (logs.length > 0) rowVirtualizer.scrollToIndex(logs.length - 1, { align: "start" });
-    // rowVirtualizer.scrollToOffset(rowVirtualizer.getTotalSize(), { align: "start" });
-  }, [logs.length, rowVirtualizer]);
+    const scrollElem = parentRef.current;
+    if (scrollElem && logs.length > 0) {
+      scrollElem.scrollTop = scrollElem.scrollHeight;
+    }
+  }, [logs.length]);
+
+  const scrollToBottomRef = useRef(scrollToBottom);
+  scrollToBottomRef.current = scrollToBottom;
 
   useEffect(() => {
     if (isScrollToBottomEnabled) {
-      scrollToBottom();
+      scrollToBottomRef.current();
     }
-  }, [scrollToBottom, isScrollToBottomEnabled]);
+  }, [isScrollToBottomEnabled, logs.length]);
 
   const newLogsButton = useMemo(() => {
     if (isScrollToBottomEnabled) {

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
@@ -18,7 +18,7 @@ import "./index.scss";
 import { TOUR_TYPES } from "components/misc/ProductWalkthrough/types";
 import { APIClientModal } from "features/apiClient/components/common/APIClient";
 
-export const ITEM_SIZE = 30;
+export const ITEM_SIZE = 32;
 
 interface Props {
   logs: any;


### PR DESCRIPTION
## Summary

Fixes two related issues in the HTTP Interceptor's network traffic table:
- Scrolling down toward the bottom caused the view to jump slightly upward.
- The last row would clip out of view when scrolled to the bottom, especially during streaming interception.

Root cause was a stack of three coordinate-system mismatches between the `@tanstack/react-virtual` virtualizer and the actual DOM:

1. **Row size estimate was off by 2px** — `ITEM_SIZE = 30` but `@devtools-ds/table` rows render at 32px. Drift accumulated over hundreds of rows.
2. **The virtualizer didn't know about the `<thead>`** — its coordinate space started at scroll offset 0, but the real first row sits 54px down (after the table header).
3. **`scrollToIndex` retried into the streaming counts** — every new log triggered a scroll, the virtualizer's "did I land on the right offset?" check failed because counts kept growing, producing `Failed to scroll to index N after 10 attempts` warnings.

## Changes

- `ITEM_SIZE: 30 → 32` in `NetworkTable/index.tsx` to match real row height.
- Measure `<thead>` height at runtime via `useLayoutEffect` + `ResizeObserver` and pass as `scrollMargin` to `useVirtualizer` so it accounts for the header.
- Update `paddingTop` / `paddingBottom` math: virtual items now report absolute scroll positions (with `scrollMargin` baked in), so subtract `headerHeight` on top, add it back on bottom.
- Replace `rowVirtualizer.scrollToIndex(last, "end")` in `scrollToBottom` with direct DOM `scrollTop = scrollHeight` — avoids the retry loop and lands at the true bottom regardless of streaming counts.
- Stabilize the autoscroll effect via `scrollToBottomRef` so streaming logs trigger scroll-to-bottom without the callback's identity polluting the dep array.

## Test plan

- [ ] Open the desktop app, start HTTP Interceptor against an app generating traffic.
- [ ] Scroll to the very bottom of the network table — last row should be fully visible at the viewport bottom (no clip).
- [ ] Let logs stream — view should stay pinned at the bottom, no upward jumps.
- [ ] Scroll up to inspect a middle row — autoscroll stops, "N new logs" pill appears.
- [ ] Click the pill — view lands cleanly with the latest row at the bottom.
- [ ] Verify no `Failed to scroll to index ... after 10 attempts` warnings appear in DevTools console during streaming.
- [ ] Confirm no ghost gap between `<thead>` and the first row at any scroll position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved table header alignment in the network traffic inspector's virtual scrolling.
  * Refined the "scroll to bottom" behavior for better reliability.
  * Adjusted row sizing configuration for improved table display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->