### PR TITLE
feat: copy rules to private workspace

### DIFF
--- a/app/src/components/common/SharingModal/Workspaces/PostSharing.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/PostSharing.tsx
@@ -74,8 +74,14 @@ export const PostSharing: React.FC<PostSharingProps> = ({ postShareViewData, set
         ctaText: "Switch to the workspace",
         action: handleSwitchWorkspace,
       },
+      [WorkspaceSharingTypes.PRIVATE_WORKSPACE]: {
+        header: <img src={"/assets/media/components/mail-success.svg"} alt="rules copied" width={60} />,
+        message: "Selected rules have been copied to your Private Workspace",
+        ctaText: "Done",
+        action: toggleModal,
+      },
     };
-  }, [handleSwitchWorkspace, setPostShareViewData, postShareViewData]);
+  }, [handleSwitchWorkspace, setPostShareViewData, postShareViewData, toggleModal]);
 
   return (
     <div className="post-sharing-wrapper">

--- a/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
@@ -2,7 +2,8 @@ import React, { useState, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { getAppMode } from "store/selectors";
 import { WorkspaceShareMenu } from "./WorkspaceShareMenu";
-import { Tooltip } from "antd";
+import { Avatar, Row, Tooltip } from "antd";
+import { LockOutlined } from "@ant-design/icons";
 import { RQButton } from "lib/design-system/components";
 import CopyButton from "components/misc/CopyButton";
 import { httpsCallable, getFunctions } from "firebase/functions";
@@ -97,9 +98,53 @@ export const ShareFromWorkspace: React.FC<Props> = ({
     [appMode, onRulesShared, selectedRules, activeWorkspace, setPostShareViewData]
   );
 
+  const handleTransferToPrivateWorkspace = useCallback(() => {
+    setIsLoading(true);
+    duplicateRulesToTargetWorkspace(appMode, null, selectedRules)
+      .then(() => {
+        setIsLoading(false);
+        trackSharingModalRulesDuplicated("team", selectedRules.length);
+        setPostShareViewData({
+          type: WorkspaceSharingTypes.PRIVATE_WORKSPACE,
+          sourceTeamData: activeWorkspace,
+        });
+
+        onRulesShared();
+      })
+      .catch(() => {
+        const errorMessage = "Failed to copy rules to Private Workspace. Please try again.";
+        setIsLoading(false);
+        toast.error(errorMessage);
+        trackSharingModalToastViewed(errorMessage);
+      });
+  }, [appMode, onRulesShared, selectedRules, activeWorkspace, setPostShareViewData]);
+
   return (
     <>
       <WorkspaceShareMenu onTransferClick={handleTransferToOtherWorkspace} isLoading={isLoading} />
+      <div className="workspace-share-menu-item-card">
+        <Row align="middle" className="items-center">
+          <Avatar
+            size={35}
+            shape="square"
+            icon={<LockOutlined />}
+            className="workspace-avatar"
+            style={{ backgroundColor: "#1E69FF" }}
+          />
+          <span className="workspace-card-description">
+            <div className="text-white">Private workspace</div>
+            <div className="text-gray">Not shared with anyone</div>
+          </span>
+        </Row>
+        <RQButton
+          disabled={isLoading}
+          type="link"
+          className="workspace-menu-item-transfer-btn"
+          onClick={handleTransferToPrivateWorkspace}
+        >
+          Copy here
+        </RQButton>
+      </div>
       <div className="subheader mt-1">Share with Teammates</div>
       <div className="mt-8 text-gray">Collaborate in real-time with your teammates within a shared workspace.</div>
       <div className="mt-1">

--- a/app/src/components/common/SharingModal/actions.ts
+++ b/app/src/components/common/SharingModal/actions.ts
@@ -77,7 +77,7 @@ export const prepareContentToExport = (appMode: string, selectedRuleIds: string[
 
 export const duplicateRulesToTargetWorkspace = async (
   appMode: string,
-  workspaceId: string,
+  workspaceId: string | null,
   ruleIdsToShare: string[]
 ) => {
   const { rules, groups } = await getRulesAndGroupsFromRuleIds(appMode, ruleIdsToShare);

--- a/app/src/components/common/SharingModal/types.ts
+++ b/app/src/components/common/SharingModal/types.ts
@@ -28,6 +28,7 @@ export enum WorkspaceSharingTypes {
   NEW_WORKSPACE_CREATED = "new_workspace_created",
   USERS_INVITED = "users_invites",
   EXISTING_WORKSPACE = "existing_workspace",
+  PRIVATE_WORKSPACE = "private_workspace",
 }
 
 export type PostShareViewData = {

--- a/app/src/utils/syncing/syncDataUtils.js
+++ b/app/src/utils/syncing/syncDataUtils.js
@@ -107,7 +107,8 @@ const preventWorkspaceSyncWrite = async (key, latestRules, objectId, uid, remote
 };
 
 export const updateUserSyncRecords = async (uid, records, appMode, options) => {
-  const targetWorkspaceId = options.workspaceId ?? window.currentlyActiveWorkspaceTeamId;
+  const targetWorkspaceId =
+    options?.workspaceId === undefined ? window.currentlyActiveWorkspaceTeamId : options.workspaceId;
   const isSameWorkspaceOperation = targetWorkspaceId === window.currentlyActiveWorkspaceTeamId;
 
   const latestRules = _.cloneDeep(records); // Does not contain all rules, only contains rules that has been updated.


### PR DESCRIPTION
## Summary
- Adds a Private workspace option to the workspace sharing modal when sharing from a team workspace.
- Copies selected rules by passing `null` as the destination workspace id.
- Preserves `null` in the sync write path so private workspace copies write to the individual sync path instead of falling back to the current team workspace.
- Adds a private-workspace success state after the copy completes.

## Issue
Closes #3825

## Verification
- Ran `git diff --check` in a sparse checkout.
- Inspected the current sharing modal and sync code paths.

Note: I used a sparse checkout for a focused bounty patch, so I did not run the full Requestly app build locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for copying and sharing rules to a private workspace. Users can now transfer selected rules to their private workspace with a new "Copy here" option in the sharing interface, followed by a success confirmation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4646)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->