### PR TITLE
fix: stale closure in PostmanImporter handleFileDrop

### DIFF
--- a/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/PostmanImporter.tsx
+++ b/app/src/features/apiClient/screens/PostmanImporterView/components/PostmanImporter/PostmanImporter.tsx
@@ -182,6 +182,7 @@ export const PostmanImporter: React.FC<PostmanImporterProps> = ({ onSuccess }) =
             .catch((error) => {
               trackImportParseFailed(ApiClientImporterType.POSTMAN, error.message);
               setImportError(error.message);
+              setProcessingStatus("idle");
               Sentry.withScope((scope) => {
                 scope.setTag("error_type", "api_client_postman_import");
                 Sentry.captureException(error);
@@ -189,16 +190,11 @@ export const PostmanImporter: React.FC<PostmanImporterProps> = ({ onSuccess }) =
               Sentry.getActiveSpan()?.setStatus({
                 code: SPAN_STATUS_ERROR,
               });
-            })
-            .finally(() => {
-              if (importError) {
-                setProcessingStatus("idle");
-              }
             });
         }
       )(files);
     },
-    [importError, apiClientRecordsRepository]
+    [apiClientRecordsRepository]
   );
 
   const handleImportEnvironments = useCallback(async () => {


### PR DESCRIPTION
Closes #4163

## What
Move `setProcessingStatus("idle")` from the `.finally()` block into `.catch()` and remove `importError` from the `useCallback` dependency array.

## Why
The previous `.finally()` block read `importError` from the closure, which still held the old (stale) value at evaluation time, since `setImportError(error.message)` in `.catch()` only schedules an asynchronous state update. As a result, `setProcessingStatus("idle")` never executed after an error and the importer was stuck in the `processing` state.

## Notes
- Opened as draft — please review before marking ready.
- Verification: read-only inspection of the surrounding code; no full test suite was run locally.