### PR TITLE
Fix copying rules to Private Workspace

### DIFF
--- a/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
@@ -82,9 +82,9 @@ export const ShareFromWorkspace: React.FC<Props> = ({
   const handleTransferToOtherWorkspace = useCallback(
     (teamData: Workspace) => {
       setIsLoading(true);
-      duplicateRulesToTargetWorkspace(appMode, teamData.id!, selectedRules).then(() => {
+      duplicateRulesToTargetWorkspace(appMode, teamData.id, selectedRules).then(() => {
         setIsLoading(false);
-        trackSharingModalRulesDuplicated("team", selectedRules.length);
+        trackSharingModalRulesDuplicated(teamData.id === null ? "personal" : "team", selectedRules.length);
         setPostShareViewData({
           type: WorkspaceSharingTypes.EXISTING_WORKSPACE,
           targetTeamData: teamData,
@@ -99,7 +99,11 @@ export const ShareFromWorkspace: React.FC<Props> = ({
 
   return (
     <>
-      <WorkspaceShareMenu onTransferClick={handleTransferToOtherWorkspace} isLoading={isLoading} />
+      <WorkspaceShareMenu
+        onTransferClick={handleTransferToOtherWorkspace}
+        isLoading={isLoading}
+        includePrivateWorkspace
+      />
       <div className="subheader mt-1">Share with Teammates</div>
       <div className="mt-8 text-gray">Collaborate in real-time with your teammates within a shared workspace.</div>
       <div className="mt-1">

--- a/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
@@ -5,9 +5,10 @@ import { RQButton } from "lib/design-system/components";
 import { MdOutlineKeyboardArrowDown } from "@react-icons/all-files/md/MdOutlineKeyboardArrowDown";
 import type { MenuProps } from "antd";
 import { trackShareModalWorkspaceDropdownClicked } from "modules/analytics/events/misc/sharing";
-import { getActiveWorkspace, getAllWorkspaces } from "store/slices/workspaces/selectors";
+import { dummyPersonalWorkspace, getActiveWorkspace, getAllWorkspaces } from "store/slices/workspaces/selectors";
 import { Workspace } from "features/workspaces/types";
 import WorkspaceAvatar from "features/workspaces/components/WorkspaceAvatar";
+import { isPersonalWorkspace } from "features/workspaces/utils";
 
 interface Props {
   /**
@@ -16,6 +17,7 @@ interface Props {
   defaultActiveWorkspaces?: number;
   onTransferClick: (teamData: Workspace) => void;
   isLoading: boolean;
+  includePrivateWorkspace?: boolean;
 }
 
 interface WorkspaceItemProps {
@@ -26,11 +28,20 @@ interface WorkspaceItemProps {
   isLoading?: boolean;
 }
 
-export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading, defaultActiveWorkspaces = 0 }) => {
+export const WorkspaceShareMenu: React.FC<Props> = ({
+  onTransferClick,
+  isLoading,
+  defaultActiveWorkspaces = 0,
+  includePrivateWorkspace = false,
+}) => {
   const availableWorkspaces = useSelector(getAllWorkspaces);
   const activeWorkspace = useSelector(getActiveWorkspace);
 
-  const filteredAvailableWorkspaces = availableWorkspaces.filter((workspace) => !workspace.browserstackDetails); // Filtering our Browserstack Workspaces)
+  const filteredAvailableWorkspaces = useMemo(() => {
+    const nonBrowserStackWorkspaces = availableWorkspaces.filter((workspace) => !workspace.browserstackDetails);
+
+    return includePrivateWorkspace ? [...nonBrowserStackWorkspaces, dummyPersonalWorkspace] : nonBrowserStackWorkspaces;
+  }, [availableWorkspaces, includePrivateWorkspace]); // Filtering our Browserstack Workspaces)
 
   const sortedTeams: Workspace[] = useMemo(
     () =>
@@ -124,6 +135,10 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   showArrow = false,
   isLoading = false,
 }) => {
+  const description = isPersonalWorkspace(workspace)
+    ? "Not shared with anyone"
+    : `${workspace.accessCount ?? 0} ${(workspace.accessCount ?? 0) !== 1 ? "members" : "member"}`;
+
   return (
     <div
       className={`workspace-share-menu-item-card ${
@@ -134,9 +149,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         <WorkspaceAvatar workspace={workspace} size={35} />
         <span className="workspace-card-description">
           <div className="text-white">{workspace.name}</div>
-          <div className="text-gray">
-            {workspace.accessCount ?? 0} {(workspace.accessCount ?? 0) !== 1 ? "members" : "member"}
-          </div>
+          <div className="text-gray">{description}</div>
         </span>
       </Row>
       {showArrow ? (

--- a/app/src/components/common/SharingModal/actions.ts
+++ b/app/src/components/common/SharingModal/actions.ts
@@ -77,7 +77,7 @@ export const prepareContentToExport = (appMode: string, selectedRuleIds: string[
 
 export const duplicateRulesToTargetWorkspace = async (
   appMode: string,
-  workspaceId: string,
+  workspaceId: Workspace["id"],
   ruleIdsToShare: string[]
 ) => {
   const { rules, groups } = await getRulesAndGroupsFromRuleIds(appMode, ruleIdsToShare);

--- a/app/src/utils/StorageServiceWrapper.js
+++ b/app/src/utils/StorageServiceWrapper.js
@@ -50,7 +50,7 @@ class StorageServiceWrapper {
    * @param ruleOrGroup rule or group
    * @param options options for save operation
    * @param {boolean} options.silentUpdate do not update last modified timestamp
-   * @param {string} options.workspaceId workspace identifier
+   * @param {string | null} options.workspaceId workspace identifier
    * @returns a promise on save of the rule or group
    */
   async saveRuleOrGroup(ruleOrGroup, options = {}) {

--- a/app/src/utils/syncing/SyncUtils.ts
+++ b/app/src/utils/syncing/SyncUtils.ts
@@ -43,7 +43,7 @@ export const doSyncRecords = async (
   records: any,
   syncType: SyncType,
   appMode: AppMode,
-  options: { forceSync?: boolean; workspaceId?: string } = {}
+  options: { forceSync?: boolean; workspaceId?: string | null } = {}
 ): Promise<void> => {
   // If the user is not logged in, do not proceed with syncing
   if (!window.uid) return;

--- a/app/src/utils/syncing/syncDataUtils.js
+++ b/app/src/utils/syncing/syncDataUtils.js
@@ -106,8 +106,10 @@ const preventWorkspaceSyncWrite = async (key, latestRules, objectId, uid, remote
   return latestRules;
 };
 
-export const updateUserSyncRecords = async (uid, records, appMode, options) => {
-  const targetWorkspaceId = options.workspaceId ?? window.currentlyActiveWorkspaceTeamId;
+export const updateUserSyncRecords = async (uid, records, appMode, options = {}) => {
+  const targetWorkspaceId = Object.prototype.hasOwnProperty.call(options, "workspaceId")
+    ? options.workspaceId
+    : window.currentlyActiveWorkspaceTeamId;
   const isSameWorkspaceOperation = targetWorkspaceId === window.currentlyActiveWorkspaceTeamId;
 
   const latestRules = _.cloneDeep(records); // Does not contain all rules, only contains rules that has been updated.


### PR DESCRIPTION
Fixes #3825

## Summary
- Adds Private Workspace as a copy target in the Share in workspace flow.
- Allows rule duplication to target the personal workspace with `workspaceId: null`.
- Fixes sync routing so explicit `null` writes to personal sync instead of falling back to the active shared workspace.

## Verification
- `git diff --check`
- `npm --prefix app run type-check` could not complete locally because dependencies are not installed in this checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced workspace sharing modal to better distinguish personal and team workspaces with clearer status descriptions
  * Personal workspaces now display "Not shared with anyone" status in the sharing interface
  * Improved workspace member counts display to show singular/plural "member/members" text appropriately

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4679)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->