### PR TITLE
fix: count only applied source filters

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.js
@@ -1,0 +1,31 @@
+export const hasMeaningfulSourceFilterValue = (key, value) => {
+  if (key === "requestPayload" && value && typeof value === "object") {
+    return [value.key, value.value].some((payloadValue) => hasMeaningfulSourceFilterValue("", payloadValue));
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasMeaningfulSourceFilterValue("", item));
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value).some(([nestedKey, nestedValue]) => {
+      if (nestedKey === "operator") {
+        return false;
+      }
+
+      return hasMeaningfulSourceFilterValue(nestedKey, nestedValue);
+    });
+  }
+
+  return value !== undefined && value !== null;
+};
+
+export const getAppliedSourceFiltersCount = (sourceFilters = {}, excludedFilterKeys = []) => {
+  return Object.entries(sourceFilters).filter(
+    ([key, value]) => !excludedFilterKeys.includes(key) && hasMeaningfulSourceFilterValue(key, value)
+  ).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { getAppliedSourceFiltersCount, hasMeaningfulSourceFilterValue } from "./filterCountUtils";
+
+describe("hasMeaningfulSourceFilterValue", () => {
+  it("treats operator-only request payload filters as empty", () => {
+    expect(
+      hasMeaningfulSourceFilterValue("requestPayload", {
+        operator: "Contains",
+        key: "",
+        value: "",
+      })
+    ).toBe(false);
+  });
+
+  it("treats populated request payload filters as meaningful", () => {
+    expect(
+      hasMeaningfulSourceFilterValue("requestPayload", {
+        operator: "Contains",
+        key: "query",
+        value: "GetUser",
+      })
+    ).toBe(true);
+  });
+
+  it("treats empty arrays, blank array entries, and whitespace strings as empty", () => {
+    expect(hasMeaningfulSourceFilterValue("requestMethod", [])).toBe(false);
+    expect(hasMeaningfulSourceFilterValue("resourceType", "   ")).toBe(false);
+    expect(hasMeaningfulSourceFilterValue("pageDomains", ["   "])).toBe(false);
+    expect(hasMeaningfulSourceFilterValue("pageDomains", [""])).toBe(false);
+  });
+});
+
+describe("getAppliedSourceFiltersCount", () => {
+  it("ignores excluded keys and empty filter values", () => {
+    const count = getAppliedSourceFiltersCount(
+      {
+        pageUrl: { value: "https://example.com" },
+        pageDomains: [],
+        requestMethod: ["GET"],
+        requestPayload: {
+          operator: "Contains",
+          key: "",
+          value: "",
+        },
+      },
+      ["pageUrl"]
+    );
+
+    expect(count).toBe(1);
+  });
+});

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -22,6 +22,7 @@ import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
+import { getAppliedSourceFiltersCount } from "./filterCountUtils";
 import "./RequestSourceRow.css";
 
 const { Text } = Typography;
@@ -71,13 +72,11 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
   const getFilterCount = useCallback(
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const sourceFilters = isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters || {};
+
+      return getAppliedSourceFiltersCount(sourceFilters, [GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL]);
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );


### PR DESCRIPTION
Closes issue: #3826

## Summary of changes:

- Count only source filters that have meaningful values before showing the applied filter badge count.
- Keep `pageUrl` excluded from the badge count, matching the previous behavior.
- Treat empty request payload filters, empty arrays, blank strings, and arrays with only blank entries as not applied.
- Added focused Vitest coverage for empty and populated filter values.

## Demo Video:

**Video/Demo:** Not attached. This is a narrow rule-editor badge count fix; the regression is covered by the added unit test. I can add a short screen recording if maintainers want one.

## Checklist:

- [ ] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [x] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## Test instructions:

Run:

```bash
cd app
npx vitest run src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js
```

Local validation performed:

- `git diff --check origin/master...HEAD`
- Node smoke check for the new filter count helper cases

I could not run the full Vitest command locally from this shell because `npm`/`npx` is not available on PATH in the environment I used.

## Other references:

Related to the earlier unmerged attempt in #4550; this version also handles the review note about arrays containing only blank entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal source filter evaluation logic by extracting reusable utility functions.

* **Tests**
  * Added comprehensive test coverage for source filter utilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4672)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->