### PR TITLE
chore(pricing): redirect API Client product switcher to requestly.com/pricing

### DIFF
--- a/app/src/config/constants/sub/links.js
+++ b/app/src/config/constants/sub/links.js
@@ -6,12 +6,15 @@ const LINKS = {
 
   // Download
   REQUESTLY_DOWNLOAD_PAGE: getLinkWithMetadata("https://requestly.com/downloads"),
+  // Pricing page
+  REQUESTLY_PRICING_PAGE: "https://requestly.com/pricing",
+  // Docs
   REQUESTLY_DOCS: "https://docs.requestly.com/",
-  //Docs - Using Rules
+  // Docs - Using Rules
   REQUESTLY_DOCS_USING_RULES: "https://docs.requestly.com/general/http-rules/overview/",
-  //Docs -Sharing Rules
+  // Docs -Sharing Rules
   REQUESTLY_DOCS_SHARING_RULES: "https://docs.requestly.com/general/http-rules/sharing",
-  //Docs - File Service
+  // Docs - File Service
   REQUESTLY_DOCS_FILES_SERVICE: "https://docs.requestly.com/general/mock-server/overview",
 
   // Docs - Premium Subscription

--- a/app/src/features/pricing/components/ProductSwitcher/index.tsx
+++ b/app/src/features/pricing/components/ProductSwitcher/index.tsx
@@ -2,8 +2,11 @@ import { PRICING } from "features/pricing/constants/pricing";
 import { PRODUCT_FEATURES } from "features/pricing/constants/productFeatures";
 import React, { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { redirectToProductSpecificPricing } from "utils/RedirectionUtils";
+import { redirectToProductSpecificPricing, redirectToUrl } from "utils/RedirectionUtils";
+import APP_CONSTANTS from "config/constants";
 import "./productSwitcher.scss";
+
+const { LINKS } = APP_CONSTANTS;
 
 interface Props {
   activeProduct: string;
@@ -17,6 +20,10 @@ const ProductSwitcher: React.FC<Props> = ({ activeProduct, setActiveProduct, isO
   const productFromQuery = searchParams.get("product") ?? null;
 
   const productChangeHandler = (value: string) => {
+    if (value === PRICING.PRODUCTS.API_CLIENT) {
+      redirectToUrl(LINKS.REQUESTLY_PRICING_PAGE);
+      return;
+    }
     if (!isOpenedFromModal) redirectToProductSpecificPricing(navigate, value);
     setActiveProduct(value);
   };


### PR DESCRIPTION
# 📜 Summary of changes:

When users select the **API Client** product in the pricing page's product switcher, redirect them to the dedicated [requestly.com/pricing](https://requestly.com/pricing) page instead of showing in-app pricing for API Client.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selecting the API Client product now redirects to the pricing page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4696)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->