### PR TITLE
fix: use pointer cursor for traffic table rows

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -1,5 +1,12 @@
 .web-traffic-table-container {
   height: 100%;
+
+  tbody tr,
+  tbody tr td,
+  tbody tr td * {
+    cursor: pointer;
+  }
+
   table {
     tbody {
       tr[aria-selected="true"] {


### PR DESCRIPTION
Closes requestly/interceptor#49

Closes issue: https://github.com/requestly/interceptor/issues/49

## 📜 Summary of changes:

- Adds pointer cursor styling for desktop web traffic table rows, cells, and row contents.
- Keeps the fix scoped to the NetworkTable stylesheet so hovering a traffic row no longer shows the text-selection cursor.

## 🎥 Demo Video:

**Video/Demo:** Not attached. This is a CSS-only cursor fix; local app dependencies were not installed in this environment, so I could not run the desktop UI to record a demo.

## ✅ Checklist:

- [x] No install/build warnings introduced. No dependency or build configuration changes were made.
- [ ] Make sure linting and unit tests pass.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

- Ran `git diff --check` locally.
- Manual verification: open the desktop Web Traffic table and hover any traffic table row/cell; the cursor should stay as a pointer across the row content.

## 🔗 Other references:

- Bounty issue: https://github.com/requestly/interceptor/issues/49


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table styling to display a pointer cursor on network traffic table rows, providing visual feedback that rows are interactive and clickable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4668)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->