### PR TITLE
Fix: hide empty source filter count badge

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.js
@@ -1,0 +1,34 @@
+const FILTER_METADATA_KEYS = new Set(["operator"]);
+
+const hasAppliedFilterValue = (value) => {
+  if (value == null) {
+    return false;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(hasAppliedFilterValue);
+  }
+
+  if (typeof value === "object") {
+    return Object.entries(value).some(
+      ([key, nestedValue]) => !FILTER_METADATA_KEYS.has(key) && hasAppliedFilterValue(nestedValue)
+    );
+  }
+
+  return true;
+};
+
+export const getAppliedSourceFilterCount = (sourceFilters, ignoredFilterKeys = []) => {
+  const filters = Array.isArray(sourceFilters) ? sourceFilters[0] : sourceFilters;
+  const ignoredKeys = new Set(ignoredFilterKeys);
+
+  if (!filters || typeof filters !== "object") {
+    return 0;
+  }
+
+  return Object.entries(filters).filter(([key, value]) => !ignoredKeys.has(key) && hasAppliedFilterValue(value)).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCountUtils.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { getAppliedSourceFilterCount } from "./filterCountUtils";
+
+describe("getAppliedSourceFilterCount", () => {
+  const ignoredFilters = ["pageUrl"];
+
+  it("returns zero when filters are missing", () => {
+    expect(getAppliedSourceFilterCount(undefined, ignoredFilters)).toBe(0);
+    expect(getAppliedSourceFilterCount(null, ignoredFilters)).toBe(0);
+    expect(getAppliedSourceFilterCount({}, ignoredFilters)).toBe(0);
+  });
+
+  it("ignores page URL filters in the badge count", () => {
+    expect(getAppliedSourceFilterCount({ pageUrl: ["https://requestly.com"] }, ignoredFilters)).toBe(0);
+  });
+
+  it("does not count empty request payload placeholders", () => {
+    expect(getAppliedSourceFilterCount([{ requestPayload: {} }], ignoredFilters)).toBe(0);
+    expect(getAppliedSourceFilterCount([{ requestPayload: { key: "", value: "" } }], ignoredFilters)).toBe(0);
+    expect(
+      getAppliedSourceFilterCount([{ requestPayload: { key: " ", operator: "Contains", value: " " } }], ignoredFilters)
+    ).toBe(0);
+  });
+
+  it("counts request payload filters with meaningful values", () => {
+    expect(getAppliedSourceFilterCount([{ requestPayload: { key: "operationName", value: "" } }], ignoredFilters)).toBe(
+      1
+    );
+    expect(getAppliedSourceFilterCount([{ requestPayload: { key: "", value: "GetUser" } }], ignoredFilters)).toBe(1);
+  });
+
+  it("counts non-empty array filters", () => {
+    expect(
+      getAppliedSourceFilterCount([{ requestMethod: ["GET"], resourceType: ["xmlhttprequest"] }], ignoredFilters)
+    ).toBe(2);
+  });
+
+  it("does not count empty arrays or blank entries", () => {
+    expect(getAppliedSourceFilterCount([{ requestMethod: [], resourceType: [""] }], ignoredFilters)).toBe(0);
+  });
+
+  it("supports the legacy non-array filter shape", () => {
+    expect(
+      getAppliedSourceFilterCount({ requestMethod: ["POST"], pageUrl: ["https://example.com"] }, ignoredFilters)
+    ).toBe(1);
+  });
+});

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -22,6 +22,7 @@ import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
+import { getAppliedSourceFilterCount } from "./filterCountUtils";
 import "./RequestSourceRow.css";
 
 const { Text } = Typography;
@@ -70,16 +71,11 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      return getAppliedSourceFilterCount(currentlySelectedRuleData.pairs[pairIndex].source.filters, [
+        GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL,
+      ]);
     },
-    [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
+    [currentlySelectedRuleData]
   );
 
   const sourceKeys = useMemo(


### PR DESCRIPTION
Fixes #3826

## Problem
The rule editor badge counted source filter keys even when the filter value was only an empty placeholder, such as an imported `requestPayload: {}` filter. That made the UI show "1 applied filter" even when no filter was configured.

## Solution
The source filter badge now counts only filters with meaningful configured values, while continuing to ignore the derived `pageUrl` filter.

## Key changes
- Added a small filter-count helper for source filters.
- Ignored empty objects, empty arrays, blank strings, and metadata-only payload filter objects.
- Added focused Vitest coverage for empty placeholders, applied payload filters, array filters, ignored page URL filters, and the legacy non-array filter shape.

## Validation
- Focused Vitest run for `filterCountUtils.test.js`: 7 tests passed.
- `npx --yes prettier@2.8.1 --check` on the touched files.
- `git diff --check`.

AI-assisted implementation, reviewed before submission.

reviewed and tested manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted filter-counting logic into a dedicated utility function for computing applied request source filters, supporting multiple filter formats and handling edge cases.

* **Tests**
  * Added comprehensive test suite for filter-count calculations, covering scenarios with empty filters, null values, nested arrays, whitespace handling, and legacy filter format support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->