### PR TITLE
Fix traffic table row cursor

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -1,5 +1,11 @@
 .web-traffic-table-container {
   height: 100%;
+
+  .web-traffic-table-row,
+  .web-traffic-table-row td {
+    cursor: pointer;
+  }
+
   table {
     tbody {
       tr[aria-selected="true"] {

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
@@ -238,6 +238,7 @@ const NetworkTable: React.FC<Props> = ({
           id={log.id}
           onContextMenu={() => setSelectedRowData(log)}
           {...rowProps}
+          className={["web-traffic-table-row", rowProps?.className].filter(Boolean).join(" ")}
           data-tour-id={index === 0 && !isTrafficTableTourCompleted ? "traffic-table-row" : null}
         >
           {columns.map((column: any) => {


### PR DESCRIPTION
## Summary
- keep traffic table rows showing a pointer cursor over row cells
- preserve any existing row classes from the row props

Fixes requestly/interceptor#49

## Testing
- app/node_modules/.bin/prettier --check app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
- npm run type-check -- --pretty false *(fails on existing repository TypeScript errors; no new error is introduced by this change)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Network traffic table rows now display with cursor pointer styling and consistent formatting, providing visual feedback that rows are interactive and clickable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4655)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->