### PR TITLE
fix: correct return type of getGraphQLDetails

### DIFF
--- a/browser-extension/common/src/devtools/containers/network/networkLogUtils.ts
+++ b/browser-extension/common/src/devtools/containers/network/networkLogUtils.ts
@@ -1,6 +1,6 @@
 import { NetworkEvent, RQNetworkEvent } from "../../types";
 
-export function getGraphQLDetails(event: NetworkEvent): RQNetworkEvent["metadata"]["GQLDetails"] {
+export function getGraphQLDetails(event: NetworkEvent): RQNetworkEvent["metadata"]["graphQLDetails"] {
   const method = event.request.method;
 
   let GQLQuery = null,


### PR DESCRIPTION
Closes #2985

## What
Rename the indexed access on `RQNetworkEvent["metadata"]` from the non-existent property `GQLDetails` to the actual property `graphQLDetails` in the return type of `getGraphQLDetails`.

## Why
`Metadata` only declares `graphQLDetails`, so referencing `GQLDetails` produces TS2339 in `npm run build` for `browser-extension`. Build still emits, but the error noise was the reason for the issue.

## Notes
- Opened as draft — please review before marking ready.
- Verification: did not run the full extension build locally. Single-line type-only change in `browser-extension/common/src/devtools/containers/network/networkLogUtils.ts`.