### PR TITLE
Fix source filter count badge

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -22,6 +22,7 @@ import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
+import { getAppliedSourceFilterCount } from "./utils";
 import "./RequestSourceRow.css";
 
 const { Text } = Typography;
@@ -71,13 +72,11 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
   const getFilterCount = useCallback(
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const sourceFilters = isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters || {};
+
+      return getAppliedSourceFilterCount(sourceFilters, [GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL]);
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
@@ -1,0 +1,33 @@
+const hasAppliedFilterValue = (value) => {
+  if (value == null) {
+    return false;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(hasAppliedFilterValue);
+  }
+
+  if (typeof value === "object") {
+    return Object.entries(value).some(([key, nestedValue]) => {
+      if (key === "operator") {
+        return false;
+      }
+
+      return hasAppliedFilterValue(nestedValue);
+    });
+  }
+
+  return Boolean(value);
+};
+
+export const getAppliedSourceFilterCount = (sourceFilters = {}, ignoredFilterKeys = []) => {
+  const ignoredFilterKeySet = new Set(ignoredFilterKeys);
+
+  return Object.entries(sourceFilters).filter(([key, value]) => {
+    return !ignoredFilterKeySet.has(key) && hasAppliedFilterValue(value);
+  }).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getAppliedSourceFilterCount } from "./utils";
+
+describe("getAppliedSourceFilterCount", () => {
+  it("does not count empty default filter values", () => {
+    expect(
+      getAppliedSourceFilterCount(
+        {
+          pageUrl: { operator: "Contains", value: "" },
+          requestPayload: { operator: "Contains" },
+          requestMethod: [],
+          resourceType: [],
+          pageDomains: [],
+        },
+        ["pageUrl"]
+      )
+    ).toBe(0);
+  });
+
+  it("counts filters only when they contain a meaningful value", () => {
+    expect(
+      getAppliedSourceFilterCount(
+        {
+          pageUrl: { operator: "Contains", value: "requestly.io" },
+          requestPayload: { operator: "Contains", key: "operationName", value: "ProductsQuery" },
+          requestMethod: ["GET"],
+          resourceType: [],
+          pageDomains: [""],
+        },
+        ["pageUrl"]
+      )
+    ).toBe(2);
+  });
+
+  it("supports legacy non-array source filter objects", () => {
+    expect(
+      getAppliedSourceFilterCount({
+        requestPayload: { key: "", value: "" },
+        resourceType: ["xmlhttprequest"],
+      })
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- count only source filters with meaningful values when rendering the Filters badge
- ignore empty default values such as blank request payload fields, empty arrays, empty objects, and operator-only filter objects
- add unit coverage for empty/default filters, meaningful filters, and legacy source filter objects

Fixes #3826

## Test plan
- npm test -- src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js --run
- npx eslint src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined source filter counting logic by consolidating implementation details for enhanced consistency across components.

* **Tests**
  * Added comprehensive test coverage for source filter validation, verifying correct behavior across various scenarios including empty values, active filters, and legacy format support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4675)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->