### PR TITLE
fix: ignore empty source filters in applied count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -26,6 +26,18 @@ import "./RequestSourceRow.css";
 
 const { Text } = Typography;
 
+const hasConfiguredFilterValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.some(hasConfiguredFilterValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(hasConfiguredFilterValue);
+  }
+
+  return value !== undefined && value !== null && value !== "";
+};
+
 const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabled }) => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -72,11 +84,13 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
       return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
+        ? Object.entries(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
+            ([key, value]) =>
+              key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL && hasConfiguredFilterValue(value)
           ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
+        : Object.entries(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
+            ([key, value]) =>
+              key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL && hasConfiguredFilterValue(value)
           ).length;
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]


### PR DESCRIPTION
## Summary
- Fix the source filter badge count so empty filter fields are not counted as applied filters.
- Keep `pageUrl` excluded from the count as before.

## Details
The previous implementation counted filter object keys, so empty arrays, empty strings, and empty nested filter objects could display `1 applied filter` even when no meaningful filter was configured. This change counts only filters with an actual configured value.

## Verification
- Ran `git diff --check`.
- Ran a small local Node assertion covering empty arrays/strings/nested objects and populated filters.

Fixes #3826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filter counts and badges now display only when filters have actual configured values, providing more accurate feedback on active filter settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4697)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->