### PR TITLE
fix: ignore empty source filters in badge count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.js
@@ -1,0 +1,39 @@
+const hasMeaningfulFilterValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(hasMeaningfulFilterValue);
+  }
+
+  return Boolean(value);
+};
+
+const hasMeaningfulRequestPayloadFilter = (requestPayload) => {
+  if (!requestPayload || typeof requestPayload !== "object") {
+    return false;
+  }
+
+  return hasMeaningfulFilterValue(requestPayload.key) || hasMeaningfulFilterValue(requestPayload.value);
+};
+
+export const getAppliedSourceFilterCount = (filters = {}, ignoredKeys = []) => {
+  const ignoredFilterKeys = new Set(ignoredKeys);
+
+  return Object.entries(filters).filter(([key, value]) => {
+    if (ignoredFilterKeys.has(key)) {
+      return false;
+    }
+
+    if (key === "requestPayload") {
+      return hasMeaningfulRequestPayloadFilter(value);
+    }
+
+    return hasMeaningfulFilterValue(value);
+  }).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getAppliedSourceFilterCount } from "./filterCountUtils";
+
+describe("getAppliedSourceFilterCount", () => {
+  it("ignores empty request payload placeholders", () => {
+    expect(
+      getAppliedSourceFilterCount({
+        requestPayload: {},
+      })
+    ).toBe(0);
+  });
+
+  it("ignores request payload filters without a key or value", () => {
+    expect(
+      getAppliedSourceFilterCount({
+        requestPayload: {
+          key: "",
+          operator: "Equals",
+          value: " ",
+        },
+      })
+    ).toBe(0);
+  });
+
+  it("counts request payload filters with a key or value", () => {
+    expect(
+      getAppliedSourceFilterCount({
+        requestPayload: {
+          key: "operationName",
+          operator: "Equals",
+          value: "",
+        },
+      })
+    ).toBe(1);
+  });
+
+  it("counts non-empty array filters and ignores empty arrays", () => {
+    expect(
+      getAppliedSourceFilterCount({
+        requestMethod: ["POST"],
+        resourceType: [],
+      })
+    ).toBe(1);
+  });
+
+  it("ignores configured filter keys", () => {
+    expect(
+      getAppliedSourceFilterCount(
+        {
+          pageUrl: "example.com",
+          requestMethod: ["POST"],
+        },
+        ["pageUrl"]
+      )
+    ).toBe(1);
+  });
+});

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -22,6 +22,7 @@ import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
+import { getAppliedSourceFilterCount } from "./filterCountUtils";
 import "./RequestSourceRow.css";
 
 const { Text } = Typography;
@@ -70,14 +71,11 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const filters = isSourceFilterFormatUpgraded(pairIndex, currentlySelectedRuleData)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0]
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters;
+
+      return getAppliedSourceFilterCount(filters, [GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL]);
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );


### PR DESCRIPTION
Closes issue: https://github.com/requestly/requestly/issues/3826

## Summary of changes:

- Extracts source filter badge counting into a small pure utility.
- Ignores empty placeholder filter values such as `requestPayload: {}`.
- Treats GraphQL request payload filters as applied only when the payload key or value has meaningful content.
- Keeps existing `pageUrl` exclusion behavior.
- Adds focused unit coverage for empty request payload placeholders, blank key/value payloads, non-empty payload filters, arrays, and ignored keys.

## Demo Video:

**Video/Demo:** Not attached. This is a narrow badge-counting fix covered by a focused unit test; the reported broken state is represented by `requestPayload: {}` now counting as 0.

## Checklist:

- [ ] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [x] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## Test instructions:

Run:

```bash
cd app
npx vitest@1.3.1 run src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js --config <minimal-node-vitest-config> --passWithNoTests
```

Also checked formatting:

```bash
npx prettier@2.8.1 --check app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.js app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js
```

Note: I did not run the full app install/build locally because `npm ci` is currently blocked by a package/lockfile sync issue (`@requestly/shared@1.0.10` missing from the app lockfile).

## Other references:

- Issue: https://github.com/requestly/requestly/issues/3826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate filter badge counts by standardizing how source filters are evaluated and counted
  * Better handling and inclusion of request-payload filters when present
  * Continues to respect excluded filters (e.g., PAGE_URL) when computing totals

* **Tests**
  * Added tests covering various filter-count scenarios and payload validation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4666)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->