### PR TITLE
[codex] Add API client header suggestion coverage

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableRow.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { Checkbox, Form, FormInstance } from "antd";
-import { KeyValueDataType, KeyValueFormType, KeyValuePair } from "features/apiClient/types";
+import { KeyValueDataType, KeyValuePair } from "features/apiClient/types";
 import SingleLineEditor from "features/apiClient/screens/environment/components/SingleLineEditor";
 import InfoIcon from "components/misc/InfoIcon";
 import { Conditional } from "components/common/Conditional";
@@ -9,7 +9,7 @@ import { ScopedVariables } from "features/apiClient/helpers/variableResolver/var
 import KeyValueDescriptionCell from "./KeyValueTableDescriptionCell";
 import { KeyValueTypeCell, ValidationWarning } from "./KeyValueTableTypeCell";
 import { captureException } from "@sentry/react";
-import HEADER_SUGGESTIONS from "config/constants/sub/header-suggestions";
+import { getKeyValueTableSuggestions } from "./keyValueTableSuggestions";
 
 const EditableContext = React.createContext<FormInstance<any> | null>(null);
 
@@ -128,9 +128,7 @@ export const KeyValueTableEditableCell: React.FC<React.PropsWithChildren<Editabl
                 save();
               }}
               variables={variables}
-              suggestions={
-                tableType === KeyValueFormType.HEADERS && dataIndex === "key" ? HEADER_SUGGESTIONS.Request : undefined
-              }
+              suggestions={getKeyValueTableSuggestions(tableType, dataIndex)}
             />
 
             <Conditional

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/keyValueTableSuggestions.test.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/keyValueTableSuggestions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { KeyValueFormType } from "features/apiClient/types";
+import HEADER_SUGGESTIONS from "config/constants/sub/header-suggestions";
+import { getKeyValueTableSuggestions } from "./keyValueTableSuggestions";
+
+describe("getKeyValueTableSuggestions", () => {
+  it("returns standard request header names for API client header key cells", () => {
+    expect(getKeyValueTableSuggestions(KeyValueFormType.HEADERS, "key")).toBe(HEADER_SUGGESTIONS.Request);
+  });
+
+  it("does not return header names for API client header value cells", () => {
+    expect(getKeyValueTableSuggestions(KeyValueFormType.HEADERS, "value")).toBeUndefined();
+  });
+
+  it("does not return header names for non-header key/value tables", () => {
+    expect(getKeyValueTableSuggestions(KeyValueFormType.QUERY_PARAMS, "key")).toBeUndefined();
+  });
+});

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/keyValueTableSuggestions.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/keyValueTableSuggestions.ts
@@ -1,0 +1,10 @@
+import { KeyValueFormType, type KeyValuePair } from "features/apiClient/types";
+import HEADER_SUGGESTIONS from "config/constants/sub/header-suggestions";
+
+export const getKeyValueTableSuggestions = (tableType: string | undefined, dataIndex: keyof KeyValuePair) => {
+  if (tableType === KeyValueFormType.HEADERS && dataIndex === "key") {
+    return HEADER_SUGGESTIONS.Request;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary

This adds regression coverage for API Client header key suggestions and moves the key/value-table suggestion selection into a small helper.

Current `master` already wires `HEADER_SUGGESTIONS.Request` into API Client header key cells. This PR keeps that behavior explicit and covers the expected cases:

- request header key cells receive standard HTTP header-name suggestions
- request header value cells do not receive header-name suggestions
- non-header key/value tables do not receive header-name suggestions

Refs requestly/requestly#3749.

## Validation

- `npx --yes vitest@1.3.1 run src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/keyValueTableSuggestions.test.ts --config /tmp/requestly-vitest.config.mjs`
- `npx --yes prettier@2.8.1 --check src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableRow.tsx src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/keyValueTableSuggestions.ts src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/keyValueTableSuggestions.test.ts`
- `git diff --check`

Note: I could not run the full `npm ci` flow in `app/` because the current `app/package-lock.json` is out of sync with `app/package.json` (`@requestly/shared@1.0.10` is missing from the lockfile).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and maintainability of autocomplete suggestion logic in the API client's key-value tables.

* **Tests**
  * Added test coverage for the suggestion logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4681)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->