### PR TITLE
Add drag-and-drop reordering for API client tabs

### DIFF
--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -167,8 +167,12 @@ const DraggableTabLabel: React.FC<DraggableTabLabelProps> = ({ tab, onMoveTab, .
         }
 
         const clientOffset = monitor.getClientOffset();
+        if (!clientOffset) {
+          return;
+        }
+
         const tabBounds = ref.current.getBoundingClientRect();
-        const position = clientOffset && clientOffset.x > tabBounds.left + tabBounds.width / 2 ? "after" : "before";
+        const position = clientOffset.x > tabBounds.left + tabBounds.width / 2 ? "after" : "before";
 
         onMoveTab(item.tabId, tab.id, position);
       },

--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Tabs, TabsProps, Typography, Popover } from "antd";
+import { useDrag, useDrop } from "react-dnd";
 import { TabItem } from "./TabItem";
 import { Outlet, unstable_useBlocker } from "react-router-dom";
 import { RQButton } from "lib/design-system-v2/components";
@@ -130,11 +131,79 @@ const TabLabel: React.FC<TabLabelProps> = ({ tab, onClose, onDoubleClick }) => {
   return <NonBufferedTabLabel tab={tab} onClose={onClose} onDoubleClick={onDoubleClick} />;
 };
 
+const TAB_DRAG_TYPE = "api-client-tab";
+
+type TabDropPosition = "before" | "after";
+
+interface DragTabItem {
+  tabId: TabId;
+}
+
+interface DraggableTabLabelProps extends TabLabelProps {
+  onMoveTab: (tabId: TabId, targetTabId: TabId, position: TabDropPosition) => void;
+}
+
+const DraggableTabLabel: React.FC<DraggableTabLabelProps> = ({ tab, onMoveTab, ...props }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [{ isDragging }, drag] = useDrag(
+    () => ({
+      type: TAB_DRAG_TYPE,
+      item: { tabId: tab.id },
+      collect: (monitor) => ({
+        isDragging: monitor.isDragging(),
+      }),
+    }),
+    [tab.id]
+  );
+
+  const [{ isOver, dropPosition }, drop] = useDrop(
+    () => ({
+      accept: TAB_DRAG_TYPE,
+      canDrop: (item: DragTabItem) => item.tabId !== tab.id,
+      drop: (item: DragTabItem, monitor) => {
+        if (!ref.current || item.tabId === tab.id) {
+          return;
+        }
+
+        const clientOffset = monitor.getClientOffset();
+        const tabBounds = ref.current.getBoundingClientRect();
+        const position = clientOffset && clientOffset.x > tabBounds.left + tabBounds.width / 2 ? "after" : "before";
+
+        onMoveTab(item.tabId, tab.id, position);
+      },
+      collect: (monitor) => {
+        const clientOffset = monitor.getClientOffset();
+        const tabBounds = ref.current?.getBoundingClientRect();
+        const position =
+          clientOffset && tabBounds && clientOffset.x > tabBounds.left + tabBounds.width / 2 ? "after" : "before";
+
+        return {
+          isOver: monitor.isOver({ shallow: true }) && monitor.canDrop(),
+          dropPosition: position,
+        };
+      },
+    }),
+    [onMoveTab, tab.id]
+  );
+
+  drag(drop(ref));
+
+  return (
+    <div
+      ref={ref}
+      className={`draggable-tab-label ${isDragging ? "dragging" : ""} ${isOver ? `drop-target-${dropPosition}` : ""}`}
+    >
+      <TabLabel tab={tab} {...props} />
+    </div>
+  );
+};
+
 export const TabsContainer: React.FC = () => {
   const tabs = useTabs();
   const activeTabId = useActiveTabId();
   const previewTabId = usePreviewTabId();
-  const { closeTab, setActiveTab, openBufferedTab, setPreviewTab } = useTabActions();
+  const { closeTab, setActiveTab, openBufferedTab, setPreviewTab, reorderTab } = useTabActions();
   const [isMorePopoverOpen, setIsMorePopoverOpen] = useState(false);
   const [workflowModalTabId, setWorkflowModalTabId] = useState<TabId | null>(null);
 
@@ -270,20 +339,28 @@ export const TabsContainer: React.FC = () => {
     [closeTab]
   );
 
+  const handleMoveTab = useCallback(
+    (tabId: TabId, targetTabId: TabId, position: TabDropPosition) => {
+      reorderTab({ tabId, targetTabId, position });
+    },
+    [reorderTab]
+  );
+
   const tabItems: TabsProps["items"] = useMemo(() => {
     return tabs.map((tab) => ({
       key: tab.id,
       closable: false,
       label: (
-        <TabLabel
+        <DraggableTabLabel
           tab={tab}
           onClose={() => handleTabCloseRequest(tab)}
           onDoubleClick={() => handleUnpreviewTab(tab.id)}
+          onMoveTab={handleMoveTab}
         />
       ),
       children: <TabItem tabId={tab.id}>{tab.source.render()}</TabItem>,
     }));
-  }, [tabs, handleTabCloseRequest, handleUnpreviewTab]);
+  }, [tabs, handleTabCloseRequest, handleUnpreviewTab, handleMoveTab]);
 
   const handleWorkflowModalCancel = useCallback(() => {
     setWorkflowModalTabId(null);

--- a/app/src/componentsV2/Tabs/components/tabsContainer.scss
+++ b/app/src/componentsV2/Tabs/components/tabsContainer.scss
@@ -255,6 +255,35 @@
       }
     }
   }
+
+  .draggable-tab-label {
+    width: 100%;
+    position: relative;
+
+    &.dragging {
+      opacity: 0.5;
+    }
+
+    &.drop-target-before::before,
+    &.drop-target-after::after {
+      content: "";
+      position: absolute;
+      top: 2px;
+      bottom: 2px;
+      width: 2px;
+      border-radius: 2px;
+      background-color: var(--requestly-color-primary);
+      z-index: 2;
+    }
+
+    &.drop-target-before::before {
+      left: -4px;
+    }
+
+    &.drop-target-after::after {
+      right: -4px;
+    }
+  }
 }
 
 .tabs-content-more-dropdown {

--- a/app/src/componentsV2/Tabs/slice/hooks.ts
+++ b/app/src/componentsV2/Tabs/slice/hooks.ts
@@ -75,6 +75,10 @@ export function useTabActions() {
       setPreviewTab(params: Parameters<typeof tabsActions.setPreviewTab>[0]) {
         return dispatch(tabsActions.setPreviewTab(params));
       },
+
+      reorderTab(params: Parameters<typeof tabsActions.reorderTab>[0]) {
+        return dispatch(tabsActions.reorderTab(params));
+      },
     };
   }, [dispatch]);
 

--- a/app/src/componentsV2/Tabs/slice/slice.ts
+++ b/app/src/componentsV2/Tabs/slice/slice.ts
@@ -70,6 +70,33 @@ export const tabsSlice = createSlice({
       state.previewTabId = action.payload;
     },
 
+    reorderTab(state, action: PayloadAction<{ tabId: TabId; targetTabId: TabId; position: "before" | "after" }>) {
+      const { tabId, targetTabId, position } = action.payload;
+      if (tabId === targetTabId) {
+        return;
+      }
+
+      const tabIds = state.tabs.ids as TabId[];
+      const sourceIndex = tabIds.indexOf(tabId);
+      let targetIndex = tabIds.indexOf(targetTabId);
+
+      if (sourceIndex === -1 || targetIndex === -1) {
+        return;
+      }
+
+      const [movedTabId] = tabIds.splice(sourceIndex, 1);
+      if (!movedTabId) {
+        return;
+      }
+
+      if (sourceIndex < targetIndex) {
+        targetIndex -= 1;
+      }
+
+      const insertIndex = position === "after" ? targetIndex + 1 : targetIndex;
+      tabIds.splice(insertIndex, 0, movedTabId);
+    },
+
     addActiveWorkflow(state, action: PayloadAction<{ tabId: TabId; workflow: ActiveWorkflow }>) {
       const { tabId, workflow } = action.payload;
       const tab = state.tabs.entities[tabId];


### PR DESCRIPTION
Closes #3618\n\n## Summary\n- Adds drag-and-drop reordering for open API Client tabs using the existing react-dnd provider.\n- Persists the custom order by reordering the existing tab entity ids in the persisted tab store.\n- Adds visual before/after drop indicators while dragging tabs.\n\n## Validation\n- npx prettier --write app/src/componentsV2/Tabs/slice/slice.ts app/src/componentsV2/Tabs/slice/hooks.ts app/src/componentsV2/Tabs/components/TabsContainer.tsx app/src/componentsV2/Tabs/components/tabsContainer.scss\n- git diff --check\n- cd app && npm run type-check -- --pretty false currently exits nonzero on pre-existing tab subsystem errors in TabsMorePopover, baseTabSource, and slice/hooks; no new errors were reported for TabsContainer.tsx or slice.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop to reorder tabs by dragging tab labels.
  * Visual feedback while dragging: dimmed tab opacity and clear before/after drop indicators.
  * Existing tab interactions (close, double-click) are preserved while using drag-and-drop.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4659)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->