### PR TITLE
Fix GraphQL schema builder selection persistence

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/SchemaBuilder.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/SchemaBuilder.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useMemo } from "react";
 import Explorer from "graphiql-explorer";
 import { buildClientSchema, parse } from "graphql";
 import "@graphiql/plugin-explorer/style.css";
@@ -29,10 +29,8 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
     url,
   });
 
-  const hasParsedSuccessfully = useRef(false);
-
   /*
-   * This effect is added due to Explorer component's internal query caching logic.
+   * This guard is added due to Explorer component's internal query caching logic.
    * The graphiql-explorer package uses module-level memoization that caches parsed queries
    * across all component instances. When multiple SchemaBuilder components are rendered
    * (e.g., in different tabs), they share the same parsed query cache, causing field
@@ -42,18 +40,20 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
    * using a previously cached query, which can lead to unexpected behavior and further
    * state sharing issues between different instances.
    *
-   * By only passing the query to Explorer after it has been successfully parsed once,
-   * we prevent the Explorer from caching invalid queries and reduce the likelihood of
-   * shared state issues between different instances.
+   * By only passing a currently valid query to Explorer, we prevent invalid queries from
+   * poisoning that cache. This must be derived during render so remounted panes still
+   * receive the saved operation and restore their checked fields immediately.
    */
-  useEffect(() => {
-    if (!hasParsedSuccessfully.current) {
-      try {
-        parse(operation);
-        hasParsedSuccessfully.current = true;
-      } catch (e) {
-        // NO OP
-      }
+  const explorerQuery = useMemo(() => {
+    if (!operation) {
+      return "";
+    }
+
+    try {
+      parse(operation);
+      return operation;
+    } catch (e) {
+      return "";
     }
   }, [operation]);
 
@@ -80,7 +80,7 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
           <div className="schema-builder__content">
             <Explorer
               schema={introspectionData ? buildClientSchema(introspectionData) : {}}
-              query={hasParsedSuccessfully.current ? operation : ""}
+              query={explorerQuery}
               explorerIsOpen={true}
               arrowClosed={<Checkbox checked={false} className="schema-builder__checkbox" />}
               arrowOpen={<Checkbox checked={true} className="schema-builder__checkbox" />}

--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilder.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilder.scss
@@ -142,6 +142,12 @@
         display: none !important;
       }
 
+      .graphiql-explorer-root {
+        display: inline-block;
+        min-width: 100%;
+        width: max-content;
+      }
+
       .graphiql-explorer-node {
         margin-top: 8px;
 


### PR DESCRIPTION
## Summary
- derive the Explorer query during render so remounted schema-builder panes receive the saved operation immediately
- keep invalid GraphQL operations out of Explorer to avoid its shared parse cache falling back to stale selections
- let the schema explorer content size to its nested tree so horizontal scrolling can reach clipped content

Fixes #3823

## Testing
- app/node_modules/.bin/prettier --check app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/SchemaBuilder.tsx app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilder.scss
- npm run type-check -- --pretty false 2>&1 | rg "SchemaBuilder|schemaBuilder" || true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved query caching issue in the GraphQL schema explorer that prevented accurate schema exploration.

* **Style**
  * Improved GraphQL schema explorer layout and width rendering for better visual presentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4657)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->