### PR TITLE
feat(apiClient): RQ-1806 backup link in auto-local-fs migration modal

### DIFF
--- a/app/src/features/apiClient/screens/migrationBlock/MigrationBlockModal.tsx
+++ b/app/src/features/apiClient/screens/migrationBlock/MigrationBlockModal.tsx
@@ -112,9 +112,10 @@ export const MigrationBlockModal: React.FC = () => {
   if (segment === "auto-local-fs") {
     if (!isLocalFsVariantOn) return null;
     // LocalFS data lives on disk and the new app reads the same paths, so the
-    // copy is workspace-agnostic — no per-workspace export, no sign-in, no
-    // WorkspaceProvider needed. Same modal renders for SINGLE (one LOCAL ws)
-    // and MULTI (N LOCAL ws) views.
+    // copy is workspace-agnostic — no sign-in, no WorkspaceProvider at this
+    // level. Same modal renders for SINGLE (one LOCAL ws) and MULTI (N LOCAL
+    // ws) views. The footer's optional backup link mounts its own
+    // WorkspaceProvider scoped to the single workspace, in SINGLE only.
     return <LocalFsBlockModalContent dismissable={dismissable} />;
   }
 
@@ -581,6 +582,21 @@ const WorkspaceBackupLink: React.FC = () => {
   );
 };
 
+// SINGLE-only backup escape hatch for LocalFS. The router doesn't wrap LocalFS
+// in WorkspaceProvider (so MULTI works), so we mount one here scoped to the
+// lone selected workspace. Renders nothing in MULTI.
+const LocalFsWorkspaceBackupLink: React.FC = () => {
+  const selectedWorkspaces = useGetAllSelectedWorkspaces();
+  if (selectedWorkspaces.length !== 1) return null;
+  const workspace = selectedWorkspaces[0];
+  if (!workspace || workspace.status.loading) return null;
+  return (
+    <WorkspaceProvider workspaceId={workspace.id}>
+      <WorkspaceBackupLink />
+    </WorkspaceProvider>
+  );
+};
+
 // LocalFS auto variant — workspace JSON files already live on disk in a
 // user-owned directory; the new app reads the same paths, so there's nothing
 // to export and nothing to sign into. Two steps: download, then open.
@@ -732,6 +748,7 @@ const LocalFsBlockModalContent: React.FC<ContentProps> = ({ dismissable }) => {
             <span>Running into issues? Let us know on GitHub</span>
             <MdArrowForward className="migration-block-modal__report-arrow" />
           </button>
+          <LocalFsWorkspaceBackupLink />
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
## Summary
- The `auto-local-fs` variant of `MigrationBlockModal` had no export/backup option, unlike the `auto-cloud` variant which already shows a minimal "Backup this workspace as zip" link in its footer. This adds the same link to local-fs.
- Implemented as a small wrapper `LocalFsWorkspaceBackupLink` that mounts a `WorkspaceProvider` scoped to the lone selected workspace and renders the existing `WorkspaceBackupLink` inside it.
- SINGLE only — renders nothing in MULTI (no single workspace context to scope to). The router stays workspace-agnostic; provider mounting is local to the footer.

## Test plan
- [ ] auto-local-fs SINGLE: footer shows "Backup this workspace as zip"; clicking exports a zip; success notification appears.
- [ ] auto-local-fs SINGLE with empty workspace: backup link is hidden (existing `WorkspaceBackupLink` self-hide).
- [ ] auto-local-fs MULTI: no backup link rendered.
- [ ] auto-cloud variants: unchanged (already had the link).
- [ ] local-storage manual variant: unchanged (still uses full Export step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backup link functionality in the LocalFS modal to properly reference the selected workspace context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->