### PR TITLE
fix: improve API Client breadcrumb navigation

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/ApiClientBreadCrumb.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/ApiClientBreadCrumb.tsx
@@ -15,6 +15,7 @@ import {
 } from "features/apiClient/slices";
 import { WorkspaceType } from "features/workspaces/types";
 import { HiOutlineDocument } from "@react-icons/all-files/hi/HiOutlineDocument";
+import { buildParentCollectionBreadcrumbs } from "./apiClientBreadcrumbUtils.mjs";
 import "./ApiClientBreadCrumb.scss";
 
 interface Props {
@@ -53,16 +54,22 @@ export const MultiViewBreadCrumb: React.FC<Props> = ({ ...props }) => {
 
   const truncatePath = truncateString(localWsPath, 40);
 
-  const parentCollectionNames = useMemo(() => {
-    return ancestorRecords
-      .slice()
-      .reverse()
-      .map((record) => ({
-        label: record?.name,
-        pathname: "",
-        isEditable: false,
-      }));
+  const parentCollectionBreadcrumbs = useMemo(() => {
+    return buildParentCollectionBreadcrumbs(ancestorRecords, PATHS.API_CLIENT.INDEX);
   }, [ancestorRecords]);
+
+  const workspaceBreadcrumbLabel = localWsPath ? (
+    <div>
+      <Tooltip trigger="hover" title={localWsPath} color="var(--requestly-color-black)" placement="bottom">
+        <span className="api-client-local-workspace-path-breadcrumb">
+          <LuFolderCog className="api-client-local-workspace-icon" />
+          {truncatePath}
+        </span>
+      </Tooltip>
+    </div>
+  ) : (
+    "API Client"
+  );
 
   return (
     <RQBreadcrumb
@@ -73,22 +80,11 @@ export const MultiViewBreadCrumb: React.FC<Props> = ({ ...props }) => {
       autoFocus={autoFocus}
       defaultBreadcrumbs={[
         {
-          label: (
-            <Conditional condition={!!truncatePath}>
-              <div>
-                <Tooltip trigger="hover" title={localWsPath} color="var(--requestly-color-black)" placement="bottom">
-                  <span className="api-client-local-workspace-path-breadcrumb">
-                    <LuFolderCog className="api-client-local-workspace-icon" />
-                    {truncatePath}
-                  </span>
-                </Tooltip>
-              </div>
-            </Conditional>
-          ),
+          label: workspaceBreadcrumbLabel,
           pathname: PATHS.API_CLIENT.INDEX,
           isEditable: false,
         },
-        ...parentCollectionNames,
+        ...parentCollectionBreadcrumbs,
         {
           isEditable: breadCrumbType === BreadcrumbType.API_REQUEST ? !isHistoryPath : true,
           pathname: window.location.pathname,

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.mjs
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.mjs
@@ -1,0 +1,18 @@
+export const getApiClientCollectionPath = (apiClientRootPath, collectionId) => {
+  const normalizedRootPath = (apiClientRootPath || "/api-client").replace(/\/+$/, "") || "/";
+  const collectionPathPrefix = normalizedRootPath === "/" ? "/collection" : `${normalizedRootPath}/collection`;
+
+  return `${collectionPathPrefix}/${encodeURIComponent(collectionId)}`;
+};
+
+export const buildParentCollectionBreadcrumbs = (ancestorRecords, apiClientRootPath) => {
+  return (ancestorRecords ?? [])
+    .slice()
+    .reverse()
+    .filter((record) => record?.id)
+    .map((record) => ({
+      label: record?.name || "Untitled collection",
+      pathname: getApiClientCollectionPath(apiClientRootPath, record.id),
+      isEditable: false,
+    }));
+};

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.mjs
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.mjs
@@ -9,7 +9,7 @@ export const buildParentCollectionBreadcrumbs = (ancestorRecords, apiClientRootP
   return (ancestorRecords ?? [])
     .slice()
     .reverse()
-    .filter((record) => record?.id)
+    .filter((record) => record?.id !== undefined && record?.id !== null && record.id !== "")
     .map((record) => ({
       label: record?.name || "Untitled collection",
       pathname: getApiClientCollectionPath(apiClientRootPath, record.id),

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.test.mjs
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+
+import { buildParentCollectionBreadcrumbs, getApiClientCollectionPath } from "./apiClientBreadcrumbUtils.mjs";
+
+const { test, expect } = await (async () => {
+  try {
+    const vitest = await import("vitest");
+    return { test: vitest.test, expect: vitest.expect };
+  } catch {
+    const nodeTest = await import("node:test");
+    return {
+      test: nodeTest.test,
+      expect: (actual) => ({
+        toEqual: (expected) => assert.deepEqual(actual, expected),
+        toBe: (expected) => assert.equal(actual, expected),
+      }),
+    };
+  }
+})();
+
+test("builds routable parent collection breadcrumbs from root to leaf", () => {
+  const breadcrumbs = buildParentCollectionBreadcrumbs(
+    [
+      { id: "leaf collection", name: "Leaf" },
+      { id: "root collection", name: "Root" },
+    ],
+    "/api-client"
+  );
+
+  expect(breadcrumbs).toEqual([
+    {
+      label: "Root",
+      pathname: "/api-client/collection/root%20collection",
+      isEditable: false,
+    },
+    {
+      label: "Leaf",
+      pathname: "/api-client/collection/leaf%20collection",
+      isEditable: false,
+    },
+  ]);
+});
+
+test("falls back to a stable label for unnamed parent collections", () => {
+  expect(buildParentCollectionBreadcrumbs([{ id: "collection-1", name: "" }], "/api-client")).toEqual([
+    {
+      label: "Untitled collection",
+      pathname: "/api-client/collection/collection-1",
+      isEditable: false,
+    },
+  ]);
+});
+
+test("uses the API client collection route for collection ids", () => {
+  expect(getApiClientCollectionPath("/api-client", "parent/child")).toBe("/api-client/collection/parent%2Fchild");
+});
+
+test("normalizes trailing slashes in the API client root path", () => {
+  expect(getApiClientCollectionPath("/api-client/", "collection-1")).toBe("/api-client/collection/collection-1");
+});

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.test.mjs
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.test.mjs
@@ -55,6 +55,16 @@ test("uses the API client collection route for collection ids", () => {
   expect(getApiClientCollectionPath("/api-client", "parent/child")).toBe("/api-client/collection/parent%2Fchild");
 });
 
+test("keeps numeric zero collection ids when building parent breadcrumbs", () => {
+  expect(buildParentCollectionBreadcrumbs([{ id: 0, name: "Root" }], "/api-client")).toEqual([
+    {
+      label: "Root",
+      pathname: "/api-client/collection/0",
+      isEditable: false,
+    },
+  ]);
+});
+
 test("normalizes trailing slashes in the API client root path", () => {
   expect(getApiClientCollectionPath("/api-client/", "collection-1")).toBe("/api-client/collection/collection-1");
 });


### PR DESCRIPTION
Fixes #3623

Closes issue: https://github.com/requestly/requestly/issues/3623

## Summary of changes:

- API Client parent collection breadcrumbs now link to generated collection routes instead of empty pathnames.
- Non-local workspace views keep a visible API Client root breadcrumb.
- Breadcrumb route generation is covered by focused unit tests, including encoded IDs, fallback labels, root path normalization, and numeric zero IDs.

## Demo Video:

**Video/Demo:** Not applicable. This is a targeted breadcrumb routing fix with no visual styling change. The behavior can be verified by opening a nested API Client collection and clicking parent collection breadcrumbs; the parent breadcrumb should route back to that collection.

## Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [x] For UI changes, added/updated analytics events (if applicable). Not applicable; no new analytics event is introduced.
- [ ] For changes in extension's code, manually tested in Chrome and Firefox. Not applicable; this change is scoped to API Client breadcrumb routing.
- [x] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists). Not applicable; no documentation page exists for this internal breadcrumb behavior.
- [x] **Added demo video showing the changes in action** (if applicable). Not applicable for this non-visual route-generation fix.

## Test instructions:

1. Run:

   ```bash
   node --test app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.test.mjs
   ```

2. Run:

   ```bash
   node --check app/src/features/apiClient/screens/apiClient/components/views/components/ApiClientBreadCrumb/apiClientBreadcrumbUtils.mjs
   ```

3. Manual verification path for reviewers:
   - Open the API Client.
   - Open a request inside a collection that has parent collections.
   - Confirm the API Client root breadcrumb is visible for non-local workspace views.
   - Click a parent collection breadcrumb and confirm it navigates to the parent collection route.

## Other references:

- CodeRabbit's numeric zero ID comment was addressed by preserving collection IDs that are `0` while still filtering missing IDs.
