### PR TITLE
fix: add missing API client icon tooltips

### DIFF
--- a/app/src/componentsV2/BottomSheet/BottomSheet.tsx
+++ b/app/src/componentsV2/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Tabs, TabsProps } from "antd";
+import { Tabs, TabsProps, Tooltip } from "antd";
 import { useBottomSheetContext } from "./context";
 import { BiDockRight } from "@react-icons/all-files/bi/BiDockRight";
 import { BiDockBottom } from "@react-icons/all-files/bi/BiDockBottom";
@@ -29,6 +29,7 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
   const { sheetPlacement, toggleBottomSheet, toggleSheetPlacement, isBottomSheetOpen } = useBottomSheetContext();
   const isSheetPlacedAtBottom = sheetPlacement === BottomSheetPlacement.BOTTOM;
   const isCollapsedSheetPlacedToRight = !isSheetPlacedAtBottom && !isBottomSheetOpen;
+  const dockTooltipTitle = isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom";
 
   const verticalTabExtraContent = (
     <div className="bottom-sheet-tab-extra-content">
@@ -38,14 +39,16 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
         {utilities}
 
         {disableDocking ? null : (
-          <RQButton
-            size="small"
-            type="transparent"
-            title="Toggle"
-            onClick={() => toggleSheetPlacement()}
-            className="bottom-sheet-toggle-btn"
-            icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-          />
+          <Tooltip title={dockTooltipTitle}>
+            <RQButton
+              size="small"
+              type="transparent"
+              aria-label={dockTooltipTitle}
+              onClick={() => toggleSheetPlacement()}
+              className="bottom-sheet-toggle-btn"
+              icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+            />
+          </Tooltip>
         )}
 
         <RQButton
@@ -82,14 +85,16 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
       </div>
     ),
     right: (
-      <RQButton
-        size="small"
-        type="transparent"
-        title="Toggle"
-        onClick={() => toggleSheetPlacement()}
-        className="bottom-sheet-toggle-btn"
-        icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-      />
+      <Tooltip title={dockTooltipTitle}>
+        <RQButton
+          size="small"
+          type="transparent"
+          aria-label={dockTooltipTitle}
+          onClick={() => toggleSheetPlacement()}
+          className="bottom-sheet-toggle-btn"
+          icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+        />
+      </Tooltip>
     ),
   };
 

--- a/app/src/componentsV2/CodeEditor/components/EditorV2/components/VariablePopOver/index.tsx
+++ b/app/src/componentsV2/CodeEditor/components/EditorV2/components/VariablePopOver/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from "react";
-import { Popover } from "antd";
+import { Popover, Tooltip } from "antd";
 import { EnvironmentVariableType, VariableScope } from "backend/environment/types";
 import type { VariableValueType } from "backend/environment/types";
 import { capitalize } from "lodash";
@@ -315,16 +315,18 @@ const VariableInfo: React.FC<{
         <span>{getScopeIcon(source.scope)}</span>
         <span className="variable-header-info-separator" />
         <div className="variable-info-header-name">{source.name}</div>
-        <RQButton
-          type="transparent"
-          size="small"
-          icon={<MdEdit className="edit-icon" />}
-          onClick={onEditClick}
-          className="edit-variable-btn"
-          hidden={!isValidPermission}
-        >
-          Edit
-        </RQButton>
+        <Tooltip title="Edit">
+          <RQButton
+            type="transparent"
+            size="small"
+            icon={<MdEdit className="edit-icon" />}
+            onClick={onEditClick}
+            className="edit-variable-btn"
+            hidden={!isValidPermission}
+          >
+            Edit
+          </RQButton>
+        </Tooltip>
       </div>
 
       <div className="variable-info-content-container">

--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Tabs, TabsProps, Typography, Popover } from "antd";
+import { Tabs, TabsProps, Typography, Popover, Tooltip } from "antd";
 import { TabItem } from "./TabItem";
 import { Outlet, unstable_useBlocker } from "react-router-dom";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdClose } from "@react-icons/all-files/md/MdClose";
+import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { IoIosArrowDown } from "@react-icons/all-files/io/IoIosArrowDown";
 import { useSetUrl } from "../hooks/useSetUrl";
 import { useCloseActiveTabShortcut } from "hooks/useCloseActiveTabShortcut";
@@ -161,9 +162,22 @@ export const TabsContainer: React.FC = () => {
         open={isMorePopoverOpen}
         onOpenChange={setIsMorePopoverOpen}
       >
-        <div className={`tabs-more-icon ${isMorePopoverOpen ? "tabs-more-icon-open" : ""}`}>
-          <IoIosArrowDown />
-        </div>
+        <Tooltip title="More actions">
+          <div
+            className={`tabs-more-icon ${isMorePopoverOpen ? "tabs-more-icon-open" : ""}`}
+            aria-label="More actions"
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setIsMorePopoverOpen((open) => !open);
+              }
+            }}
+          >
+            <IoIosArrowDown />
+          </div>
+        </Tooltip>
       </Popover>
     ),
     [isMorePopoverOpen, onTabItemClick]
@@ -312,6 +326,13 @@ export const TabsContainer: React.FC = () => {
         className="tabs-content"
         popupClassName="tabs-content-more-dropdown"
         size="small"
+        addIcon={
+          <Tooltip title="New request">
+            <span>
+              <MdAdd />
+            </span>
+          </Tooltip>
+        }
         onChange={(key) => {
           setActiveTab(key.toString());
         }}

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/ContextualEnvironmentsSidebar/ContextualEnvironmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/ContextualEnvironmentsSidebar/ContextualEnvironmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
@@ -273,13 +273,16 @@ export const EnvironmentsListItem: React.FC<EnvironmentsListItemProps> = ({
         <div onClick={(e) => e.stopPropagation()}>
           {!isGlobalEnvironment(environment.id) ? (
             <Dropdown menu={{ items: menuItems }} trigger={["click"]} placement="bottomRight">
-              <RQButton
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-                className="environment-list-item-dropdown-button"
-                onClick={(e) => e.stopPropagation()}
-              />
+              <Tooltip title="More actions">
+                <RQButton
+                  size="small"
+                  type="transparent"
+                  icon={<MdOutlineMoreHoriz />}
+                  aria-label="More actions"
+                  className="environment-list-item-dropdown-button"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </Tooltip>
             </Dropdown>
           ) : null}
         </div>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
 import { MdOutlineArrowForwardIos } from "@react-icons/all-files/md/MdOutlineArrowForwardIos";
-import { Collapse, Dropdown, MenuProps, Typography } from "antd";
+import { Collapse, Dropdown, MenuProps, Tooltip, Typography } from "antd";
 import { Conditional } from "components/common/Conditional";
 import { useRBAC } from "features/rbac";
 import { RQButton } from "lib/design-system-v2/components";
@@ -157,20 +157,23 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                     {showNewRecordBtn ? (
                       <>
                         {type === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-                          <RQButton
-                            size="small"
-                            type="transparent"
-                            icon={<MdAdd />}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onNewClickV2({
-                                contextId: workspaceId,
-                                analyticEventSource: "api_client_sidebar_header",
-                                recordType: RQAPI.RecordType.ENVIRONMENT,
-                                collectionId: undefined,
-                              });
-                            }}
-                          />
+                          <Tooltip title="New environment">
+                            <RQButton
+                              size="small"
+                              type="transparent"
+                              icon={<MdAdd />}
+                              aria-label="New environment"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onNewClickV2({
+                                  contextId: workspaceId,
+                                  analyticEventSource: "api_client_sidebar_header",
+                                  recordType: RQAPI.RecordType.ENVIRONMENT,
+                                  collectionId: undefined,
+                                });
+                              }}
+                            />
+                          </Tooltip>
                         ) : (
                           <NewApiRecordDropdown
                             invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
@@ -186,12 +189,15 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                               });
                             }}
                           >
-                            <RQButton
-                              size="small"
-                              type="transparent"
-                              icon={<MdAdd />}
-                              onClick={(e) => e.stopPropagation()}
-                            />
+                            <Tooltip title="New request or collection">
+                              <RQButton
+                                size="small"
+                                type="transparent"
+                                icon={<MdAdd />}
+                                aria-label="New request or collection"
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                            </Tooltip>
                           </NewApiRecordDropdown>
                         )}
                       </>
@@ -203,14 +209,17 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                       placement="bottomRight"
                       overlayClassName="collection-dropdown-menu"
                     >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
+                      <Tooltip title="More actions">
+                        <RQButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                          size="small"
+                          type="transparent"
+                          icon={<MdOutlineMoreHoriz />}
+                          aria-label="More actions"
+                        />
+                      </Tooltip>
                     </Dropdown>
                   </div>
                 </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
-import { Checkbox, Dropdown, MenuProps, Skeleton, Typography, notification } from "antd";
+import { Checkbox, Dropdown, MenuProps, Skeleton, Tooltip, Typography, notification } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQAPI as SharedRQAPI } from "@requestly/shared/types/entities/apiClient";
 import { RQButton } from "lib/design-system-v2/components";
@@ -493,7 +493,15 @@ export const CollectionRow: React.FC<Props> = ({
                         });
                       }}
                     >
-                      <RQButton size="small" type="transparent" icon={<MdAdd />} onClick={(e) => e.stopPropagation()} />
+                      <Tooltip title="New request or collection">
+                        <RQButton
+                          size="small"
+                          type="transparent"
+                          icon={<MdAdd />}
+                          aria-label="New request or collection"
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      </Tooltip>
                     </NewApiRecordDropdown>
                     <Dropdown
                       trigger={["click"]}
@@ -501,15 +509,18 @@ export const CollectionRow: React.FC<Props> = ({
                       placement="bottomRight"
                       overlayClassName="collection-dropdown-menu"
                     >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowSelection(false);
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
+                      <Tooltip title="More actions">
+                        <RQButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setShowSelection(false);
+                          }}
+                          size="small"
+                          type="transparent"
+                          icon={<MdOutlineMoreHoriz />}
+                          aria-label="More actions"
+                        />
+                      </Tooltip>
                     </Dropdown>
                   </div>
                 </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps } from "antd";
+import { Typography, Dropdown, MenuProps, Tooltip } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
@@ -275,14 +275,17 @@ export const ExampleRow: React.FC<Props> = ({ record, isReadOnly, handleRecordsT
               open={isDropdownVisible}
               onOpenChange={setIsDropdownVisible}
             >
-              <RQButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-              />
+              <Tooltip title="More actions">
+                <RQButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  size="small"
+                  type="transparent"
+                  icon={<MdOutlineMoreHoriz />}
+                  aria-label="More actions"
+                />
+              </Tooltip>
             </Dropdown>
           </div>
         </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps, Checkbox, notification } from "antd";
+import { Typography, Dropdown, MenuProps, Checkbox, Tooltip, notification } from "antd";
 import { REQUEST_METHOD_BACKGROUND_COLORS, REQUEST_METHOD_COLORS } from "../../../../../../../../../constants";
 import { RequestMethod, RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
@@ -500,15 +500,18 @@ export const RequestRow: React.FC<Props> = ({
             open={isDropdownVisible}
             onOpenChange={handleDropdownVisibleChange}
           >
-            <RQButton
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowSelection(false);
-              }}
-              size="small"
-              type="transparent"
-              icon={<MdOutlineMoreHoriz />}
-            />
+            <Tooltip title="More actions">
+              <RQButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowSelection(false);
+                }}
+                size="small"
+                type="transparent"
+                icon={<MdOutlineMoreHoriz />}
+                aria-label="More actions"
+              />
+            </Tooltip>
           </Dropdown>
         </div>
       </Conditional>
@@ -646,15 +649,18 @@ export const RequestRow: React.FC<Props> = ({
                   open={isDropdownVisible}
                   onOpenChange={handleDropdownVisibleChange}
                 >
-                  <RQButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowSelection(false);
-                    }}
-                    size="small"
-                    type="transparent"
-                    icon={<MdOutlineMoreHoriz />}
-                  />
+                  <Tooltip title="More actions">
+                    <RQButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowSelection(false);
+                      }}
+                      size="small"
+                      type="transparent"
+                      icon={<MdOutlineMoreHoriz />}
+                      aria-label="More actions"
+                    />
+                  </Tooltip>
                 </Dropdown>
               </div>
             </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
@@ -55,16 +55,18 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
 
       {listType ? (
         listType === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-          <RQButton
-            size="small"
-            type="transparent"
-            icon={<MdAdd />}
-            title="Create new environment"
-            className="sidebar-list-header-button"
-            onClick={() => {
-              onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
-            }}
-          />
+          <Tooltip title="New environment">
+            <RQButton
+              size="small"
+              type="transparent"
+              icon={<MdAdd />}
+              aria-label="New environment"
+              className="sidebar-list-header-button"
+              onClick={() => {
+                onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
+              }}
+            />
+          </Tooltip>
         ) : null
       ) : (
         showNewRecordAction && (
@@ -74,7 +76,15 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
               onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
             }}
           >
-            <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            <Tooltip title="New request or collection">
+              <RQButton
+                size="small"
+                type="transparent"
+                icon={<MdAdd />}
+                aria-label="New request or collection"
+                className="sidebar-list-header-button"
+              />
+            </Tooltip>
           </NewApiRecordDropdown>
         )
       )}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -260,13 +260,16 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
           }
 
           return (
-            <RQButton
-              className="key-value-delete-btn"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title="Delete">
+              <RQButton
+                className="key-value-delete-btn"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                aria-label="Delete"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dropdown, Checkbox } from "antd";
+import { Dropdown, Checkbox, Tooltip } from "antd";
 import { MdMoreHoriz } from "@react-icons/all-files/md/MdMoreHoriz";
 import { RQButton } from "lib/design-system-v2/components";
 
@@ -33,7 +33,15 @@ export const KeyValueTableSettingsDropdown: React.FC<KeyValueTableSettingsDropdo
   return (
     <div className="key-value-settings-header">
       <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
-        <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
+        <Tooltip title="More actions">
+          <RQButton
+            type="transparent"
+            size="small"
+            icon={<MdMoreHoriz />}
+            aria-label="More actions"
+            className="key-value-settings-icon"
+          />
+        </Tooltip>
       </Dropdown>
     </div>
   );

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
@@ -3,7 +3,7 @@ import { FormDropDownOptions, RQAPI } from "features/apiClient/types";
 import React, { useCallback, useMemo } from "react";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
-import { TableProps } from "antd";
+import { TableProps, Tooltip } from "antd";
 import { RiDeleteBin6Line } from "@react-icons/all-files/ri/RiDeleteBin6Line";
 import { MultiEditableCell, MultiEditableRow } from "./MultipartFormRowTable";
 import "./MultiPartFormTable.scss";
@@ -158,13 +158,16 @@ export const MultipartFormTable: React.FC<KeyValueTableProps> = ({
             return null;
           }
           return (
-            <RQButton
-              className="key-value-delete-icon"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title="Delete">
+              <RQButton
+                className="key-value-delete-icon"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                aria-label="Delete"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },


### PR DESCRIPTION
## Issue
Closes #3868

## Summary
Adds missing tooltips and accessible labels to API client icon-only controls called out in the issue, including:

- `New request or collection` for collection/sidebar add actions
- `New environment` for environment add actions
- `New request` for the tab add action
- `Dock to right` / `Dock to bottom` for the response panel dock toggle
- `More actions` for overflow/action menu buttons
- `Delete` for key-value table delete buttons
- `Edit` for the variable popover edit action

## Verification
- [x] `git diff --check`
- [x] Confirmed tooltip/aria-label copy is present in the changed API client controls

## Notes
I could not run the full app build locally in this environment because this checkout does not have `node_modules` installed.