### PR TITLE
Fix empty source filter badge count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -26,6 +26,34 @@ import "./RequestSourceRow.css";
 
 const { Text } = Typography;
 
+const IGNORED_FILTER_BADGE_KEYS = new Set([GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL]);
+
+const hasAppliedFilterValue = (key, value) => {
+  if (key === GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.REQUEST_DATA) {
+    return Boolean(value?.key || value?.value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value).some(([nestedKey, nestedValue]) => hasAppliedFilterValue(nestedKey, nestedValue));
+  }
+
+  return Boolean(value);
+};
+
+const getAppliedFilterCount = (filters = {}) => {
+  return Object.entries(filters || {}).filter(([key, value]) => {
+    return !IGNORED_FILTER_BADGE_KEYS.has(key) && hasAppliedFilterValue(key, value);
+  }).length;
+};
+
 const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabled }) => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -72,12 +100,8 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
       return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+        ? getAppliedFilterCount(currentlySelectedRuleData.pairs[pairIndex].source.filters[0])
+        : getAppliedFilterCount(currentlySelectedRuleData.pairs[pairIndex].source.filters);
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -30,7 +30,9 @@ const IGNORED_FILTER_BADGE_KEYS = new Set([GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_T
 
 const hasAppliedFilterValue = (key, value) => {
   if (key === GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.REQUEST_DATA) {
-    return Boolean(value?.key || value?.value);
+    const payloadKey = typeof value?.key === "string" ? value.key.trim() : value?.key;
+    const payloadValue = typeof value?.value === "string" ? value.value.trim() : value?.value;
+    return Boolean(payloadKey || payloadValue);
   }
 
   if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary
- fixes the source filter badge count so empty filter values do not show as applied filters
- keeps the existing page URL exclusion from the badge count
- handles empty arrays, blank strings, empty nested objects, and request payload filters without key/value data

Fixes #3826

## Validation
- `git diff --check`
- Node smoke test for filter-count cases covering empty objects, empty arrays, request payload, page URL, and applied filters

Note: local app ESLint was not available in this checkout; no paid services were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate active source filter badge: counts only truly applied filters, ignores PAGE_URL, and correctly handles strings, arrays, nested objects, and request data entries to prevent inflated counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4688)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->