### PR TITLE
fix: use pointer cursor for traffic table rows

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -34,4 +34,10 @@
       }
     }
   }
+
+  tbody tr,
+  tbody tr td,
+  tbody tr td * {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
This fixes the cursor on traffic table rows to show a pointer cursor instead of text selection cursor. Closes requestly/interceptor#49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table styling to display a pointer cursor on interactive table rows, providing clearer visual feedback that elements are clickable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4670)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->