### PR TITLE
fix: keep edit description action out of description text

### DIFF
--- a/app/src/lib/design-system/components/RQEditorTitle/RQEditorTitle.css
+++ b/app/src/lib/design-system/components/RQEditorTitle/RQEditorTitle.css
@@ -92,6 +92,7 @@
   max-width: 600px;
 }
 .editor-description .edit-description-btn {
+  flex-shrink: 0;
   padding: 0;
   color: var(--text-gray);
   transition: 0.2s ease-in-out;

--- a/app/src/lib/design-system/components/RQEditorTitle/index.tsx
+++ b/app/src/lib/design-system/components/RQEditorTitle/index.tsx
@@ -128,34 +128,32 @@ export const RQEditorTitle: React.FC<TitleProps> = ({
               <div className="editor-description">
                 <Typography.Paragraph
                   disabled={disabled}
-                  style={{ width: "100%" }}
+                  style={{ flex: 1, minWidth: 0 }}
                   ellipsis={{
                     rows: 3,
                   }}
-                  editable={{
-                    icon:
-                      description.length > 0 ? (
-                        <RQButton
-                          disabled={disabled}
-                          onClick={() => {
-                            setIsDescriptionEditable(true);
-                          }}
-                          className="edit-description-btn"
-                          type="text"
-                        >
-                          Edit description
-                        </RQButton>
-                      ) : (
-                        <></>
-                      ),
-                    tooltip: false,
-                  }}
                   onClick={() => {
+                    if (disabled) {
+                      return;
+                    }
+
                     setIsDescriptionEditable(true);
                   }}
                 >
                   <span>{description ? description : descriptionPlaceholder}</span>
                 </Typography.Paragraph>
+                {description.length > 0 ? (
+                  <RQButton
+                    disabled={disabled}
+                    onClick={() => {
+                      setIsDescriptionEditable(true);
+                    }}
+                    className="edit-description-btn"
+                    type="text"
+                  >
+                    Edit description
+                  </RQButton>
+                ) : null}
               </div>
             )}
           </Row>


### PR DESCRIPTION
## Summary

- Move the `Edit description` action outside `Typography.Paragraph`.
- Keep the description text as the only content owned by the paragraph ellipsis logic.
- Prevent disabled description text from entering edit mode on click.

## Why

The edit action was passed as `Typography.Paragraph`'s `editable.icon`. Because that content is rendered as part of the typography editable affordance, the `Edit description` label can appear with the rule description text.

## Testing

- Not run locally; change is scoped to `RQEditorTitle` rendering.

Closes requestly/interceptor#34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edit description button layout to prevent unintended shrinking in flex containers.

* **User Interface**
  * Redesigned description editing interface with a dedicated edit button for improved clarity and interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4690)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->