### PR TITLE
fix: ignore empty source filters in badge count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -22,6 +22,7 @@ import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
+import { getSourceFilterCount } from "./utils";
 import "./RequestSourceRow.css";
 
 const { Text } = Typography;
@@ -70,16 +71,9 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      return getSourceFilterCount(currentlySelectedRuleData.pairs[pairIndex].source.filters);
     },
-    [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
+    [currentlySelectedRuleData]
   );
 
   const sourceKeys = useMemo(

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
@@ -8,7 +8,8 @@ const hasMeaningfulFilterValue = (filterValue) => {
   }
 
   if (typeof filterValue === "string") {
-    return filterValue.trim() !== "" && filterValue !== DEFAULT_FILTER_VALUE;
+    const normalizedFilterValue = filterValue.trim().toLowerCase();
+    return normalizedFilterValue !== "" && normalizedFilterValue !== DEFAULT_FILTER_VALUE;
   }
 
   if (Array.isArray(filterValue)) {

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
@@ -1,0 +1,47 @@
+const PAGE_URL_FILTER_KEY = "pageUrl";
+const REQUEST_PAYLOAD_FILTER_KEY = "requestPayload";
+const DEFAULT_FILTER_VALUE = "all";
+
+const hasMeaningfulFilterValue = (filterValue) => {
+  if (filterValue == null) {
+    return false;
+  }
+
+  if (typeof filterValue === "string") {
+    return filterValue.trim() !== "" && filterValue !== DEFAULT_FILTER_VALUE;
+  }
+
+  if (Array.isArray(filterValue)) {
+    return filterValue.some(hasMeaningfulFilterValue);
+  }
+
+  if (typeof filterValue === "object") {
+    return Object.values(filterValue).some(hasMeaningfulFilterValue);
+  }
+
+  return true;
+};
+
+const hasMeaningfulRequestPayloadFilter = (requestPayloadFilter) => {
+  if (!requestPayloadFilter || typeof requestPayloadFilter !== "object") {
+    return false;
+  }
+
+  return hasMeaningfulFilterValue(requestPayloadFilter.key) && hasMeaningfulFilterValue(requestPayloadFilter.value);
+};
+
+export const getSourceFilterCount = (sourceFilters) => {
+  const filters = Array.isArray(sourceFilters) ? sourceFilters[0] : sourceFilters;
+
+  if (!filters || typeof filters !== "object") {
+    return 0;
+  }
+
+  return Object.entries(filters).filter(
+    ([filterKey, filterValue]) =>
+      filterKey !== PAGE_URL_FILTER_KEY &&
+      (filterKey === REQUEST_PAYLOAD_FILTER_KEY
+        ? hasMeaningfulRequestPayloadFilter(filterValue)
+        : hasMeaningfulFilterValue(filterValue))
+  ).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { getSourceFilterCount } from "./utils";
+
+describe("getSourceFilterCount", () => {
+  it("does not count empty migrated source filters", () => {
+    expect(
+      getSourceFilterCount([
+        {
+          requestPayload: {},
+        },
+      ])
+    ).toBe(0);
+  });
+
+  it("does not count empty request payload values", () => {
+    expect(
+      getSourceFilterCount([
+        {
+          requestPayload: {
+            key: "",
+            value: "",
+          },
+        },
+      ])
+    ).toBe(0);
+  });
+
+  it("does not count request payload filters with only an operator", () => {
+    expect(
+      getSourceFilterCount([
+        {
+          requestPayload: {
+            operator: "Contains",
+          },
+        },
+      ])
+    ).toBe(0);
+  });
+
+  it("counts completed request payload filters", () => {
+    expect(
+      getSourceFilterCount([
+        {
+          requestPayload: {
+            key: "operationName",
+            operator: "Contains",
+            value: "Users",
+          },
+        },
+      ])
+    ).toBe(1);
+  });
+
+  it("counts configured filters while ignoring the derived pageUrl filter", () => {
+    expect(
+      getSourceFilterCount([
+        {
+          pageUrl: {
+            operator: "Contains",
+            value: "example.com",
+          },
+          pageDomains: ["example.com"],
+          requestMethod: ["POST"],
+        },
+      ])
+    ).toBe(2);
+  });
+});

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
@@ -37,6 +37,21 @@ describe("getSourceFilterCount", () => {
     ).toBe(0);
   });
 
+  it('does not count normalized "all" sentinel values', () => {
+    expect(
+      getSourceFilterCount([
+        {
+          pageDomains: ["all"],
+          requestMethod: " All ",
+          requestPayload: {
+            key: "ALL",
+            value: "users",
+          },
+        },
+      ])
+    ).toBe(0);
+  });
+
   it("counts completed request payload filters", () => {
     expect(
       getSourceFilterCount([
@@ -48,6 +63,18 @@ describe("getSourceFilterCount", () => {
           },
         },
       ])
+    ).toBe(1);
+  });
+
+  it("supports non-migrated object filter shape", () => {
+    expect(
+      getSourceFilterCount({
+        requestPayload: {
+          key: "operationName",
+          operator: "Contains",
+          value: "Users",
+        },
+      })
     ).toBe(1);
   });
 


### PR DESCRIPTION
Fixes #3826

## Summary
- Count only source filters with meaningful configured values instead of counting every filter key.
- Ignore empty/migrated request payload filters and operator-only partial payload filters.
- Keep the derived pageUrl filter excluded from the visible badge count.

## Tests
- cd app && npx vitest run src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
- cd app && npx eslint src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
- cd app && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated source-filter counting into a shared utility and updated the UI to use it for consistent behavior.
* **Tests**
  * Added a comprehensive test suite covering various source-filter shapes, edge cases, and normalization rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4647)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4647)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->