### PR TITLE
fix: allow dragging requests to top level

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/CollectionsList.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/CollectionsList.tsx
@@ -117,12 +117,7 @@ const TopLevelDropZone: React.FC<TopLevelDropZoneProps> = ({
     [dropWorkspaceId, isReadOnly, onDropToTopLevel]
   );
 
-  const className = [
-    "top-level-drop-zone",
-    `top-level-drop-zone--${position}`,
-    canDrop ? "available" : "",
-    isOver && canDrop ? "active" : "",
-  ]
+  const className = ["top-level-drop-zone", canDrop ? "available" : "", isOver && canDrop ? "active" : ""]
     .filter(Boolean)
     .join(" ");
 

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/CollectionsList.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/CollectionsList.tsx
@@ -36,14 +36,7 @@ import { ExampleCollectionsNudge } from "../ExampleCollectionsNudge/ExampleColle
 import { useNewApiClientContext } from "features/apiClient/hooks/useNewApiClientContext";
 import { submitAttrUtil } from "utils/AnalyticsUtils";
 import APP_CONSTANTS from "config/constants";
-import {
-  duplicateRecords,
-  useAllRecords,
-  useApiClientRepository,
-  useChildToParent,
-  moveRecords,
-  getApiClientFeatureContext,
-} from "features/apiClient/slices";
+import { duplicateRecords, useAllRecords, useApiClientRepository, useChildToParent } from "features/apiClient/slices";
 import { useApiClientDispatch } from "features/apiClient/slices/hooks/base.hooks";
 import { EXPANDED_RECORD_IDS_UPDATED } from "features/apiClient/slices/exampleCollections";
 import { ErrorSeverity } from "errors/types";
@@ -90,6 +83,50 @@ const trackUserProperties = (records: RQAPI.ApiClientRecord[]) => {
   const totalRequests = records.length - totalCollections;
   submitAttrUtil(APP_CONSTANTS.GA_EVENTS.ATTR.NUM_COLLECTIONS, totalCollections);
   submitAttrUtil(APP_CONSTANTS.GA_EVENTS.ATTR.NUM_REQUESTS, totalRequests);
+};
+
+interface TopLevelDropZoneProps {
+  dropWorkspaceId: Workspace["id"] | null;
+  isReadOnly: boolean;
+  onDropToTopLevel: (item: DraggableApiRecord, dropWorkspaceId: Workspace["id"] | null) => Promise<void>;
+  position: "top" | "bottom";
+}
+
+const TopLevelDropZone: React.FC<TopLevelDropZoneProps> = ({
+  dropWorkspaceId,
+  isReadOnly,
+  onDropToTopLevel,
+  position,
+}) => {
+  const [{ isOver, canDrop }, drop] = useDrop(
+    () => ({
+      accept: [RQAPI.RecordType.API, RQAPI.RecordType.COLLECTION],
+      drop: (item: DraggableApiRecord, monitor) => {
+        if (!monitor.isOver({ shallow: true })) {
+          return;
+        }
+
+        onDropToTopLevel(item, dropWorkspaceId);
+      },
+      canDrop: (item: DraggableApiRecord) => !isReadOnly && !!item.record.collectionId,
+      collect: (monitor) => ({
+        isOver: monitor.isOver({ shallow: true }),
+        canDrop: monitor.canDrop(),
+      }),
+    }),
+    [dropWorkspaceId, isReadOnly, onDropToTopLevel]
+  );
+
+  const className = [
+    "top-level-drop-zone",
+    `top-level-drop-zone--${position}`,
+    canDrop ? "available" : "",
+    isOver && canDrop ? "active" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return <div ref={drop} className={className} aria-hidden="true" />;
 };
 
 export const CollectionsList: React.FC<Props> = ({ onNewClick, recordTypeToBeCreated, handleRecordsToBeDeleted }) => {
@@ -416,33 +453,10 @@ export const CollectionsList: React.FC<Props> = ({ onNewClick, recordTypeToBeCre
       // Empty string for collectionId means move to top-level (no parent collection)
       await handleRecordDrop(item, dropWorkspaceId, {
         targetCollectionId: "",
+        onFinally: item.onDropComplete,
       });
     },
     []
-  );
-
-  const [{ isOver, canDrop }, drop] = useDrop(
-    () => ({
-      accept: [RQAPI.RecordType.API, RQAPI.RecordType.COLLECTION],
-      drop: (item: DraggableApiRecord, monitor) => {
-        const isOverCurrent = monitor.isOver({ shallow: true });
-        if (!isOverCurrent) return;
-
-        // Only handle drop if item is from a collection (collectionId is not empty)
-        if (item.record.collectionId) {
-          handleRecordDropToTopLevel(item, workspaceId || null);
-        }
-      },
-      canDrop: (item: DraggableApiRecord) => {
-        // Can drop if the item is currently in a collection (moving it to top-level)
-        return !!item.record.collectionId;
-      },
-      collect: (monitor) => ({
-        isOver: monitor.isOver({ shallow: true }),
-        canDrop: monitor.canDrop(),
-      }),
-    }),
-    [handleRecordDropToTopLevel, workspaceId]
   );
 
   useEffect(() => {
@@ -474,10 +488,17 @@ export const CollectionsList: React.FC<Props> = ({ onNewClick, recordTypeToBeCre
         )}
       </div>
       <div className={`collections-list-container ${showSelection ? "selection-enabled" : ""}`}>
-        <div className={`collections-list-content ${isOver && canDrop ? "drop-target-active" : ""}`} ref={drop}>
+        <div className="collections-list-content">
           <ExampleCollectionsNudge />
           {updatedRecords.count > 0 ? (
             <div className="collections-list">
+              <TopLevelDropZone
+                dropWorkspaceId={workspaceId || null}
+                isReadOnly={!isValidPermission}
+                onDropToTopLevel={handleRecordDropToTopLevel}
+                position="top"
+              />
+
               {updatedRecords.collections.map((record) => {
                 return (
                   <CollectionRow
@@ -524,7 +545,12 @@ export const CollectionsList: React.FC<Props> = ({ onNewClick, recordTypeToBeCre
               )}
 
               {/* Dedicated drop zone for easier dropping at top-level */}
-              <div className={`top-level-drop-zone ${isOver && canDrop ? "active" : ""}`}></div>
+              <TopLevelDropZone
+                dropWorkspaceId={workspaceId || null}
+                isReadOnly={!isValidPermission}
+                onDropToTopLevel={handleRecordDropToTopLevel}
+                position="bottom"
+              />
             </div>
           ) : (
             <ApiRecordEmptyState

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -65,6 +65,7 @@ interface Props {
 export type DraggableApiRecord = {
   record: RQAPI.ApiClientRecord;
   workspaceId: ApiClientFeatureContext["workspaceId"];
+  onDropComplete?: () => void;
 };
 
 export const CollectionRow: React.FC<Props> = ({

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionsList.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionsList.scss
@@ -25,24 +25,34 @@
     overflow: auto;
     padding: 0 var(--requestly-space-2, 4px);
 
-    &.drop-target-active {
-      background: #004eeb33;
-      border: 1px solid var(--requestly-color-primary-600);
-      border-radius: 4px;
-    }
-
     .collections-list {
       display: flex;
       flex-direction: column;
 
       .top-level-drop-zone {
-        min-height: 20px;
-        transition: all 0.2s ease;
+        height: 0;
+        display: flex;
+        align-items: center;
+        overflow: hidden;
+        opacity: 0;
+        transition: height 0.15s ease, opacity 0.15s ease;
+
+        &::before {
+          content: "";
+          width: 100%;
+          height: 2px;
+          border-radius: 2px;
+          background: var(--requestly-color-primary-600);
+        }
+
+        &.available {
+          height: 12px;
+          opacity: 0.35;
+        }
 
         &.active {
-          min-height: 10px;
-          opacity: 0.2;
-          border-radius: 4px;
+          height: 12px;
+          opacity: 1;
         }
       }
     }


### PR DESCRIPTION
Closes #3626

## Summary
- Adds explicit top and bottom drop targets for moving nested API records back to the top-level workspace.
- Shows line-style drop indicators while a draggable nested record can be dropped, matching the requested UI feedback from the prior review.
- Keeps the existing shared move handler and ensures request row drag state is cleared after top-level drops.

## Validation
- `npx --yes prettier@2.8.1 --check src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/CollectionsList.tsx src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionsList.scss`
- `git diff --check`

Note: I could not run `npm run type-check` in this clone because `npm ci` fails before installing dependencies: the app lockfile is out of sync and reports missing `@requestly/shared@1.0.10`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved drag-and-drop for organizing collections and records, including explicit top-level drop zones (top and bottom) for more reliable moves
  * Drag items can optionally provide a completion callback to trigger follow-up actions after a successful drop

* **Style**
  * Refreshed drop-zone visuals with a clearer horizontal indicator and smoother height/opacity transitions to show availability and active states

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4673)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->