### PR TITLE
fix: add tooltips to API client icon buttons

### DIFF
--- a/app/src/componentsV2/BottomSheet/BottomSheet.tsx
+++ b/app/src/componentsV2/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Tabs, TabsProps } from "antd";
+import { Tabs, TabsProps, Tooltip } from "antd";
 import { useBottomSheetContext } from "./context";
 import { BiDockRight } from "@react-icons/all-files/bi/BiDockRight";
 import { BiDockBottom } from "@react-icons/all-files/bi/BiDockBottom";
@@ -38,32 +38,38 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
         {utilities}
 
         {disableDocking ? null : (
+          <Tooltip title={isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom"} placement="bottom" color="#000">
+            <RQButton
+              size="small"
+              type="transparent"
+              onClick={() => toggleSheetPlacement()}
+              className="bottom-sheet-toggle-btn"
+              icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+            />
+          </Tooltip>
+        )}
+
+        <Tooltip
+          title={isBottomSheetOpen ? "Collapse response panel" : "Expand response panel"}
+          placement="bottom"
+          color="#000"
+        >
           <RQButton
             size="small"
             type="transparent"
-            title="Toggle"
-            onClick={() => toggleSheetPlacement()}
-            className="bottom-sheet-toggle-btn"
-            icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+            className="bottom-sheet-collapse-btn bottom-sheet-collapse-btn__vertical"
+            onClick={() => toggleBottomSheet({ action: "bottom_sheet_collapse_expand" })}
+            icon={
+              !isBottomSheetOpen ? (
+                <MdOutlineKeyboardArrowUp />
+              ) : isSheetPlacedAtBottom ? (
+                <MdOutlineKeyboardArrowDown />
+              ) : (
+                <MdOutlineKeyboardArrowRight />
+              )
+            }
           />
-        )}
-
-        <RQButton
-          size="small"
-          type="transparent"
-          title="Collapse"
-          className="bottom-sheet-collapse-btn bottom-sheet-collapse-btn__vertical"
-          onClick={() => toggleBottomSheet({ action: "bottom_sheet_collapse_expand" })}
-          icon={
-            !isBottomSheetOpen ? (
-              <MdOutlineKeyboardArrowUp />
-            ) : isSheetPlacedAtBottom ? (
-              <MdOutlineKeyboardArrowDown />
-            ) : (
-              <MdOutlineKeyboardArrowRight />
-            )
-          }
-        />
+        </Tooltip>
       </div>
     </div>
   );
@@ -71,25 +77,31 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
   const horizontalTabExtraContent = {
     left: (
       <div className="bottom-sheet-collapse-btn__horizontal-container">
-        <RQButton
-          size="small"
-          type="transparent"
-          title="Collapse"
-          className="bottom-sheet-collapse-btn bottom-sheet-collapse-btn__horizontal"
-          onClick={() => toggleBottomSheet({ action: "bottom_sheet_collapse_expand" })}
-          icon={isBottomSheetOpen ? <MdOutlineKeyboardArrowRight /> : <MdOutlineKeyboardArrowLeft />}
-        />
+        <Tooltip
+          title={isBottomSheetOpen ? "Collapse response panel" : "Expand response panel"}
+          placement="right"
+          color="#000"
+        >
+          <RQButton
+            size="small"
+            type="transparent"
+            className="bottom-sheet-collapse-btn bottom-sheet-collapse-btn__horizontal"
+            onClick={() => toggleBottomSheet({ action: "bottom_sheet_collapse_expand" })}
+            icon={isBottomSheetOpen ? <MdOutlineKeyboardArrowRight /> : <MdOutlineKeyboardArrowLeft />}
+          />
+        </Tooltip>
       </div>
     ),
     right: (
-      <RQButton
-        size="small"
-        type="transparent"
-        title="Toggle"
-        onClick={() => toggleSheetPlacement()}
-        className="bottom-sheet-toggle-btn"
-        icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-      />
+      <Tooltip title={isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom"} placement="left" color="#000">
+        <RQButton
+          size="small"
+          type="transparent"
+          onClick={() => toggleSheetPlacement()}
+          className="bottom-sheet-toggle-btn"
+          icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+        />
+      </Tooltip>
     ),
   };
 

--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Tabs, TabsProps, Typography, Popover } from "antd";
+import { Tabs, TabsProps, Typography, Popover, Tooltip } from "antd";
 import { TabItem } from "./TabItem";
 import { Outlet, unstable_useBlocker } from "react-router-dom";
 import { RQButton } from "lib/design-system-v2/components";
@@ -60,16 +60,18 @@ const BufferedTabLabel: React.FC<BufferedTabLabelProps> = ({ tab, onClose, onDou
       </div>
 
       <div className="tab-actions">
-        <RQButton
-          size="small"
-          type="transparent"
-          className="tab-close-button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClose();
-          }}
-          icon={<MdClose />}
-        />
+        <Tooltip title="Close tab" placement="bottom" color="#000">
+          <RQButton
+            size="small"
+            type="transparent"
+            className="tab-close-button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            icon={<MdClose />}
+          />
+        </Tooltip>
         {isDirty && <div className="unsaved-changes-indicator" />}
       </div>
     </div>
@@ -107,16 +109,18 @@ const NonBufferedTabLabel: React.FC<TabLabelProps> = ({ tab, onClose, onDoubleCl
       </div>
 
       <div className="tab-actions">
-        <RQButton
-          size="small"
-          type="transparent"
-          className="tab-close-button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClose();
-          }}
-          icon={<MdClose />}
-        />
+        <Tooltip title="Close tab" placement="bottom" color="#000">
+          <RQButton
+            size="small"
+            type="transparent"
+            className="tab-close-button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            icon={<MdClose />}
+          />
+        </Tooltip>
       </div>
     </div>
   );

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
@@ -157,6 +157,7 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                             <RQButton
                               size="small"
                               type="transparent"
+                              aria-label="Create new environment"
                               icon={<MdAdd />}
                               onClick={(e) => {
                                 e.stopPropagation();
@@ -188,6 +189,7 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                               <RQButton
                                 size="small"
                                 type="transparent"
+                                aria-label="Create new request"
                                 icon={<MdAdd />}
                                 onClick={(e) => e.stopPropagation()}
                               />

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
 import { MdOutlineArrowForwardIos } from "@react-icons/all-files/md/MdOutlineArrowForwardIos";
-import { Collapse, Dropdown, MenuProps, Typography } from "antd";
+import { Collapse, Dropdown, MenuProps, Tooltip, Typography } from "antd";
 import { Conditional } from "components/common/Conditional";
 import { useRBAC } from "features/rbac";
 import { RQButton } from "lib/design-system-v2/components";
@@ -63,12 +63,8 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
   const user = useSelector(getUserAuthDetails);
   const userId = user?.details?.profile?.uid;
 
-  const {
-    handleWorkspaceSwitch,
-    confirmWorkspaceSwitch,
-    isWorkspaceLoading,
-    setIsWorkspaceLoading,
-  } = useWorkspaceSwitcher();
+  const { handleWorkspaceSwitch, confirmWorkspaceSwitch, isWorkspaceLoading, setIsWorkspaceLoading } =
+    useWorkspaceSwitcher();
 
   const { onNewClickV2 } = useApiClientContext();
 
@@ -157,20 +153,22 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                     {showNewRecordBtn ? (
                       <>
                         {type === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-                          <RQButton
-                            size="small"
-                            type="transparent"
-                            icon={<MdAdd />}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onNewClickV2({
-                                contextId: workspaceId,
-                                analyticEventSource: "api_client_sidebar_header",
-                                recordType: RQAPI.RecordType.ENVIRONMENT,
-                                collectionId: undefined,
-                              });
-                            }}
-                          />
+                          <Tooltip title="Create new environment" placement="bottom" color="#000">
+                            <RQButton
+                              size="small"
+                              type="transparent"
+                              icon={<MdAdd />}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onNewClickV2({
+                                  contextId: workspaceId,
+                                  analyticEventSource: "api_client_sidebar_header",
+                                  recordType: RQAPI.RecordType.ENVIRONMENT,
+                                  collectionId: undefined,
+                                });
+                              }}
+                            />
+                          </Tooltip>
                         ) : (
                           <NewApiRecordDropdown
                             invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
@@ -186,12 +184,14 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                               });
                             }}
                           >
-                            <RQButton
-                              size="small"
-                              type="transparent"
-                              icon={<MdAdd />}
-                              onClick={(e) => e.stopPropagation()}
-                            />
+                            <Tooltip title="Create new request" placement="bottom" color="#000">
+                              <RQButton
+                                size="small"
+                                type="transparent"
+                                icon={<MdAdd />}
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                            </Tooltip>
                           </NewApiRecordDropdown>
                         )}
                       </>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
-import { Checkbox, Dropdown, MenuProps, Skeleton, Typography, notification } from "antd";
+import { Checkbox, Dropdown, MenuProps, Skeleton, Tooltip, Typography, notification } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQAPI as SharedRQAPI } from "@requestly/shared/types/entities/apiClient";
 import { RQButton } from "lib/design-system-v2/components";
@@ -493,7 +493,14 @@ export const CollectionRow: React.FC<Props> = ({
                         });
                       }}
                     >
-                      <RQButton size="small" type="transparent" icon={<MdAdd />} onClick={(e) => e.stopPropagation()} />
+                      <Tooltip title="Create new request" placement="bottom" color="#000">
+                        <RQButton
+                          size="small"
+                          type="transparent"
+                          icon={<MdAdd />}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      </Tooltip>
                     </NewApiRecordDropdown>
                     <Dropdown
                       trigger={["click"]}

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
@@ -74,7 +74,9 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
               onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
             }}
           >
-            <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            <Tooltip title="Create new request" placement="bottom" color="#000">
+              <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            </Tooltip>
           </NewApiRecordDropdown>
         )
       )}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -343,7 +343,13 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
             scroll={{ x: 550 }}
             footer={() => (
               <div className="api-key-value-table-footer">
-                <RQButton icon={<MdAdd />} size="small" onClick={handleAddPair} className="key-value-add-more-btn">
+                <RQButton
+                  icon={<MdAdd />}
+                  size="small"
+                  title={`Add ${tableType} entry`}
+                  onClick={handleAddPair}
+                  className="key-value-add-more-btn"
+                >
                   Add More
                 </RQButton>
               </div>

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -260,13 +260,15 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
           }
 
           return (
-            <RQButton
-              className="key-value-delete-btn"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title={`Delete ${tableType} entry`} placement="bottom" color="#000">
+              <RQButton
+                className="key-value-delete-btn"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },
@@ -343,15 +345,11 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
             scroll={{ x: 550 }}
             footer={() => (
               <div className="api-key-value-table-footer">
-                <RQButton
-                  icon={<MdAdd />}
-                  size="small"
-                  title={`Add ${tableType} entry`}
-                  onClick={handleAddPair}
-                  className="key-value-add-more-btn"
-                >
-                  Add More
-                </RQButton>
+                <Tooltip title={`Add ${tableType} entry`} placement="bottom" color="#000">
+                  <RQButton icon={<MdAdd />} size="small" onClick={handleAddPair} className="key-value-add-more-btn">
+                    Add More
+                  </RQButton>
+                </Tooltip>
               </div>
             )}
           />

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -52,6 +52,7 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
   headerContent,
 }) => {
   const { checkInvalidCharacter = false } = config || {};
+  const tableEntryLabel = tableType || "entry";
 
   const isDescriptionVisible =
     hasDescription(extraColumns) &&
@@ -260,7 +261,7 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
           }
 
           return (
-            <Tooltip title={`Delete ${tableType} entry`} placement="bottom" color="#000">
+            <Tooltip title={`Delete ${tableEntryLabel} entry`} placement="bottom" color="#000">
               <RQButton
                 className="key-value-delete-btn"
                 icon={<RiDeleteBin6Line />}
@@ -345,7 +346,7 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
             scroll={{ x: 550 }}
             footer={() => (
               <div className="api-key-value-table-footer">
-                <Tooltip title={`Add ${tableType} entry`} placement="bottom" color="#000">
+                <Tooltip title={`Add ${tableEntryLabel} entry`} placement="bottom" color="#000">
                   <RQButton icon={<MdAdd />} size="small" onClick={handleAddPair} className="key-value-add-more-btn">
                     Add More
                   </RQButton>

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dropdown, Checkbox } from "antd";
+import { Dropdown, Checkbox, Tooltip } from "antd";
 import { MdMoreHoriz } from "@react-icons/all-files/md/MdMoreHoriz";
 import { RQButton } from "lib/design-system-v2/components";
 
@@ -32,9 +32,11 @@ export const KeyValueTableSettingsDropdown: React.FC<KeyValueTableSettingsDropdo
 
   return (
     <div className="key-value-settings-header">
-      <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
-        <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
-      </Dropdown>
+      <Tooltip title="Table settings" placement="bottom" color="#000">
+        <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
+          <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
+        </Dropdown>
+      </Tooltip>
     </div>
   );
 };

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
@@ -32,11 +32,11 @@ export const KeyValueTableSettingsDropdown: React.FC<KeyValueTableSettingsDropdo
 
   return (
     <div className="key-value-settings-header">
-      <Tooltip title="Table settings" placement="bottom" color="#000">
-        <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
+      <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
+        <Tooltip title="Table settings" placement="bottom" color="#000">
           <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
-        </Dropdown>
-      </Tooltip>
+        </Tooltip>
+      </Dropdown>
     </div>
   );
 };

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
@@ -3,7 +3,7 @@ import { FormDropDownOptions, RQAPI } from "features/apiClient/types";
 import React, { useCallback, useMemo } from "react";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
-import { TableProps } from "antd";
+import { TableProps, Tooltip } from "antd";
 import { RiDeleteBin6Line } from "@react-icons/all-files/ri/RiDeleteBin6Line";
 import { MultiEditableCell, MultiEditableRow } from "./MultipartFormRowTable";
 import "./MultiPartFormTable.scss";
@@ -190,9 +190,11 @@ export const MultipartFormTable: React.FC<KeyValueTableProps> = ({
       scroll={{ x: true }}
       footer={() => (
         <div className="api-key-value-table-footer">
-          <RQButton icon={<MdAdd />} size="small" onClick={handleAddPair}>
-            Add More
-          </RQButton>
+          <Tooltip title="Add form data entry" placement="bottom" color="#000">
+            <RQButton icon={<MdAdd />} size="small" onClick={handleAddPair}>
+              Add More
+            </RQButton>
+          </Tooltip>
         </div>
       )}
     />


### PR DESCRIPTION
Fixes #3868

## Summary
- Added tooltips to API Client icon-only controls for tab close, response panel docking/collapse, sidebar create request, and key-value table settings.
- Added a native title for the key-value table Add More action.

## Testing
- npm exec -- prettier --check src/componentsV2/BottomSheet/BottomSheet.tsx src/componentsV2/Tabs/components/TabsContainer.tsx src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
- git diff --check

Note: npm run type-check is currently blocked locally by missing project type definitions / TypeScript config compatibility before checking app code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explanatory tooltips to many interactive controls across the app — response panel docking/collapse controls, tab close buttons, create-new-request buttons, table delete/add controls, table settings trigger, and form-data "Add more" — improving discoverability and accessibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4651)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->