### PR TITLE
Expand rule code editors to available height

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/CustomScriptRow/index.jsx
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/CustomScriptRow/index.jsx
@@ -247,6 +247,7 @@ const CustomScriptRow = ({
               handleChange={handleEditorUpdate}
               isReadOnly={isInputDisabled}
               analyticEventProperties={{ source: "rule_editor", rule_type: RuleType.SCRIPT }}
+              autoFillAvailableHeight
               toolbarOptions={{
                 title: "Code",
               }}

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js
@@ -136,6 +136,7 @@ const RequestBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisable
                 prettifyOnInit={true}
                 isReadOnly={isInputDisabled}
                 analyticEventProperties={{ source: "rule_editor", rule_type: RuleType.REQUEST }}
+                autoFillAvailableHeight
                 toolbarOptions={{
                   title: "Request Body",
                   options: [EditorRadioGroupOptions],

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ResponseBodyRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ResponseBodyRow/index.js
@@ -337,6 +337,7 @@ const ResponseBodyRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabl
                 handleChange={responseBodyChangeHandler}
                 isResizable
                 analyticEventProperties={{ source: "rule_editor", rule_type: RuleType.RESPONSE }}
+                autoFillAvailableHeight
                 toolbarOptions={{
                   title: "Response Body",
                   options: [EditorRadioGroupOptions],

--- a/app/src/componentsV2/CodeEditor/components/EditorV2/Editor.tsx
+++ b/app/src/componentsV2/CodeEditor/components/EditorV2/Editor.tsx
@@ -41,6 +41,7 @@ interface EditorProps {
   isReadOnly?: boolean;
   height?: number;
   isResizable?: boolean;
+  autoFillAvailableHeight?: boolean;
   scriptId?: string;
   toolbarOptions?: EditorCustomToolbar;
   toolbarRightContent?: React.ReactNode;
@@ -72,6 +73,7 @@ const Editor: React.FC<EditorProps> = ({
   isReadOnly = false,
   height = 225,
   isResizable = false,
+  autoFillAvailableHeight = false,
   hideCharacterCount = false,
   handleChange = () => {},
   toolbarOptions,
@@ -94,6 +96,7 @@ const Editor: React.FC<EditorProps> = ({
   const location = useLocation();
   const dispatch = useDispatch();
   const editorRef = useRef<ReactCodeMirrorRef | null>(null);
+  const resizableContainerRef = useRef<HTMLDivElement | null>(null);
   const [editorHeight, setEditorHeight] = useState(height);
   const [hoveredVariable, setHoveredVariable] = useState<string | null>(null);
   const isFullScreenModeOnboardingCompleted = useSelector(getIsCodeEditorFullScreenModeOnboardingCompleted);
@@ -114,6 +117,37 @@ const Editor: React.FC<EditorProps> = ({
   const handleResize = (event: any, { element, size, handle }: any) => {
     setEditorHeight(size.height);
   };
+
+  useEffect(() => {
+    if (!autoFillAvailableHeight || isFullScreen) {
+      return;
+    }
+
+    const updateEditorHeight = () => {
+      const resizableContainer = resizableContainerRef.current;
+      const containerTop = resizableContainer?.getBoundingClientRect().top;
+
+      if (!resizableContainer || containerTop === undefined) {
+        return;
+      }
+
+      const editorContainerBottom =
+        resizableContainer
+          .closest(".rule-editor-procard, .rule-editor-body-scroll, .bottomsheet-split-layout-container")
+          ?.getBoundingClientRect().bottom ?? window.innerHeight;
+      const bottomSpacing = isResizable ? 48 : 24;
+      const availableHeight = Math.floor(editorContainerBottom - containerTop - bottomSpacing);
+      setEditorHeight(Math.max(height, availableHeight));
+    };
+
+    const animationFrameId = requestAnimationFrame(updateEditorHeight);
+    window.addEventListener("resize", updateEditorHeight);
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      window.removeEventListener("resize", updateEditorHeight);
+    };
+  }, [autoFillAvailableHeight, height, isFullScreen, isResizable]);
 
   const handleFullScreenToggle = useCallback(() => {
     handleFullScreenChange();
@@ -418,37 +452,39 @@ const Editor: React.FC<EditorProps> = ({
   ) : (
     <>
       {!hideToolbar && toolbar}
-      <ResizableBox
-        height={editorHeight}
-        width={Infinity}
-        onResize={handleResize}
-        handle={
-          isResizable ? (
-            <div className="custom-handle">
-              {!hideCharacterCount ? (
-                <div className="code-editor-character-count">{getByteSize(value)} characters</div>
-              ) : null}
-            </div>
-          ) : null
-        }
-        axis="y"
-        style={{
-          minHeight: `${height}px`,
-          marginBottom: isResizable ? "25px" : 0,
-        }}
-      >
-        {toastContainer}
-        {mergeView ? (
-          <MergeViewEditor
-            originalValue={value}
-            newValue={mergeView.incomingValue}
-            onMergeChunk={handleMergeChunk}
-            onEditorReady={editorRefCallback}
-          />
-        ) : (
-          editor
-        )}
-      </ResizableBox>
+      <div ref={resizableContainerRef}>
+        <ResizableBox
+          height={editorHeight}
+          width={Infinity}
+          onResize={handleResize}
+          handle={
+            isResizable ? (
+              <div className="custom-handle">
+                {!hideCharacterCount ? (
+                  <div className="code-editor-character-count">{getByteSize(value)} characters</div>
+                ) : null}
+              </div>
+            ) : null
+          }
+          axis="y"
+          style={{
+            minHeight: `${height}px`,
+            marginBottom: isResizable ? "25px" : 0,
+          }}
+        >
+          {toastContainer}
+          {mergeView ? (
+            <MergeViewEditor
+              originalValue={value}
+              newValue={mergeView.incomingValue}
+              onMergeChunk={handleMergeChunk}
+              onEditorReady={editorRefCallback}
+            />
+          ) : (
+            editor
+          )}
+        </ResizableBox>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- add an opt-in mode for the shared CodeEditor to fill the remaining rule editor viewport
- enable it for Modify Request body, Modify Response body, and Insert Script custom-code editors
- keep the existing manual vertical resize handle and minimum editor heights intact

Fixes requestly/interceptor#38

## Testing
- app/node_modules/.bin/prettier --check app/src/componentsV2/CodeEditor/components/EditorV2/Editor.tsx app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestBodyRow/index.js app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/ResponseBodyRow/index.js app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/CustomScriptRow/index.jsx
- npm run type-check -- --pretty false *(fails on existing repository TypeScript errors; relevant errors are pre-existing and unrelated to this change)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code editor now automatically adjusts its height to fill available vertical space on the screen, providing improved visibility and better workspace utilization when editing code.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4656)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->