### PR TITLE
fix: add API client icon tooltips

### DIFF
--- a/app/src/componentsV2/BottomSheet/BottomSheet.tsx
+++ b/app/src/componentsV2/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Tabs, TabsProps } from "antd";
+import { Tabs, TabsProps, Tooltip } from "antd";
 import { useBottomSheetContext } from "./context";
 import { BiDockRight } from "@react-icons/all-files/bi/BiDockRight";
 import { BiDockBottom } from "@react-icons/all-files/bi/BiDockBottom";
@@ -38,14 +38,15 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
         {utilities}
 
         {disableDocking ? null : (
-          <RQButton
-            size="small"
-            type="transparent"
-            title="Toggle"
-            onClick={() => toggleSheetPlacement()}
-            className="bottom-sheet-toggle-btn"
-            icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-          />
+          <Tooltip title={isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom"} placement="top" color="#000">
+            <RQButton
+              size="small"
+              type="transparent"
+              onClick={() => toggleSheetPlacement()}
+              className="bottom-sheet-toggle-btn"
+              icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+            />
+          </Tooltip>
         )}
 
         <RQButton
@@ -82,14 +83,15 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
       </div>
     ),
     right: (
-      <RQButton
-        size="small"
-        type="transparent"
-        title="Toggle"
-        onClick={() => toggleSheetPlacement()}
-        className="bottom-sheet-toggle-btn"
-        icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-      />
+      <Tooltip title={isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom"} placement="top" color="#000">
+        <RQButton
+          size="small"
+          type="transparent"
+          onClick={() => toggleSheetPlacement()}
+          className="bottom-sheet-toggle-btn"
+          icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+        />
+      </Tooltip>
     ),
   };
 

--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Tabs, TabsProps, Typography, Popover } from "antd";
+import { Tabs, TabsProps, Typography, Popover, Tooltip } from "antd";
 import { TabItem } from "./TabItem";
 import { Outlet, unstable_useBlocker } from "react-router-dom";
 import { RQButton } from "lib/design-system-v2/components";
@@ -312,6 +312,11 @@ export const TabsContainer: React.FC = () => {
         className="tabs-content"
         popupClassName="tabs-content-more-dropdown"
         size="small"
+        addIcon={
+          <Tooltip title="New request" placement="bottom" color="#000">
+            <span>+</span>
+          </Tooltip>
+        }
         onChange={(key) => {
           setActiveTab(key.toString());
         }}

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
 import { MdOutlineArrowForwardIos } from "@react-icons/all-files/md/MdOutlineArrowForwardIos";
-import { Collapse, Dropdown, MenuProps, Typography } from "antd";
+import { Collapse, Dropdown, MenuProps, Tooltip, Typography } from "antd";
 import { Conditional } from "components/common/Conditional";
 import { useRBAC } from "features/rbac";
 import { RQButton } from "lib/design-system-v2/components";
@@ -186,12 +186,14 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                               });
                             }}
                           >
-                            <RQButton
-                              size="small"
-                              type="transparent"
-                              icon={<MdAdd />}
-                              onClick={(e) => e.stopPropagation()}
-                            />
+                            <Tooltip title="New request or collection" placement="top" color="#000">
+                              <RQButton
+                                size="small"
+                                type="transparent"
+                                icon={<MdAdd />}
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                            </Tooltip>
                           </NewApiRecordDropdown>
                         )}
                       </>
@@ -203,14 +205,16 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                       placement="bottomRight"
                       overlayClassName="collection-dropdown-menu"
                     >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
+                      <Tooltip title="More actions" placement="top" color="#000">
+                        <RQButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                          size="small"
+                          type="transparent"
+                          icon={<MdOutlineMoreHoriz />}
+                        />
+                      </Tooltip>
                     </Dropdown>
                   </div>
                 </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
-import { Checkbox, Dropdown, MenuProps, Skeleton, Typography, notification } from "antd";
+import { Checkbox, Dropdown, MenuProps, Skeleton, Tooltip, Typography, notification } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQAPI as SharedRQAPI } from "@requestly/shared/types/entities/apiClient";
 import { RQButton } from "lib/design-system-v2/components";
@@ -493,7 +493,14 @@ export const CollectionRow: React.FC<Props> = ({
                         });
                       }}
                     >
-                      <RQButton size="small" type="transparent" icon={<MdAdd />} onClick={(e) => e.stopPropagation()} />
+                      <Tooltip title="New request or collection" placement="top" color="#000">
+                        <RQButton
+                          size="small"
+                          type="transparent"
+                          icon={<MdAdd />}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      </Tooltip>
                     </NewApiRecordDropdown>
                     <Dropdown
                       trigger={["click"]}
@@ -501,15 +508,17 @@ export const CollectionRow: React.FC<Props> = ({
                       placement="bottomRight"
                       overlayClassName="collection-dropdown-menu"
                     >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowSelection(false);
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
+                      <Tooltip title="More actions" placement="top" color="#000">
+                        <RQButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setShowSelection(false);
+                          }}
+                          size="small"
+                          type="transparent"
+                          icon={<MdOutlineMoreHoriz />}
+                        />
+                      </Tooltip>
                     </Dropdown>
                   </div>
                 </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps } from "antd";
+import { Typography, Dropdown, MenuProps, Tooltip } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
@@ -275,14 +275,16 @@ export const ExampleRow: React.FC<Props> = ({ record, isReadOnly, handleRecordsT
               open={isDropdownVisible}
               onOpenChange={setIsDropdownVisible}
             >
-              <RQButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-              />
+              <Tooltip title="More actions" placement="top" color="#000">
+                <RQButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  size="small"
+                  type="transparent"
+                  icon={<MdOutlineMoreHoriz />}
+                />
+              </Tooltip>
             </Dropdown>
           </div>
         </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps, Checkbox, notification } from "antd";
+import { Typography, Dropdown, MenuProps, Checkbox, notification, Tooltip } from "antd";
 import { REQUEST_METHOD_BACKGROUND_COLORS, REQUEST_METHOD_COLORS } from "../../../../../../../../../constants";
 import { RequestMethod, RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
@@ -500,15 +500,17 @@ export const RequestRow: React.FC<Props> = ({
             open={isDropdownVisible}
             onOpenChange={handleDropdownVisibleChange}
           >
-            <RQButton
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowSelection(false);
-              }}
-              size="small"
-              type="transparent"
-              icon={<MdOutlineMoreHoriz />}
-            />
+            <Tooltip title="More actions" placement="top" color="#000">
+              <RQButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowSelection(false);
+                }}
+                size="small"
+                type="transparent"
+                icon={<MdOutlineMoreHoriz />}
+              />
+            </Tooltip>
           </Dropdown>
         </div>
       </Conditional>
@@ -646,15 +648,17 @@ export const RequestRow: React.FC<Props> = ({
                   open={isDropdownVisible}
                   onOpenChange={handleDropdownVisibleChange}
                 >
-                  <RQButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowSelection(false);
-                    }}
-                    size="small"
-                    type="transparent"
-                    icon={<MdOutlineMoreHoriz />}
-                  />
+                  <Tooltip title="More actions" placement="top" color="#000">
+                    <RQButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowSelection(false);
+                      }}
+                      size="small"
+                      type="transparent"
+                      icon={<MdOutlineMoreHoriz />}
+                    />
+                  </Tooltip>
                 </Dropdown>
               </div>
             </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
@@ -55,16 +55,17 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
 
       {listType ? (
         listType === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-          <RQButton
-            size="small"
-            type="transparent"
-            icon={<MdAdd />}
-            title="Create new environment"
-            className="sidebar-list-header-button"
-            onClick={() => {
-              onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
-            }}
-          />
+          <Tooltip title="New environment">
+            <RQButton
+              size="small"
+              type="transparent"
+              icon={<MdAdd />}
+              className="sidebar-list-header-button"
+              onClick={() => {
+                onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
+              }}
+            />
+          </Tooltip>
         ) : null
       ) : (
         showNewRecordAction && (
@@ -74,7 +75,9 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
               onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
             }}
           >
-            <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            <Tooltip title="New request or collection">
+              <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            </Tooltip>
           </NewApiRecordDropdown>
         )
       )}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -260,13 +260,15 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
           }
 
           return (
-            <RQButton
-              className="key-value-delete-btn"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title="Delete" placement="top" color="#000">
+              <RQButton
+                className="key-value-delete-btn"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dropdown, Checkbox } from "antd";
+import { Dropdown, Checkbox, Tooltip } from "antd";
 import { MdMoreHoriz } from "@react-icons/all-files/md/MdMoreHoriz";
 import { RQButton } from "lib/design-system-v2/components";
 
@@ -33,7 +33,9 @@ export const KeyValueTableSettingsDropdown: React.FC<KeyValueTableSettingsDropdo
   return (
     <div className="key-value-settings-header">
       <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
-        <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
+        <Tooltip title="Settings" placement="top" color="#000">
+          <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
+        </Tooltip>
       </Dropdown>
     </div>
   );

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
@@ -3,7 +3,7 @@ import { FormDropDownOptions, RQAPI } from "features/apiClient/types";
 import React, { useCallback, useMemo } from "react";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
-import { TableProps } from "antd";
+import { TableProps, Tooltip } from "antd";
 import { RiDeleteBin6Line } from "@react-icons/all-files/ri/RiDeleteBin6Line";
 import { MultiEditableCell, MultiEditableRow } from "./MultipartFormRowTable";
 import "./MultiPartFormTable.scss";
@@ -158,13 +158,15 @@ export const MultipartFormTable: React.FC<KeyValueTableProps> = ({
             return null;
           }
           return (
-            <RQButton
-              className="key-value-delete-icon"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title="Delete" placement="top" color="#000">
+              <RQButton
+                className="key-value-delete-icon"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },

--- a/app/src/features/apiClient/screens/environment/components/environmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
+++ b/app/src/features/apiClient/screens/environment/components/environmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
@@ -287,13 +287,15 @@ export const EnvironmentsListItem: React.FC<EnvironmentsListItemProps> = ({
         <div onClick={(e) => e.stopPropagation()}>
           {!isGlobalEnvironment(environment.id) ? (
             <Dropdown menu={{ items: menuItems }} trigger={["click"]} placement="bottomRight">
-              <RQButton
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-                className="environment-list-item-dropdown-button"
-                onClick={(e) => e.stopPropagation()}
-              />
+              <Tooltip title="More actions" placement="top" color="#000">
+                <RQButton
+                  size="small"
+                  type="transparent"
+                  icon={<MdOutlineMoreHoriz />}
+                  className="environment-list-item-dropdown-button"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </Tooltip>
             </Dropdown>
           ) : null}
         </div>


### PR DESCRIPTION
Closes issue: #3868

## Summary of changes:

- Adds missing tooltips to API client icon-only controls called out in #3868.
- Covers create, more actions, settings, delete, new request tab, and response panel dock controls.
- Updates dock tooltip text dynamically between `Dock to right` and `Dock to bottom`.

## Demo Video:

No demo video. This is a small tooltip-only UI accessibility improvement.

## Checklist:

- [x] Make sure linting and unit tests pass. (`git diff --check`)
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] Added demo video showing the changes in action (if applicable).

## Test instructions:

- Open the API client.
- Hover over the icon-only controls in the sidebar, tabs, key-value tables, and response panel dock controls.
- Confirm the tooltips appear with the expected labels.

## Other references:

Fixes #3868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added informational tooltips to action buttons throughout the application, providing contextual guidance for users. Tooltips now appear on add buttons, delete controls, settings icons, menu triggers, and docking controls in the sidebar, request views, environment management, and sheet operations, improving overall user clarity and action discoverability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->