### PR TITLE
Add Private Workspace to rule sharing

### DIFF
--- a/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
@@ -82,7 +82,7 @@ export const ShareFromWorkspace: React.FC<Props> = ({
   const handleTransferToOtherWorkspace = useCallback(
     (teamData: Workspace) => {
       setIsLoading(true);
-      duplicateRulesToTargetWorkspace(appMode, teamData.id!, selectedRules).then(() => {
+      duplicateRulesToTargetWorkspace(appMode, teamData.id, selectedRules).then(() => {
         setIsLoading(false);
         trackSharingModalRulesDuplicated("team", selectedRules.length);
         setPostShareViewData({

--- a/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
@@ -9,6 +9,8 @@ import { dummyPersonalWorkspace, getActiveWorkspace, getAllWorkspaces } from "st
 import { Workspace } from "features/workspaces/types";
 import WorkspaceAvatar from "features/workspaces/components/WorkspaceAvatar";
 
+const PRIVATE_WORKSPACE_KEY = "private_workspace";
+
 interface Props {
   /**
    * The default number of active workspaces to display before dropdown menu.
@@ -56,7 +58,7 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
       .map((team: Workspace, index: number) => {
         if (!defaultActiveWorkspaces && team?.id === activeWorkspace?.id) return null;
         return {
-          key: team.id ?? "private_workspace",
+          key: team.id ?? PRIVATE_WORKSPACE_KEY,
           label: <WorkspaceItem isLoading={isLoading} onTransferClick={onTransferClick} workspace={team} />,
         };
       })
@@ -93,7 +95,7 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
                 isLoading={isLoading}
                 workspace={team}
                 onTransferClick={onTransferClick}
-                key={team.id ?? "private_workspace"}
+                key={team.id ?? PRIVATE_WORKSPACE_KEY}
               />
             ))}
           </div>

--- a/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
@@ -5,7 +5,7 @@ import { RQButton } from "lib/design-system/components";
 import { MdOutlineKeyboardArrowDown } from "@react-icons/all-files/md/MdOutlineKeyboardArrowDown";
 import type { MenuProps } from "antd";
 import { trackShareModalWorkspaceDropdownClicked } from "modules/analytics/events/misc/sharing";
-import { getActiveWorkspace, getAllWorkspaces } from "store/slices/workspaces/selectors";
+import { dummyPersonalWorkspace, getActiveWorkspace, getAllWorkspaces } from "store/slices/workspaces/selectors";
 import { Workspace } from "features/workspaces/types";
 import WorkspaceAvatar from "features/workspaces/components/WorkspaceAvatar";
 
@@ -42,18 +42,26 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
     [filteredAvailableWorkspaces]
   );
 
+  const targetWorkspaces = useMemo(() => {
+    if (!activeWorkspace?.id) {
+      return sortedTeams;
+    }
+
+    return [dummyPersonalWorkspace, ...sortedTeams];
+  }, [activeWorkspace?.id, sortedTeams]);
+
   const menuItems: MenuProps["items"] = useMemo(() => {
-    return sortedTeams
+    return targetWorkspaces
       .slice(defaultActiveWorkspaces || 0)
       .map((team: Workspace, index: number) => {
         if (!defaultActiveWorkspaces && team?.id === activeWorkspace?.id) return null;
         return {
-          key: index,
+          key: team.id ?? "private_workspace",
           label: <WorkspaceItem isLoading={isLoading} onTransferClick={onTransferClick} workspace={team} />,
         };
       })
       .filter(Boolean);
-  }, [sortedTeams, activeWorkspace?.id, onTransferClick, defaultActiveWorkspaces, isLoading]);
+  }, [targetWorkspaces, activeWorkspace?.id, onTransferClick, defaultActiveWorkspaces, isLoading]);
 
   const chooseOtherWorkspaceItem = (
     <div className="workspace-share-menu-item-card workspace-share-menu-dropdown">
@@ -80,11 +88,16 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
       {defaultActiveWorkspaces ? (
         <>
           <div className="mt-1">
-            {sortedTeams.slice(0, defaultActiveWorkspaces).map((team: Workspace, index: number) => (
-              <WorkspaceItem isLoading={isLoading} workspace={team} onTransferClick={onTransferClick} key={index} />
+            {targetWorkspaces.slice(0, defaultActiveWorkspaces).map((team: Workspace) => (
+              <WorkspaceItem
+                isLoading={isLoading}
+                workspace={team}
+                onTransferClick={onTransferClick}
+                key={team.id ?? "private_workspace"}
+              />
             ))}
           </div>
-          {sortedTeams.length > defaultActiveWorkspaces && (
+          {targetWorkspaces.length > defaultActiveWorkspaces && (
             <Dropdown
               menu={{ items: menuItems }}
               placement="bottom"
@@ -103,13 +116,13 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
           menu={{ items: menuItems }}
           placement="bottom"
           overlayClassName="workspace-share-menu-wrapper"
-          trigger={filteredAvailableWorkspaces?.length > 1 ? ["click"] : undefined}
+          trigger={menuItems?.length ? ["click"] : undefined}
           onOpenChange={(open) => {
             if (open) trackShareModalWorkspaceDropdownClicked();
           }}
         >
           <div>
-            <WorkspaceItem workspace={activeWorkspace} showArrow availableWorkspaces={filteredAvailableWorkspaces} />
+            <WorkspaceItem workspace={activeWorkspace} showArrow availableWorkspaces={targetWorkspaces} />
           </div>
         </Dropdown>
       )}

--- a/app/src/components/common/SharingModal/actions.ts
+++ b/app/src/components/common/SharingModal/actions.ts
@@ -77,7 +77,7 @@ export const prepareContentToExport = (appMode: string, selectedRuleIds: string[
 
 export const duplicateRulesToTargetWorkspace = async (
   appMode: string,
-  workspaceId: string,
+  workspaceId: Workspace["id"],
   ruleIdsToShare: string[]
 ) => {
   const { rules, groups } = await getRulesAndGroupsFromRuleIds(appMode, ruleIdsToShare);

--- a/app/src/store/slices/workspaces/selectors.ts
+++ b/app/src/store/slices/workspaces/selectors.ts
@@ -29,6 +29,7 @@ export const getActiveWorkspaceIds = (state: RootState) => {
 export const dummyPersonalWorkspace: Workspace = {
   id: null,
   name: "Private Workspace",
+  accessCount: 1,
   membersCount: 1,
   workspaceType: WorkspaceType.PERSONAL,
 };


### PR DESCRIPTION
Fixes #3825.

This adds Private Workspace as a target in the rule sharing workspace menu when the current rule is being shared from a team workspace.

The implementation keeps the existing copy flow:
- the share menu now includes Private Workspace alongside other target workspaces
- selecting it passes a null workspace id, which is the existing private workspace identifier in the app
- the duplicate action accepts that workspace id type instead of forcing a non-null team id
- the Private Workspace stub now exposes the member count used by the menu item

Validation:
- npx --yes prettier@2.2.1 --check app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx app/src/components/common/SharingModal/actions.ts app/src/store/slices/workspaces/selectors.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved personal workspace handling in the sharing modal interface, ensuring consistent behavior and proper data integrity when transferring rules between workspaces.
  * Refined workspace selection logic with enhanced type safety to prevent inconsistencies during workspace transfer operations.

* **Refactor**
  * Optimized workspace list generation logic and improved overall code maintainability in the workspace sharing workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4691)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->