### PR TITLE
[codex] Allow editing request bodies for GET requests

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/http/components/HttpRequestTabs/HttpRequestTabs.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/http/components/HttpRequestTabs/HttpRequestTabs.tsx
@@ -2,13 +2,11 @@ import { useFeatureValue } from "@growthbook/growthbook-react";
 import { Checkbox } from "antd";
 import { Conditional } from "components/common/Conditional";
 import FEATURES from "config/constants/sub/features";
-import { sanitizeKeyValuePairs, supportsRequestBodyForAllMethods } from "features/apiClient/screens/apiClient/utils";
+import { sanitizeKeyValuePairs } from "features/apiClient/screens/apiClient/utils";
 import { BufferedHttpRecordEntity } from "features/apiClient/slices/entities";
 import { useApiClientSelector } from "features/apiClient/slices/hooks/base.hooks";
-import { RequestMethod, RQAPI } from "features/apiClient/types";
+import { RQAPI } from "features/apiClient/types";
 import React, { useMemo } from "react";
-import { useSelector } from "react-redux";
-import { getAppMode } from "store/selectors";
 import { isFeatureCompatible } from "utils/CompatibilityUtils";
 import { ApiClientRequestTabs } from "../../../components/request/components/ApiClientRequestTabs/ApiClientRequestTabs";
 import { RequestTabLabel } from "../../../components/request/components/ApiClientRequestTabs/components/RequestTabLabel/RequestTabLabel";
@@ -18,7 +16,6 @@ import { QueryParamsTable } from "../../../components/request/components/QueryPa
 import RequestBody from "../../../components/request/RequestBody";
 import { ScriptEditor } from "../../../components/Scripts/components/ScriptEditor/ScriptEditor";
 import { PathVariableTable } from "../PathVariableTable";
-import RequestBodyRedirectScreen from "../../../../clientView/components/RequestBodyRedirectScreen";
 
 export enum RequestTab {
   QUERY_PARAMS = "query_params",
@@ -44,11 +41,9 @@ const HttpRequestTabs: React.FC<Props> = ({
   scriptEditorVersion,
 }) => {
   const showCredentialsCheckbox = useFeatureValue("api-client-include-credentials", false);
-  const appMode = useSelector(getAppMode);
 
   const queryParams = useApiClientSelector((s) => entity.getQueryParams(s));
   const pathVariables = useApiClientSelector((s) => entity.getPathVariables(s));
-  const method = useApiClientSelector((s) => entity.getMethod(s));
   const bodyLength = useApiClientSelector((s) => entity.getBody(s)?.length || 0);
   const headersLength = useApiClientSelector((s) => sanitizeKeyValuePairs(entity.getHeaders(s)).length);
   const auth = useApiClientSelector((s) => entity.getAuth(s));
@@ -57,10 +52,6 @@ const HttpRequestTabs: React.FC<Props> = ({
 
   const requestEntry = useApiClientSelector((s) => entity.getEntityFromState(s).data);
 
-  const METHODS_WITHOUT_BODY = [RequestMethod.GET, RequestMethod.HEAD];
-  const supportsRequestBody = supportsRequestBodyForAllMethods(appMode);
-  const needsDesktopForBody = METHODS_WITHOUT_BODY.includes(method);
-  const canHaveRequestBody = supportsRequestBody || !needsDesktopForBody;
   const hasScriptError = error?.type === RQAPI.ApiClientErrorType.SCRIPT;
 
   const items = useMemo(() => {
@@ -78,8 +69,8 @@ const HttpRequestTabs: React.FC<Props> = ({
       },
       {
         key: RequestTab.BODY,
-        label: <RequestTabLabel label="Body" count={bodyLength ? 1 : 0} showDot={canHaveRequestBody} />,
-        children: !canHaveRequestBody ? <RequestBodyRedirectScreen method={method} /> : <RequestBody entity={entity} />,
+        label: <RequestTabLabel label="Body" count={bodyLength ? 1 : 0} showDot={true} />,
+        children: <RequestBody entity={entity} />,
       },
       {
         key: RequestTab.HEADERS,
@@ -135,7 +126,6 @@ const HttpRequestTabs: React.FC<Props> = ({
     pathVariables?.length,
     entity,
     bodyLength,
-    canHaveRequestBody,
     headersLength,
     auth,
     handleAuthChange,


### PR DESCRIPTION
## Summary
- allow the API client Body tab to stay editable for GET/HEAD requests
- keep the existing browser/web send guard so requests with bodies still prompt users to switch to the desktop app
- remove the redirect screen from the Body tab for these methods, matching the issue guidance that users should be warned but not blocked from composing the body

Closes #3704

## Checks
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request Body tab now reliably displays body content and indicator, preventing unexpected redirects or hidden content.

* **Refactor**
  * Simplified tab selection logic for HTTP requests, reducing conditional gating and improving stability across modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4667)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4667)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->