### PR TITLE
fix: count only non-empty source filters

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -26,6 +26,40 @@ import "./RequestSourceRow.css";
 
 const { Text } = Typography;
 
+const FILTER_KEYS_TO_IGNORE_IN_COUNT = [GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL];
+
+const hasNonEmptyFilterValue = (filterKey, filterValue) => {
+  if (Array.isArray(filterValue)) {
+    return filterValue.some((value) => hasNonEmptyFilterValue(filterKey, value));
+  }
+
+  if (filterKey === GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.REQUEST_DATA) {
+    return !!filterValue?.key?.trim?.() && !!filterValue?.value?.trim?.();
+  }
+
+  if (filterValue && typeof filterValue === "object") {
+    return Object.entries(filterValue).some(([key, value]) => {
+      if (key === "operator") {
+        return false;
+      }
+
+      return hasNonEmptyFilterValue(key, value);
+    });
+  }
+
+  if (typeof filterValue === "string") {
+    return filterValue.trim().length > 0;
+  }
+
+  return filterValue !== null && filterValue !== undefined && filterValue !== false;
+};
+
+const getAppliedFiltersCount = (sourceFilters) => {
+  return Object.entries(sourceFilters || {}).filter(([key, value]) => {
+    return !FILTER_KEYS_TO_IGNORE_IN_COUNT.includes(key) && hasNonEmptyFilterValue(key, value);
+  }).length;
+};
+
 const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabled }) => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -71,13 +105,11 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
   const getFilterCount = useCallback(
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const sourceFilters = isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0]
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters;
+
+      return getAppliedFiltersCount(sourceFilters);
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );


### PR DESCRIPTION
## Summary

- Fixes the source filter badge count so empty filter values are not counted as applied filters.
- Keeps `pageUrl` excluded from the displayed count, matching the previous behavior.
- Treats empty arrays, empty strings, empty nested filter objects, and request payload filters without both key and value as empty.

## Issue

Fixes requestly/requestly#3826

## Testing

Ran a lightweight local logic check for the new filter-count behavior:

- `requestMethod: []` -> `0`
- `requestPayload: { operator: "Equals", key: "", value: "" }` -> `0`
- `resourceType: ["script"]` -> `1`
- `pageDomains: ["example.com"]` -> `1`

Full app tests were not run because `app/node_modules` is not installed in this checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the applied-filters badge counting so it more accurately reflects active filters across arrays, nested objects and special request-data entries, and now ignores non-filter keys (e.g., page URL) for clearer badge totals.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4686)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->