### PR TITLE
fix: separate edit description action

### DIFF
--- a/app/src/lib/design-system/components/RQEditorTitle/RQEditorTitle.css
+++ b/app/src/lib/design-system/components/RQEditorTitle/RQEditorTitle.css
@@ -39,6 +39,14 @@
   color: #86868b;
 }
 
+.editor-description .editor-description-text {
+  flex: 0 1 auto;
+  min-width: 0;
+  width: auto;
+  max-width: 100%;
+  cursor: pointer;
+}
+
 .editor-title-container .editor-description .ant-typography span {
   margin-right: 4px;
 }
@@ -92,6 +100,7 @@
   max-width: 600px;
 }
 .editor-description .edit-description-btn {
+  flex-shrink: 0;
   padding: 0;
   color: var(--text-gray);
   transition: 0.2s ease-in-out;

--- a/app/src/lib/design-system/components/RQEditorTitle/index.tsx
+++ b/app/src/lib/design-system/components/RQEditorTitle/index.tsx
@@ -128,34 +128,32 @@ export const RQEditorTitle: React.FC<TitleProps> = ({
               <div className="editor-description">
                 <Typography.Paragraph
                   disabled={disabled}
-                  style={{ width: "100%" }}
+                  className="editor-description-text"
                   ellipsis={{
                     rows: 3,
                   }}
-                  editable={{
-                    icon:
-                      description.length > 0 ? (
-                        <RQButton
-                          disabled={disabled}
-                          onClick={() => {
-                            setIsDescriptionEditable(true);
-                          }}
-                          className="edit-description-btn"
-                          type="text"
-                        >
-                          Edit description
-                        </RQButton>
-                      ) : (
-                        <></>
-                      ),
-                    tooltip: false,
-                  }}
                   onClick={() => {
+                    if (disabled) {
+                      return;
+                    }
+
                     setIsDescriptionEditable(true);
                   }}
                 >
                   <span>{description ? description : descriptionPlaceholder}</span>
                 </Typography.Paragraph>
+                {description.length > 0 ? (
+                  <RQButton
+                    disabled={disabled}
+                    onClick={() => {
+                      setIsDescriptionEditable(true);
+                    }}
+                    className="edit-description-btn"
+                    type="text"
+                  >
+                    Edit description
+                  </RQButton>
+                ) : null}
               </div>
             )}
           </Row>


### PR DESCRIPTION
Closes requestly/interceptor#34

## Summary
- Renders the existing description text and the "Edit description" action as separate controls.
- Keeps the description text clickable to enter edit mode.
- Prevents disabled descriptions from entering edit mode via text click.

## Validation
- `git diff --check` passes.
- `npx eslint src/lib/design-system/components/RQEditorTitle/index.tsx` could not run because the local install is missing `@rushstack/eslint-patch/modern-module-resolution`.
- `npm run type-check` currently fails on existing project-wide missing-module/type errors outside this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved layout stability of the editor description area with enhanced flex constraints and cursor feedback
  * Redesigned description editing interface with a clearer, more intuitive edit button interaction

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4665)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->