### PR TITLE
Fix request bot viewport overflow

### DIFF
--- a/app/src/features/requestBot/requestBot.css
+++ b/app/src/features/requestBot/requestBot.css
@@ -4,14 +4,16 @@
 
 .request-bot {
   position: fixed;
-  bottom: 30px;
-  right: 20px;
+  bottom: 16px;
+  right: clamp(16px, 5vw, 65px);
   z-index: 100;
-  width: 424px;
-  height: 640px;
+  width: min(424px, calc(100vw - 32px));
+  height: min(640px, calc(100vh - 32px));
+  box-sizing: border-box;
   background-color: var(--requestly-color-surface-2);
   padding: 8px;
   border-radius: 1rem;
+  overflow: hidden;
 }
 
 .request-bot iframe {
@@ -45,4 +47,10 @@
   border-radius: 0 0 16px 16px;
   font-size: var(--requestly-font-size-sm, 13px);
   cursor: pointer;
+}
+
+@media (max-width: 520px) {
+  .request-bot {
+    right: 16px;
+  }
 }


### PR DESCRIPTION
## Summary
- constrain the RequestBot panel width and height to the visible viewport
- keep the bot aligned inside narrow screens with a small-screen right offset override
- hide any panel overflow so the iframe/support footer cannot spill outside the rounded container

Fixes #3846

## Testing
- ./app/node_modules/.bin/prettier --check app/src/features/requestBot/requestBot.css
- git diff --check
- npm run type-check (fails on existing baseline RequestBot.tsx/framer-motion typing issue and other repo-wide type errors; this PR only changes CSS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive positioning and adaptive sizing for the request bot widget to better fit various screen sizes.
  * Prevents layout overflow and ensures consistent box sizing for more stable rendering.
  * Added a mobile-specific adjustment to fix the widget offset on small viewports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4653)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->