### PR TITLE
Add hide/show toggle for sensitive auth fields

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/index.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/index.ts
@@ -12,7 +12,7 @@ export const AUTH_SELECTOR_LABELS = [
 const FORM_FIELDS_LAYOUT: Record<AuthConfigMeta.AuthWithConfig, AuthForm.FormField[]> = {
   [Authorization.Type.API_KEY]: [
     { id: "key", type: AuthForm.FIELD_TYPE.INPUT, label: "Key", placeholder: "Key" },
-    { id: "value", type: AuthForm.FIELD_TYPE.INPUT, label: "Value", placeholder: "Value" },
+    { id: "value", type: AuthForm.FIELD_TYPE.INPUT, label: "Value", placeholder: "Value", isSensitive: true },
     {
       id: "addTo",
       type: AuthForm.FIELD_TYPE.SELECT,
@@ -25,11 +25,11 @@ const FORM_FIELDS_LAYOUT: Record<AuthConfigMeta.AuthWithConfig, AuthForm.FormFie
     },
   ],
   [Authorization.Type.BEARER_TOKEN]: [
-    { id: "bearer", type: AuthForm.FIELD_TYPE.INPUT, label: "Token", placeholder: "Token" },
+    { id: "bearer", type: AuthForm.FIELD_TYPE.INPUT, label: "Token", placeholder: "Token", isSensitive: true },
   ],
   [Authorization.Type.BASIC_AUTH]: [
     { id: "username", type: AuthForm.FIELD_TYPE.INPUT, label: "Username", placeholder: "Username" },
-    { id: "password", type: AuthForm.FIELD_TYPE.INPUT, label: "Password", placeholder: "Password" },
+    { id: "password", type: AuthForm.FIELD_TYPE.INPUT, label: "Password", placeholder: "Password", isSensitive: true },
   ],
 };
 

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/types.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/types.ts
@@ -19,6 +19,7 @@ export namespace AuthForm {
   export interface InputField extends BaseAuthFormField {
     type: FIELD_TYPE.INPUT;
     placeholder?: string;
+    isSensitive?: boolean;
   }
 
   export interface SelectField extends BaseAuthFormField {

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/index.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/index.tsx
@@ -1,5 +1,5 @@
 import { Select } from "antd";
-import React from "react";
+import React, { useState } from "react";
 import { AuthForm } from "./formStructure/types";
 import { AuthConfig, AuthConfigMeta, Authorization } from "../types/AuthConfig";
 import { useAuthFormState } from "./hooks/useAuthFormState";
@@ -9,6 +9,9 @@ import InfoIcon from "components/misc/InfoIcon";
 import { Conditional } from "components/common/Conditional";
 import { INVALID_KEY_CHARACTERS } from "features/apiClient/constants";
 import { ScopedVariables, useScopedVariables } from "features/apiClient/helpers/variableResolver/variable-resolver";
+import { RQButton } from "lib/design-system-v2/components";
+import { RiEyeLine } from "@react-icons/all-files/ri/RiEyeLine";
+import { RiEyeOffLine } from "@react-icons/all-files/ri/RiEyeOffLine";
 
 interface AuthorizationFormProps<AuthType extends AuthConfigMeta.AuthWithConfig> {
   recordId: string;
@@ -55,7 +58,8 @@ function generateFields(
   onChangeHandler: (value: string, id: string) => void,
   formState: Record<string, string>
 ) {
-  const hasInvalidCharacter = INVALID_KEY_CHARACTERS.test(formState[field.id]);
+  const fieldValue = formState[field.id] ?? "";
+  const hasInvalidCharacter = INVALID_KEY_CHARACTERS.test(fieldValue);
   //this is used as on mount the formState is undefinded so added a fallback
   const isHeader = (formState.addTo || addToOptions.HEADER) === addToOptions.HEADER;
   /*
@@ -64,37 +68,16 @@ function generateFields(
   switch (field.type) {
     case AuthForm.FIELD_TYPE.INPUT:
       return (
-        <div
-          className={`input-container ${
-            hasInvalidCharacter && formType === Authorization.Type.API_KEY && field.id === "key" && isHeader
-              ? "error-state"
-              : ""
-          }`}
-        >
-          <SingleLineEditor
-            key={`${formType}-${index}`}
-            className={field.className ?? ""}
-            placeholder={field.placeholder}
-            defaultValue={formState[field.id]}
-            onChange={(value) => onChangeHandler(value, field.id)}
-            variables={variables}
-          />
-          <Conditional
-            condition={hasInvalidCharacter && formType === Authorization.Type.API_KEY && field.id === "key" && isHeader}
-          >
-            <div className="error-icon">
-              <InfoIcon
-                text="Invalid character used in key"
-                tooltipPlacement="right"
-                showArrow={false}
-                style={{
-                  color: "var(--requestly-color-error)",
-                  fontFamily: "Material Symbols Outlined",
-                }}
-              />
-            </div>
-          </Conditional>
-        </div>
+        <AuthorizationInputField
+          field={field}
+          formType={formType}
+          index={index}
+          variables={variables}
+          value={fieldValue}
+          hasInvalidCharacter={hasInvalidCharacter}
+          isHeader={isHeader}
+          onChangeHandler={onChangeHandler}
+        />
       );
     case AuthForm.FIELD_TYPE.SELECT:
       return (
@@ -111,5 +94,74 @@ function generateFields(
       return null;
   }
 }
+
+interface AuthorizationInputFieldProps {
+  field: AuthForm.InputField;
+  formType: Authorization.Type;
+  index: number;
+  variables: ScopedVariables;
+  value: string;
+  hasInvalidCharacter: boolean;
+  isHeader: boolean;
+  onChangeHandler: (value: string, id: string) => void;
+}
+
+const AuthorizationInputField: React.FC<AuthorizationInputFieldProps> = ({
+  field,
+  formType,
+  index,
+  variables,
+  value,
+  hasInvalidCharacter,
+  isHeader,
+  onChangeHandler,
+}) => {
+  const [isValueVisible, setIsValueVisible] = useState(false);
+  const shouldShowError =
+    hasInvalidCharacter && formType === Authorization.Type.API_KEY && field.id === "key" && isHeader;
+  const shouldMaskValue = field.isSensitive && !isValueVisible;
+
+  return (
+    <div
+      className={`input-container ${shouldShowError ? "error-state" : ""} ${
+        field.isSensitive ? "sensitive-input" : ""
+      }`}
+    >
+      <SingleLineEditor
+        key={`${formType}-${index}`}
+        className={`${field.className ?? ""} ${field.isSensitive ? "sensitive-auth-editor" : ""} ${
+          shouldMaskValue ? "sensitive-auth-editor-masked" : ""
+        }`}
+        placeholder={field.placeholder}
+        defaultValue={value}
+        onChange={(updatedValue) => onChangeHandler(updatedValue, field.id)}
+        variables={variables}
+      />
+      <Conditional condition={!!field.isSensitive}>
+        <RQButton
+          type="transparent"
+          size="small"
+          className="sensitive-auth-toggle-btn"
+          title={isValueVisible ? "Hide value" : "Show value"}
+          icon={isValueVisible ? <RiEyeOffLine /> : <RiEyeLine />}
+          onClick={() => setIsValueVisible((prev) => !prev)}
+        />
+      </Conditional>
+      <Conditional condition={shouldShowError}>
+        <div className="error-icon">
+          <InfoIcon
+            text="Invalid character used in key"
+            tooltipPlacement="right"
+            showArrow={false}
+            style={{
+              color: "var(--requestly-color-error)",
+              fontFamily: "Material Symbols Outlined",
+            }}
+          />
+        </div>
+      </Conditional>
+    </div>
+  );
+};
 
 export default React.memo(AuthorizationForm);

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/index.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/index.tsx
@@ -143,6 +143,8 @@ const AuthorizationInputField: React.FC<AuthorizationInputFieldProps> = ({
           size="small"
           className="sensitive-auth-toggle-btn"
           title={isValueVisible ? "Hide value" : "Show value"}
+          aria-label={isValueVisible ? "Hide value" : "Show value"}
+          aria-pressed={isValueVisible}
           icon={isValueVisible ? <RiEyeOffLine /> : <RiEyeLine />}
           onClick={() => setIsValueVisible((prev) => !prev)}
         />

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/authorizationView.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/authorizationView.scss
@@ -90,6 +90,26 @@
               padding: var(--requestly-space-0, 0px);
               margin-bottom: var(--requestly-space-4, 8px);
             }
+
+            .input-container.sensitive-input {
+              position: relative;
+
+              .sensitive-auth-editor {
+                padding-right: 34px;
+              }
+
+              .sensitive-auth-editor-masked .cm-content {
+                -webkit-text-security: disc;
+              }
+
+              .sensitive-auth-toggle-btn {
+                position: absolute;
+                top: 50%;
+                right: 4px;
+                transform: translateY(-50%);
+                color: var(--requestly-color-text-subtle);
+              }
+            }
           }
 
           .ant-select-selector {


### PR DESCRIPTION
## Summary
- mark API key value, bearer token, and basic auth password fields as sensitive
- mask sensitive authorization field values by default
- add an inline visibility toggle to show or hide each sensitive value

Fixes #3725

## Testing
- ./app/node_modules/.bin/prettier --check <touched files>
- git diff --check
- npm run type-check (full repo still fails on existing baseline errors; no type-check errors reported for the touched authorization files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization inputs (API Key, Bearer Token, Basic Auth password) are now treated as sensitive by default.
  * Added a visibility toggle (eye icon) to show/hide sensitive authorization values.
* **Style**
  * New masked display styling for sensitive fields to hide values by default and reveal on demand.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4654)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->