### PR TITLE
Fix traffic table row cursor

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -1,7 +1,16 @@
+
 .web-traffic-table-container {
   height: 100%;
   table {
     tbody {
+      tr {
+        cursor: pointer;
+      }
+
+      td {
+        cursor: inherit;
+      }
+
       tr[aria-selected="true"] {
         .graphql-operation-name {
           color: var(--requestly-color-text-default);


### PR DESCRIPTION
Closes requestly/interceptor#49

## Summary
- Sets the desktop traffic table rows to use the pointer cursor.
- Lets table cells inherit the row cursor so hovering over URL/text cells no longer falls back to the text cursor.
- Scopes the change to the desktop traffic table stylesheet only.

## Demo Video
Not attached: this is a small CSS-only cursor fix for the desktop traffic table.

## Checklist
- [x] No install/build warnings introduced.
- [x] Change is scoped to the affected traffic table UI.
- [ ] Make sure linting and unit tests pass.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] Added demo video showing the changes in action (if applicable).

## Test Instructions
1. Open the Requestly desktop traffic table with captured requests.
2. Hover over a request row, including the URL/text cells.
3. Confirm the cursor remains a pointer across the row.

## Other References
Bounty issue: requestly/interceptor#49