### PR TITLE
feat: copy rules to Private Workspace

### DIFF
--- a/app/src/components/common/SharingModal/Workspaces/PostSharing.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/PostSharing.tsx
@@ -5,16 +5,17 @@ import { getAppMode } from "store/selectors";
 import { RQButton } from "lib/design-system/components";
 import { switchWorkspace } from "actions/TeamWorkspaceActions";
 import { FaRegCopy } from "@react-icons/all-files/fa/FaRegCopy";
-import { PostShareViewData, WorkspaceSharingTypes } from "../types";
+import { PostShareViewData, SetPostShareViewData, WorkspaceSharingTypes } from "../types";
 import { trackInviteTeammatesClicked } from "modules/analytics/events/common/teams";
 import "./index.scss";
 import { toast } from "utils/Toast";
 import { isActiveWorkspaceShared } from "store/slices/workspaces/selectors";
 import WorkspaceAvatar from "features/workspaces/components/WorkspaceAvatar";
+import { Workspace, WorkspaceType } from "features/workspaces/types";
 
 interface PostSharingProps {
   postShareViewData: PostShareViewData;
-  setPostShareViewData: ({ type, targetTeamData }: PostShareViewData) => void;
+  setPostShareViewData: SetPostShareViewData;
   toggleModal: () => void;
 }
 
@@ -24,6 +25,11 @@ export const PostSharing: React.FC<PostSharingProps> = ({ postShareViewData, set
   const isSharedWorkspaceMode = useSelector(isActiveWorkspaceShared);
 
   const handleSwitchWorkspace = useCallback(() => {
+    if (!postShareViewData.targetTeamData) {
+      toggleModal();
+      return;
+    }
+
     switchWorkspace(
       {
         teamId: postShareViewData.targetTeamData.id,
@@ -74,8 +80,14 @@ export const PostSharing: React.FC<PostSharingProps> = ({ postShareViewData, set
         ctaText: "Switch to the workspace",
         action: handleSwitchWorkspace,
       },
+      [WorkspaceSharingTypes.PRIVATE_WORKSPACE]: {
+        header: <WorkspaceSharingInfoHeader postShareViewData={postShareViewData} />,
+        message: "Selected rules have been copied to your Private Workspace",
+        ctaText: "Done",
+        action: toggleModal,
+      },
     };
-  }, [handleSwitchWorkspace, setPostShareViewData, postShareViewData]);
+  }, [handleSwitchWorkspace, setPostShareViewData, postShareViewData, toggleModal]);
 
   return (
     <div className="post-sharing-wrapper">
@@ -94,17 +106,23 @@ export const PostSharing: React.FC<PostSharingProps> = ({ postShareViewData, set
 
 const WorkspaceSharingInfoHeader: React.FC<{ postShareViewData: PostShareViewData }> = ({ postShareViewData }) => {
   const { targetTeamData, sourceTeamData } = postShareViewData;
+  const sourceWorkspaceData = sourceTeamData ?? undefined;
+  const targetWorkspaceData: Workspace = targetTeamData ?? {
+    id: null,
+    name: "Private Workspace",
+    workspaceType: WorkspaceType.PERSONAL,
+  };
 
   return (
     <div className="items-center workspace-sharing-flow-cta">
       <div className="sharing-flow-cta-workspace-avatar">
-        <WorkspaceAvatar workspace={sourceTeamData} />
-        <div className="mt-8">{sourceTeamData?.name}</div>
+        <WorkspaceAvatar workspace={sourceWorkspaceData} />
+        <div className="mt-8">{sourceWorkspaceData?.name}</div>
       </div>
       <FaRegCopy className="header text-gray" />
       <div className="sharing-flow-cta-workspace-avatar">
-        <WorkspaceAvatar workspace={targetTeamData} />
-        <div className="mt-8">{targetTeamData?.name}</div>
+        <WorkspaceAvatar workspace={targetWorkspaceData} />
+        <div className="mt-8">{targetWorkspaceData.name}</div>
       </div>
     </div>
   );

--- a/app/src/components/common/SharingModal/Workspaces/ShareFromPrivate.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/ShareFromPrivate.tsx
@@ -10,7 +10,7 @@ import { getFunctions, httpsCallable } from "firebase/functions";
 import { isVerifiedBusinessDomainUser } from "utils/Misc";
 import { duplicateRulesToTargetWorkspace } from "../actions";
 import { trackAddTeamMemberSuccess, trackNewTeamCreateSuccess } from "modules/analytics/events/features/teams";
-import { WorkspaceSharingTypes, PostShareViewData } from "../types";
+import { WorkspaceSharingTypes, SetPostShareViewData } from "../types";
 import { TeamRole } from "types";
 import { trackSharingModalRulesDuplicated } from "modules/analytics/events/misc/sharing";
 import EmailInputWithDomainBasedSuggestions from "components/common/EmailInputWithDomainBasedSuggestions";
@@ -24,7 +24,7 @@ import { Workspace, WorkspaceType } from "features/workspaces/types";
 
 interface Props {
   selectedRules: string[];
-  setPostShareViewData: ({ type, targetTeamData }: PostShareViewData) => void;
+  setPostShareViewData: SetPostShareViewData;
   onRulesShared?: () => void;
 }
 

--- a/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
@@ -2,12 +2,13 @@ import React, { useState, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { getAppMode } from "store/selectors";
 import { WorkspaceShareMenu } from "./WorkspaceShareMenu";
-import { Tooltip } from "antd";
+import { Avatar, Row, Tooltip } from "antd";
+import { LockOutlined } from "@ant-design/icons";
 import { RQButton } from "lib/design-system/components";
 import CopyButton from "components/misc/CopyButton";
 import { httpsCallable, getFunctions } from "firebase/functions";
 import { trackAddTeamMemberSuccess } from "modules/analytics/events/features/teams";
-import { PostShareViewData, WorkspaceSharingTypes } from "../types";
+import { SetPostShareViewData, WorkspaceSharingTypes } from "../types";
 import { TeamRole } from "types";
 import { duplicateRulesToTargetWorkspace } from "../actions";
 import {
@@ -26,7 +27,7 @@ import { Workspace } from "features/workspaces/types";
 
 interface Props {
   selectedRules: string[];
-  setPostShareViewData: ({ type, targetTeamData }: PostShareViewData) => void;
+  setPostShareViewData: SetPostShareViewData;
   onRulesShared?: () => void;
 }
 
@@ -97,8 +98,39 @@ export const ShareFromWorkspace: React.FC<Props> = ({
     [appMode, onRulesShared, selectedRules, activeWorkspace, setPostShareViewData]
   );
 
+  const handleTransferToPrivateWorkspace = useCallback(() => {
+    setIsLoading(true);
+    duplicateRulesToTargetWorkspace(appMode, null, selectedRules).then(() => {
+      setIsLoading(false);
+      trackSharingModalRulesDuplicated("team", selectedRules.length);
+      setPostShareViewData({
+        type: WorkspaceSharingTypes.PRIVATE_WORKSPACE,
+        sourceTeamData: activeWorkspace,
+      });
+
+      onRulesShared();
+    });
+  }, [appMode, onRulesShared, selectedRules, activeWorkspace, setPostShareViewData]);
+
   return (
     <>
+      <div className="workspace-share-menu-item-card">
+        <Row align="middle" className="items-center">
+          <Avatar size={35} shape="square" icon={<LockOutlined />} className="workspace-avatar" />
+          <span className="workspace-card-description">
+            <div className="text-white">Private Workspace</div>
+            <div className="text-gray">Not shared with anyone</div>
+          </span>
+        </Row>
+        <RQButton
+          disabled={isLoading}
+          type="link"
+          className="workspace-menu-item-transfer-btn"
+          onClick={handleTransferToPrivateWorkspace}
+        >
+          Copy here
+        </RQButton>
+      </div>
       <WorkspaceShareMenu onTransferClick={handleTransferToOtherWorkspace} isLoading={isLoading} />
       <div className="subheader mt-1">Share with Teammates</div>
       <div className="mt-8 text-gray">Collaborate in real-time with your teammates within a shared workspace.</div>

--- a/app/src/components/common/SharingModal/Workspaces/index.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/index.tsx
@@ -4,6 +4,7 @@ import { ShareFromPrivate } from "./ShareFromPrivate";
 import { ShareFromWorkspace } from "./ShareFromWorkspace";
 import { PostSharing } from "./PostSharing";
 import { isActiveWorkspaceShared } from "store/slices/workspaces/selectors";
+import { PostShareViewData } from "../types";
 
 interface ShareInWorkspaceProps {
   selectedRules: string[];
@@ -17,7 +18,7 @@ export const ShareInWorkspaces: React.FC<ShareInWorkspaceProps> = ({
   onRulesShared = () => {},
 }) => {
   const isSharedWorkspaceMode = useSelector(isActiveWorkspaceShared);
-  const [postShareViewData, setPostShareViewData] = useState(null);
+  const [postShareViewData, setPostShareViewData] = useState<PostShareViewData | null>(null);
 
   return (
     <div className="sharing-modal-body share-in-workspaces-wrapper">

--- a/app/src/components/common/SharingModal/actions.ts
+++ b/app/src/components/common/SharingModal/actions.ts
@@ -77,7 +77,7 @@ export const prepareContentToExport = (appMode: string, selectedRuleIds: string[
 
 export const duplicateRulesToTargetWorkspace = async (
   appMode: string,
-  workspaceId: string,
+  workspaceId: Workspace["id"],
   ruleIdsToShare: string[]
 ) => {
   const { rules, groups } = await getRulesAndGroupsFromRuleIds(appMode, ruleIdsToShare);

--- a/app/src/components/common/SharingModal/types.ts
+++ b/app/src/components/common/SharingModal/types.ts
@@ -1,4 +1,5 @@
 import { Group as NewGroup, Rule as NewRule } from "@requestly/shared/types/entities/rules";
+import React from "react";
 import { Workspace } from "features/workspaces/types";
 
 export enum SharingOptions {
@@ -28,6 +29,7 @@ export enum WorkspaceSharingTypes {
   NEW_WORKSPACE_CREATED = "new_workspace_created",
   USERS_INVITED = "users_invites",
   EXISTING_WORKSPACE = "existing_workspace",
+  PRIVATE_WORKSPACE = "private_workspace",
 }
 
 export type PostShareViewData = {
@@ -35,3 +37,5 @@ export type PostShareViewData = {
   targetTeamData?: Workspace;
   sourceTeamData?: Workspace | null;
 };
+
+export type SetPostShareViewData = React.Dispatch<React.SetStateAction<PostShareViewData | null>>;

--- a/app/src/utils/StorageServiceWrapper.js
+++ b/app/src/utils/StorageServiceWrapper.js
@@ -50,7 +50,7 @@ class StorageServiceWrapper {
    * @param ruleOrGroup rule or group
    * @param options options for save operation
    * @param {boolean} options.silentUpdate do not update last modified timestamp
-   * @param {string} options.workspaceId workspace identifier
+   * @param {string|null} options.workspaceId workspace identifier. Use null for the private workspace.
    * @returns a promise on save of the rule or group
    */
   async saveRuleOrGroup(ruleOrGroup, options = {}) {

--- a/app/src/utils/syncing/syncDataUtils.js
+++ b/app/src/utils/syncing/syncDataUtils.js
@@ -107,7 +107,8 @@ const preventWorkspaceSyncWrite = async (key, latestRules, objectId, uid, remote
 };
 
 export const updateUserSyncRecords = async (uid, records, appMode, options) => {
-  const targetWorkspaceId = options.workspaceId ?? window.currentlyActiveWorkspaceTeamId;
+  const targetWorkspaceId =
+    typeof options.workspaceId === "undefined" ? window.currentlyActiveWorkspaceTeamId : options.workspaceId;
   const isSameWorkspaceOperation = targetWorkspaceId === window.currentlyActiveWorkspaceTeamId;
 
   const latestRules = _.cloneDeep(records); // Does not contain all rules, only contains rules that has been updated.


### PR DESCRIPTION
## Closes issue

Closes #3825

## Summary
- Add a Private Workspace destination card to the sharing modal when rules are shared from a team workspace.
- Allow `duplicateRulesToTargetWorkspace` to receive `null` as the explicit Private Workspace target.
- Preserve `undefined` as the existing "current active workspace" behavior while routing `null` to the personal sync path.
- Add a post-copy success state for Private Workspace copies.

## Why
The existing sharing modal can copy rules from a private workspace into a team workspace, but not the reverse. This adds the missing Private Workspace option and fixes sync target resolution so `null` is treated as personal/private instead of falling back to the active team workspace.

## Verification
- `git diff --check`
- `./node_modules/.bin/eslint src/components/common/SharingModal/actions.ts src/components/common/SharingModal/types.ts src/components/common/SharingModal/Workspaces/index.tsx src/components/common/SharingModal/Workspaces/ShareFromPrivate.tsx src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx src/components/common/SharingModal/Workspaces/PostSharing.tsx src/utils/syncing/syncDataUtils.js src/utils/StorageServiceWrapper.js`
  - Result: 0 errors. Existing warnings remain in untouched lines: `processRecordsArrayIntoObject` unused and `localRecords` unused.
- `npx tsc --noEmit --pretty false` after building `shared/dist`, filtered for touched paths.
  - Result: no errors in touched files. Existing unrelated errors remain in `SharingModal/ShareLinkView.tsx` and `SharingModal/DownloadRules/index.tsx`.

## Bounty
/claim #3825
