### PR TITLE
Improve variable autocomplete dropdown UI

### DIFF
--- a/app/src/features/apiClient/screens/environment/components/VariableAutocompletePopover/components/VariableRowContent.tsx
+++ b/app/src/features/apiClient/screens/environment/components/VariableAutocompletePopover/components/VariableRowContent.tsx
@@ -4,6 +4,7 @@ import { InfoCircleOutlined, RightOutlined } from "@ant-design/icons";
 import { capitalize } from "lodash";
 import {
   AutocompleteItem,
+  Variable,
   checkIsDynamicVariable,
   checkIsSecretsVariable,
 } from "features/apiClient/helpers/variableResolver/variableHelper";
@@ -12,13 +13,76 @@ import { DynamicVariableInfoPopover } from "../../DynamicVariableInfoPopover/Dyn
 import { DynamicVariable } from "lib/dynamic-variables/types";
 import { VariableScope } from "backend/environment/types";
 
+const SCOPE_LABELS: Partial<Record<VariableScope, string>> = {
+  [VariableScope.DATA_FILE]: "Data",
+  [VariableScope.RUNTIME]: "Runtime",
+  [VariableScope.ENVIRONMENT]: "Environment",
+  [VariableScope.COLLECTION]: "Collection",
+  [VariableScope.GLOBAL]: "Global",
+  [VariableScope.DYNAMIC]: "Dynamic",
+  [VariableScope.SECRETS]: "Secrets",
+};
+
+const getVariableScope = (variable: Variable): VariableScope => {
+  return (Array.isArray(variable) ? variable[1].scope : variable.scope) as VariableScope;
+};
+
+const getVariableSourceName = (variable: Variable) => {
+  if (Array.isArray(variable)) {
+    return variable[1].name;
+  }
+
+  if (checkIsDynamicVariable(variable)) {
+    return "Generated at request time";
+  }
+
+  if (checkIsSecretsVariable(variable)) {
+    return "Secrets";
+  }
+
+  return "";
+};
+
+const getVariablePreview = (variable: Variable, isNamespace?: boolean) => {
+  if (isNamespace) {
+    return "Browse nested variables";
+  }
+
+  if (Array.isArray(variable)) {
+    const [data] = variable;
+    if (data.type === "secret") {
+      return "Secret value";
+    }
+
+    const value = data.localValue ?? data.syncValue;
+    if (value === undefined || value === "") {
+      return "No value";
+    }
+
+    return String(value);
+  }
+
+  if (checkIsDynamicVariable(variable)) {
+    return variable.example ? `Example: ${variable.example}` : variable.description;
+  }
+
+  if (checkIsSecretsVariable(variable)) {
+    return "Secret value";
+  }
+
+  return "";
+};
+
 export const VariableRowContent: React.FC<{ item: AutocompleteItem; hideIcon?: boolean }> = ({
   item,
   hideIcon = false,
 }) => {
   const isDynamic = checkIsDynamicVariable(item.variable);
   const isSecret = checkIsSecretsVariable(item.variable);
-  const variableScope = Array.isArray(item.variable) ? item.variable[1].scope : item.variable.scope;
+  const variableScope = getVariableScope(item.variable);
+  const scopeLabel = isSecret ? SCOPE_LABELS[VariableScope.SECRETS] : SCOPE_LABELS[variableScope];
+  const sourceName = getVariableSourceName(item.variable);
+  const preview = getVariablePreview(item.variable, item.isNamespace);
 
   const scopeTooltipTitle = isSecret
     ? "Scope: Secrets"
@@ -28,13 +92,30 @@ export const VariableRowContent: React.FC<{ item: AutocompleteItem; hideIcon?: b
 
   return (
     <>
-      <div className="item-left-section">
+      <div className={`item-left-section ${hideIcon ? "compact" : ""}`}>
         {!hideIcon && (
           <Tooltip title={scopeTooltipTitle} placement="top" showArrow={false} overlayClassName="scope-tooltip">
             <span className="scope-icon-wrapper">{getScopeIcon(variableScope, { showBackgroundColor: false })}</span>
           </Tooltip>
         )}
-        <span className="variable-label">{item.displayName}</span>
+        <span className="variable-label" title={item.displayName}>
+          {item.displayName}
+        </span>
+        {!hideIcon && (
+          <div className="variable-metadata">
+            {scopeLabel ? <span className="variable-scope-badge">{scopeLabel}</span> : null}
+            {sourceName ? (
+              <span className="variable-source-name" title={sourceName}>
+                {sourceName}
+              </span>
+            ) : null}
+            {preview ? (
+              <span className="variable-value-preview" title={preview}>
+                {preview}
+              </span>
+            ) : null}
+          </div>
+        )}
       </div>
       {item.isNamespace ? (
         <RightOutlined className="namespace-chevron" />

--- a/app/src/features/apiClient/screens/environment/components/VariableAutocompletePopover/components/VariableRowContent.tsx
+++ b/app/src/features/apiClient/screens/environment/components/VariableAutocompletePopover/components/VariableRowContent.tsx
@@ -55,7 +55,7 @@ const getVariablePreview = (variable: Variable, isNamespace?: boolean) => {
     }
 
     const value = data.localValue ?? data.syncValue;
-    if (value === undefined || value === "") {
+    if (value == null || value === "") {
       return "No value";
     }
 
@@ -87,8 +87,8 @@ export const VariableRowContent: React.FC<{ item: AutocompleteItem; hideIcon?: b
   const scopeTooltipTitle = isSecret
     ? "Scope: Secrets"
     : variableScope === VariableScope.DYNAMIC
-    ? "Scope: Dynamic"
-    : `Scope: ${capitalize(String(variableScope))} environment`;
+      ? "Scope: Dynamic"
+      : `Scope: ${capitalize(String(variableScope))} environment`;
 
   return (
     <>

--- a/app/src/features/apiClient/screens/environment/components/VariableAutocompletePopover/variableAutocompletePopover.scss
+++ b/app/src/features/apiClient/screens/environment/components/VariableAutocompletePopover/variableAutocompletePopover.scss
@@ -2,7 +2,7 @@
   .ant-popover-inner-content {
     margin-top: -10px;
     display: flex;
-    width: 240px !important;
+    width: 320px !important;
     max-height: 400px !important;
     padding: var(--space-2, 4px);
     flex-direction: column;
@@ -35,6 +35,10 @@
       margin-left: -10px !important;
       width: 144px !important;
 
+      .ant-popover-inner-content {
+        width: 144px !important;
+      }
+
       .variable-autocomplete-item {
         width: 135px !important;
       }
@@ -43,11 +47,13 @@
 
   .variable-autocomplete-item {
     display: flex;
-    padding: var(--space-3, 6px) var(--space-2, 4px) !important;
+    padding: var(--space-3, 6px) var(--space-3, 6px) !important;
     flex-direction: row;
-    width: 230px !important;
+    width: 310px !important;
     border-bottom: none !important;
     justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-3, 6px);
     border-radius: 4px;
     cursor: pointer;
     &:hover {
@@ -60,8 +66,27 @@
 
     .item-left-section {
       display: flex;
-      flex-direction: row;
+      flex-direction: column;
       gap: var(--space-3, 6px);
+      min-width: 0;
+      flex: 1;
+      position: relative;
+
+      &.compact {
+        flex-direction: row;
+        align-items: center;
+      }
+
+      .scope-icon-wrapper {
+        display: flex;
+        align-items: center;
+        width: 16px;
+        min-width: 16px;
+        height: 18px;
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
 
       .scope-tooltip {
         .ant-tooltip-inner {
@@ -82,6 +107,7 @@
       display: flex;
       width: 12px;
       height: 12px;
+      margin-top: 3px;
       color: var(--requestly-color-text-placeholder);
       font-size: 12px;
       font-style: normal;
@@ -92,6 +118,7 @@
     .namespace-chevron {
       display: flex;
       align-items: center;
+      margin-top: 4px;
       color: var(--requestly-color-text-placeholder);
       font-size: 10px;
       opacity: 0.6;
@@ -107,8 +134,55 @@
       overflow: hidden !important;
       text-overflow: ellipsis !important;
       white-space: nowrap !important;
-      max-width: 160px;
+      max-width: 240px;
       flex-shrink: 1;
+      padding-left: 22px;
+    }
+
+    .item-left-section.compact .variable-label {
+      max-width: 105px;
+      padding-left: 0;
+    }
+
+    .variable-metadata {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2, 4px);
+      min-width: 0;
+      padding-left: 22px;
+      color: var(--requestly-color-text-subtle);
+      font-size: 11px;
+      font-weight: 400;
+      line-height: 16px;
+    }
+
+    .variable-scope-badge {
+      flex-shrink: 0;
+      padding: 1px var(--space-2, 4px);
+      border-radius: 3px;
+      color: var(--requestly-color-text-subtle);
+      background: var(--requestly-color-white-t-10);
+      font-size: 10px;
+      line-height: 14px;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+    }
+
+    .variable-source-name,
+    .variable-value-preview {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .variable-source-name {
+      max-width: 96px;
+    }
+
+    .variable-value-preview {
+      max-width: 112px;
+      color: var(--requestly-color-text-placeholder);
     }
   }
 }


### PR DESCRIPTION
## Summary
- widen the variable autocomplete popover so rows can show useful context
- add visible scope badges, source names, and value/example previews for top-level variable suggestions
- keep nested namespace menus compact so the cascading secret-variable flow stays easy to scan

Fixes #3619

## Verification
- `app/node_modules/.bin/prettier --write app/src/features/apiClient/screens/environment/components/VariableAutocompletePopover/components/VariableRowContent.tsx app/src/features/apiClient/screens/environment/components/VariableAutocompletePopover/variableAutocompletePopover.scss`
- `npm run type-check -- --pretty false 2>&1 | rg "VariableRowContent|VariableAutocompletePopover|variableAutocompletePopover" || true` returned no touched-file errors

Note: the repo-wide type-check still has pre-existing unrelated baseline errors, so I filtered verification to the touched autocomplete files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variable autocomplete rows now show scope badges (including Secrets), optional source names, and value previews with tooltips; rows support a compact layout when icons are hidden.

* **Style**
  * Popover and row layout updated for improved spacing, wider popover content, tighter truncation rules, and refined alignment for clearer readability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4658)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->