### PR TITLE
Add API client icon tooltips

### DIFF
--- a/app/src/componentsV2/BottomSheet/BottomSheet.tsx
+++ b/app/src/componentsV2/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Tabs, TabsProps } from "antd";
+import { Tabs, TabsProps, Tooltip } from "antd";
 import { useBottomSheetContext } from "./context";
 import { BiDockRight } from "@react-icons/all-files/bi/BiDockRight";
 import { BiDockBottom } from "@react-icons/all-files/bi/BiDockBottom";
@@ -29,6 +29,7 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
   const { sheetPlacement, toggleBottomSheet, toggleSheetPlacement, isBottomSheetOpen } = useBottomSheetContext();
   const isSheetPlacedAtBottom = sheetPlacement === BottomSheetPlacement.BOTTOM;
   const isCollapsedSheetPlacedToRight = !isSheetPlacedAtBottom && !isBottomSheetOpen;
+  const dockTooltipTitle = isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom";
 
   const verticalTabExtraContent = (
     <div className="bottom-sheet-tab-extra-content">
@@ -38,14 +39,16 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
         {utilities}
 
         {disableDocking ? null : (
-          <RQButton
-            size="small"
-            type="transparent"
-            title="Toggle"
-            onClick={() => toggleSheetPlacement()}
-            className="bottom-sheet-toggle-btn"
-            icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-          />
+          <Tooltip title={dockTooltipTitle}>
+            <RQButton
+              size="small"
+              type="transparent"
+              title={dockTooltipTitle}
+              onClick={() => toggleSheetPlacement()}
+              className="bottom-sheet-toggle-btn"
+              icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+            />
+          </Tooltip>
         )}
 
         <RQButton
@@ -82,14 +85,16 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
       </div>
     ),
     right: (
-      <RQButton
-        size="small"
-        type="transparent"
-        title="Toggle"
-        onClick={() => toggleSheetPlacement()}
-        className="bottom-sheet-toggle-btn"
-        icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-      />
+      <Tooltip title={dockTooltipTitle}>
+        <RQButton
+          size="small"
+          type="transparent"
+          title={dockTooltipTitle}
+          onClick={() => toggleSheetPlacement()}
+          className="bottom-sheet-toggle-btn"
+          icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+        />
+      </Tooltip>
     ),
   };
 

--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Tabs, TabsProps, Typography, Popover } from "antd";
+import { Tabs, TabsProps, Typography, Popover, Tooltip } from "antd";
 import { TabItem } from "./TabItem";
 import { Outlet, unstable_useBlocker } from "react-router-dom";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdClose } from "@react-icons/all-files/md/MdClose";
+import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { IoIosArrowDown } from "@react-icons/all-files/io/IoIosArrowDown";
 import { useSetUrl } from "../hooks/useSetUrl";
 import { useCloseActiveTabShortcut } from "hooks/useCloseActiveTabShortcut";
@@ -306,6 +307,11 @@ export const TabsContainer: React.FC = () => {
     <div className="tabs-container">
       <Tabs
         type="editable-card"
+        addIcon={
+          <Tooltip title="New request">
+            <MdAdd />
+          </Tooltip>
+        }
         tabBarExtraContent={operations}
         items={tabItems}
         activeKey={activeTabId}

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/ContextualEnvironmentsSidebar/ContextualEnvironmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/ContextualEnvironmentsSidebar/ContextualEnvironmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
@@ -119,7 +119,7 @@ export const EnvironmentsListItem: React.FC<EnvironmentsListItemProps> = ({
       const allEnvironmentsMap = allEnvironments.reduce((acc, env) => {
         acc[env.id] = env;
         return acc;
-      }, {} as Record<string, typeof allEnvironments[number]>);
+      }, {} as Record<string, (typeof allEnvironments)[number]>);
 
       await dispatch(
         duplicateEnvironment({
@@ -272,15 +272,19 @@ export const EnvironmentsListItem: React.FC<EnvironmentsListItemProps> = ({
       {isReadOnly ? null : (
         <div onClick={(e) => e.stopPropagation()}>
           {!isGlobalEnvironment(environment.id) ? (
-            <Dropdown menu={{ items: menuItems }} trigger={["click"]} placement="bottomRight">
-              <RQButton
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-                className="environment-list-item-dropdown-button"
-                onClick={(e) => e.stopPropagation()}
-              />
-            </Dropdown>
+            <Tooltip title="More actions">
+              <span>
+                <Dropdown menu={{ items: menuItems }} trigger={["click"]} placement="bottomRight">
+                  <RQButton
+                    size="small"
+                    type="transparent"
+                    icon={<MdOutlineMoreHoriz />}
+                    className="environment-list-item-dropdown-button"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </Dropdown>
+              </span>
+            </Tooltip>
           ) : null}
         </div>
       )}

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
 import { MdOutlineArrowForwardIos } from "@react-icons/all-files/md/MdOutlineArrowForwardIos";
-import { Collapse, Dropdown, MenuProps, Typography } from "antd";
+import { Collapse, Dropdown, MenuProps, Tooltip, Typography } from "antd";
 import { Conditional } from "components/common/Conditional";
 import { useRBAC } from "features/rbac";
 import { RQButton } from "lib/design-system-v2/components";
@@ -63,12 +63,8 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
   const user = useSelector(getUserAuthDetails);
   const userId = user?.details?.profile?.uid;
 
-  const {
-    handleWorkspaceSwitch,
-    confirmWorkspaceSwitch,
-    isWorkspaceLoading,
-    setIsWorkspaceLoading,
-  } = useWorkspaceSwitcher();
+  const { handleWorkspaceSwitch, confirmWorkspaceSwitch, isWorkspaceLoading, setIsWorkspaceLoading } =
+    useWorkspaceSwitcher();
 
   const { onNewClickV2 } = useApiClientContext();
 
@@ -157,61 +153,71 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                     {showNewRecordBtn ? (
                       <>
                         {type === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-                          <RQButton
-                            size="small"
-                            type="transparent"
-                            icon={<MdAdd />}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onNewClickV2({
-                                contextId: workspaceId,
-                                analyticEventSource: "api_client_sidebar_header",
-                                recordType: RQAPI.RecordType.ENVIRONMENT,
-                                collectionId: undefined,
-                              });
-                            }}
-                          />
-                        ) : (
-                          <NewApiRecordDropdown
-                            invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
-                            onSelect={(params) => {
-                              apiClientContextRegistry.setLastUsedContext(workspaceId);
-                              //FIXME: fix the analytics here
-                              onNewClickV2({
-                                contextId: workspaceId,
-                                analyticEventSource: "api_client_sidebar_header",
-                                recordType: params.recordType,
-                                collectionId: undefined,
-                                entryType: params.entryType,
-                              });
-                            }}
-                          >
+                          <Tooltip title="New environment">
                             <RQButton
                               size="small"
                               type="transparent"
                               icon={<MdAdd />}
-                              onClick={(e) => e.stopPropagation()}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onNewClickV2({
+                                  contextId: workspaceId,
+                                  analyticEventSource: "api_client_sidebar_header",
+                                  recordType: RQAPI.RecordType.ENVIRONMENT,
+                                  collectionId: undefined,
+                                });
+                              }}
                             />
-                          </NewApiRecordDropdown>
+                          </Tooltip>
+                        ) : (
+                          <Tooltip title="New request or collection">
+                            <span>
+                              <NewApiRecordDropdown
+                                invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
+                                onSelect={(params) => {
+                                  apiClientContextRegistry.setLastUsedContext(workspaceId);
+                                  //FIXME: fix the analytics here
+                                  onNewClickV2({
+                                    contextId: workspaceId,
+                                    analyticEventSource: "api_client_sidebar_header",
+                                    recordType: params.recordType,
+                                    collectionId: undefined,
+                                    entryType: params.entryType,
+                                  });
+                                }}
+                              >
+                                <RQButton
+                                  size="small"
+                                  type="transparent"
+                                  icon={<MdAdd />}
+                                  onClick={(e) => e.stopPropagation()}
+                                />
+                              </NewApiRecordDropdown>
+                            </span>
+                          </Tooltip>
                         )}
                       </>
                     ) : null}
 
-                    <Dropdown
-                      menu={{ items }}
-                      trigger={["click"]}
-                      placement="bottomRight"
-                      overlayClassName="collection-dropdown-menu"
-                    >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
-                    </Dropdown>
+                    <Tooltip title="More actions">
+                      <span>
+                        <Dropdown
+                          menu={{ items }}
+                          trigger={["click"]}
+                          placement="bottomRight"
+                          overlayClassName="collection-dropdown-menu"
+                        >
+                          <RQButton
+                            onClick={(e) => {
+                              e.stopPropagation();
+                            }}
+                            size="small"
+                            type="transparent"
+                            icon={<MdOutlineMoreHoriz />}
+                          />
+                        </Dropdown>
+                      </span>
+                    </Tooltip>
                   </div>
                 </Conditional>
               </div>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
-import { Checkbox, Dropdown, MenuProps, Skeleton, Typography, notification } from "antd";
+import { Checkbox, Dropdown, MenuProps, Skeleton, Tooltip, Typography } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQAPI as SharedRQAPI } from "@requestly/shared/types/entities/apiClient";
 import { RQButton } from "lib/design-system-v2/components";
@@ -483,34 +483,47 @@ export const CollectionRow: React.FC<Props> = ({
 
                 <Conditional condition={!isReadOnly}>
                   <div className={`collection-options ${hoveredId === record.id ? "active" : " "}`}>
-                    <NewApiRecordDropdown
-                      invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
-                      onSelect={(params) => {
-                        setActiveKey(record.id);
-                        setCreateNewField(params.recordType);
-                        onNewClick("collection_row", params.recordType, record.id, params.entryType).then(() => {
-                          setCreateNewField(null);
-                        });
-                      }}
-                    >
-                      <RQButton size="small" type="transparent" icon={<MdAdd />} onClick={(e) => e.stopPropagation()} />
-                    </NewApiRecordDropdown>
-                    <Dropdown
-                      trigger={["click"]}
-                      menu={{ items: getCollectionOptions(record) }}
-                      placement="bottomRight"
-                      overlayClassName="collection-dropdown-menu"
-                    >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowSelection(false);
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
-                    </Dropdown>
+                    <Tooltip title="New request or collection">
+                      <span>
+                        <NewApiRecordDropdown
+                          invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
+                          onSelect={(params) => {
+                            setActiveKey(record.id);
+                            setCreateNewField(params.recordType);
+                            onNewClick("collection_row", params.recordType, record.id, params.entryType).then(() => {
+                              setCreateNewField(null);
+                            });
+                          }}
+                        >
+                          <RQButton
+                            size="small"
+                            type="transparent"
+                            icon={<MdAdd />}
+                            onClick={(e) => e.stopPropagation()}
+                          />
+                        </NewApiRecordDropdown>
+                      </span>
+                    </Tooltip>
+                    <Tooltip title="More actions">
+                      <span>
+                        <Dropdown
+                          trigger={["click"]}
+                          menu={{ items: getCollectionOptions(record) }}
+                          placement="bottomRight"
+                          overlayClassName="collection-dropdown-menu"
+                        >
+                          <RQButton
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setShowSelection(false);
+                            }}
+                            size="small"
+                            type="transparent"
+                            icon={<MdOutlineMoreHoriz />}
+                          />
+                        </Dropdown>
+                      </span>
+                    </Tooltip>
                   </div>
                 </Conditional>
               </div>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps } from "antd";
+import { Typography, Dropdown, MenuProps, Tooltip } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
@@ -268,22 +268,26 @@ export const ExampleRow: React.FC<Props> = ({ record, isReadOnly, handleRecordsT
 
         <Conditional condition={!isReadOnly}>
           <div className={`request-options ${isDropdownVisible ? "active" : ""}`}>
-            <Dropdown
-              trigger={["click"]}
-              menu={{ items: exampleOptions }}
-              placement="bottomRight"
-              open={isDropdownVisible}
-              onOpenChange={setIsDropdownVisible}
-            >
-              <RQButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-              />
-            </Dropdown>
+            <Tooltip title="More actions">
+              <span>
+                <Dropdown
+                  trigger={["click"]}
+                  menu={{ items: exampleOptions }}
+                  placement="bottomRight"
+                  open={isDropdownVisible}
+                  onOpenChange={setIsDropdownVisible}
+                >
+                  <RQButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                    size="small"
+                    type="transparent"
+                    icon={<MdOutlineMoreHoriz />}
+                  />
+                </Dropdown>
+              </span>
+            </Tooltip>
           </div>
         </Conditional>
       </div>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps, Checkbox, notification } from "antd";
+import { Typography, Dropdown, MenuProps, Checkbox, Tooltip, notification } from "antd";
 import { REQUEST_METHOD_BACKGROUND_COLORS, REQUEST_METHOD_COLORS } from "../../../../../../../../../constants";
 import { RequestMethod, RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
@@ -493,23 +493,27 @@ export const RequestRow: React.FC<Props> = ({
 
       <Conditional condition={!isReadOnly}>
         <div className={`request-options ${isDropdownVisible ? "active" : ""}`}>
-          <Dropdown
-            trigger={["click"]}
-            menu={{ items: requestOptions }}
-            placement="bottomRight"
-            open={isDropdownVisible}
-            onOpenChange={handleDropdownVisibleChange}
-          >
-            <RQButton
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowSelection(false);
-              }}
-              size="small"
-              type="transparent"
-              icon={<MdOutlineMoreHoriz />}
-            />
-          </Dropdown>
+          <Tooltip title="More actions">
+            <span>
+              <Dropdown
+                trigger={["click"]}
+                menu={{ items: requestOptions }}
+                placement="bottomRight"
+                open={isDropdownVisible}
+                onOpenChange={handleDropdownVisibleChange}
+              >
+                <RQButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setShowSelection(false);
+                  }}
+                  size="small"
+                  type="transparent"
+                  icon={<MdOutlineMoreHoriz />}
+                />
+              </Dropdown>
+            </span>
+          </Tooltip>
         </div>
       </Conditional>
     </div>
@@ -639,23 +643,27 @@ export const RequestRow: React.FC<Props> = ({
 
             <Conditional condition={!isReadOnly}>
               <div className={`request-options ${isDropdownVisible ? "active" : ""}`}>
-                <Dropdown
-                  trigger={["click"]}
-                  menu={{ items: requestOptions }}
-                  placement="bottomRight"
-                  open={isDropdownVisible}
-                  onOpenChange={handleDropdownVisibleChange}
-                >
-                  <RQButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowSelection(false);
-                    }}
-                    size="small"
-                    type="transparent"
-                    icon={<MdOutlineMoreHoriz />}
-                  />
-                </Dropdown>
+                <Tooltip title="More actions">
+                  <span>
+                    <Dropdown
+                      trigger={["click"]}
+                      menu={{ items: requestOptions }}
+                      placement="bottomRight"
+                      open={isDropdownVisible}
+                      onOpenChange={handleDropdownVisibleChange}
+                    >
+                      <RQButton
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setShowSelection(false);
+                        }}
+                        size="small"
+                        type="transparent"
+                        icon={<MdOutlineMoreHoriz />}
+                      />
+                    </Dropdown>
+                  </span>
+                </Tooltip>
               </div>
             </Conditional>
           </div>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
@@ -55,27 +55,32 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
 
       {listType ? (
         listType === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-          <RQButton
-            size="small"
-            type="transparent"
-            icon={<MdAdd />}
-            title="Create new environment"
-            className="sidebar-list-header-button"
-            onClick={() => {
-              onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
-            }}
-          />
+          <Tooltip title="New environment">
+            <RQButton
+              size="small"
+              type="transparent"
+              icon={<MdAdd />}
+              className="sidebar-list-header-button"
+              onClick={() => {
+                onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
+              }}
+            />
+          </Tooltip>
         ) : null
       ) : (
         showNewRecordAction && (
-          <NewApiRecordDropdown
-            invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
-            onSelect={(params) => {
-              onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
-            }}
-          >
-            <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
-          </NewApiRecordDropdown>
+          <Tooltip title="New request or collection">
+            <span>
+              <NewApiRecordDropdown
+                invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
+                onSelect={(params) => {
+                  onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
+                }}
+              >
+                <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+              </NewApiRecordDropdown>
+            </span>
+          </Tooltip>
         )
       )}
     </div>

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -260,13 +260,15 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
           }
 
           return (
-            <RQButton
-              className="key-value-delete-btn"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title="Delete">
+              <RQButton
+                className="key-value-delete-btn"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dropdown, Checkbox } from "antd";
+import { Dropdown, Checkbox, Tooltip } from "antd";
 import { MdMoreHoriz } from "@react-icons/all-files/md/MdMoreHoriz";
 import { RQButton } from "lib/design-system-v2/components";
 
@@ -32,9 +32,13 @@ export const KeyValueTableSettingsDropdown: React.FC<KeyValueTableSettingsDropdo
 
   return (
     <div className="key-value-settings-header">
-      <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
-        <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
-      </Dropdown>
+      <Tooltip title="Settings">
+        <span>
+          <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
+            <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
+          </Dropdown>
+        </span>
+      </Tooltip>
     </div>
   );
 };

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
@@ -3,7 +3,7 @@ import { FormDropDownOptions, RQAPI } from "features/apiClient/types";
 import React, { useCallback, useMemo } from "react";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
-import { TableProps } from "antd";
+import { TableProps, Tooltip } from "antd";
 import { RiDeleteBin6Line } from "@react-icons/all-files/ri/RiDeleteBin6Line";
 import { MultiEditableCell, MultiEditableRow } from "./MultipartFormRowTable";
 import "./MultiPartFormTable.scss";
@@ -158,13 +158,15 @@ export const MultipartFormTable: React.FC<KeyValueTableProps> = ({
             return null;
           }
           return (
-            <RQButton
-              className="key-value-delete-icon"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title="Delete">
+              <RQButton
+                className="key-value-delete-icon"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },

--- a/app/src/features/apiClient/screens/environment/components/environmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
+++ b/app/src/features/apiClient/screens/environment/components/environmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
@@ -129,7 +129,7 @@ export const EnvironmentsListItem: React.FC<EnvironmentsListItemProps> = ({
       const allEnvironmentsMap = allEnvironments.reduce((acc, env) => {
         acc[env.id] = env;
         return acc;
-      }, {} as Record<string, typeof allEnvironments[number]>);
+      }, {} as Record<string, (typeof allEnvironments)[number]>);
 
       await dispatch(
         duplicateEnvironment({
@@ -286,15 +286,19 @@ export const EnvironmentsListItem: React.FC<EnvironmentsListItemProps> = ({
       {isReadOnly ? null : (
         <div onClick={(e) => e.stopPropagation()}>
           {!isGlobalEnvironment(environment.id) ? (
-            <Dropdown menu={{ items: menuItems }} trigger={["click"]} placement="bottomRight">
-              <RQButton
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-                className="environment-list-item-dropdown-button"
-                onClick={(e) => e.stopPropagation()}
-              />
-            </Dropdown>
+            <Tooltip title="More actions">
+              <span>
+                <Dropdown menu={{ items: menuItems }} trigger={["click"]} placement="bottomRight">
+                  <RQButton
+                    size="small"
+                    type="transparent"
+                    icon={<MdOutlineMoreHoriz />}
+                    className="environment-list-item-dropdown-button"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </Dropdown>
+              </span>
+            </Tooltip>
           ) : null}
         </div>
       )}

--- a/app/src/layouts/DashboardLayout/MenuHeader/MenuHeader.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/MenuHeader.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { isSafariBrowser } from "actions/ExtensionActions";
 import { getAppMode, getRequestBot } from "store/selectors";
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
-import { Col } from "antd";
+import { Col, Tooltip } from "antd";
 import PremiumPlanBadge from "./PremiumPlanBadge/PremiumPlanBadge";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
 import GitHubButton from "react-github-btn";
@@ -103,11 +103,13 @@ export const MenuHeader = () => {
         </div>
 
         <div className="app-primary-header__right-section">
-          <RQButton
-            type="transparent"
-            icon={<Settings />}
-            onClick={() => redirectToSettings(navigate, window.location.pathname, "header")}
-          />
+          <Tooltip title="Settings">
+            <RQButton
+              type="transparent"
+              icon={<Settings />}
+              onClick={() => redirectToSettings(navigate, window.location.pathname, "header")}
+            />
+          </Tooltip>
           <HeaderUser />
         </div>
       </div>

--- a/app/src/lib/design-system-v2/components/RQBreadcrumb/RQBreadcrumb.tsx
+++ b/app/src/lib/design-system-v2/components/RQBreadcrumb/RQBreadcrumb.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link, Params, useMatches } from "react-router-dom";
 import { MdOutlineChevronRight } from "@react-icons/all-files/md/MdOutlineChevronRight";
-import { Input, Skeleton, Typography } from "antd";
+import { Input, Skeleton, Tooltip, Typography } from "antd";
 import { MdOutlineEdit } from "@react-icons/all-files/md/MdOutlineEdit";
 import { useRBAC } from "features/rbac";
 import "./RQBreadcrumb.scss";
@@ -138,7 +138,9 @@ export const RQBreadcrumb: React.FC<Props> = ({
                       {name || placeholder}
                     </Typography.Text>
                     {disabled || !isValidPermission ? null : (
-                      <MdOutlineEdit className="edit-icon" onClick={handleRecordNameEditClick} />
+                      <Tooltip title="Edit">
+                        <MdOutlineEdit className="edit-icon" onClick={handleRecordNameEditClick} />
+                      </Tooltip>
                     )}
                   </div>
                 )


### PR DESCRIPTION
## Summary
- add missing API client tooltips for settings, sidebar add, breadcrumb edit, new-tab, dock, more-actions, and delete icon buttons
- keep tooltip labels aligned with the issue text

Fixes #3868

## Testing
- ./app/node_modules/.bin/prettier --check <touched files>
- git diff --check
- npm run type-check (fails on existing baseline repo errors / missing built local package types; no new errors identified for the added tooltip patterns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User Experience**
  * Added contextual tooltips across the app for action controls (add/new, delete, settings, more actions, edit).
  * Dynamic dock tooltip for the bottom sheet toggle (changes based on placement).
  * Tooltips added to tab add icon, sidebar items, collection/request rows, key/value tables, header settings, and breadcrumb edit.
  * Consistent hover guidance across sidebar, request panels, tabs, and layout areas.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4652)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->