### PR TITLE
fix: ignore empty source filters in badge count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -22,6 +22,7 @@ import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
+import { getSourceFilterCount } from "./sourceFilterUtils.mjs";
 import "./RequestSourceRow.css";
 
 const { Text } = Typography;
@@ -70,16 +71,9 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      return getSourceFilterCount(currentlySelectedRuleData.pairs[pairIndex].source.filters);
     },
-    [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
+    [currentlySelectedRuleData]
   );
 
   const sourceKeys = useMemo(

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/sourceFilterUtils.mjs
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/sourceFilterUtils.mjs
@@ -1,0 +1,29 @@
+const LEGACY_PAGE_URL_FILTER = "pageUrl";
+
+const isConfiguredFilterValue = (value) => {
+  if (value === null || typeof value === "undefined") {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(isConfiguredFilterValue);
+  }
+
+  if (typeof value === "object") {
+    return Object.values(value).some(isConfiguredFilterValue);
+  }
+
+  if (typeof value === "string") {
+    return value.trim() !== "";
+  }
+
+  return true;
+};
+
+export const getSourceFilterCount = (sourceFilters) => {
+  const sourceFilter = Array.isArray(sourceFilters) ? sourceFilters[0] : sourceFilters;
+
+  return Object.entries(sourceFilter || {}).filter(
+    ([key, value]) => key !== LEGACY_PAGE_URL_FILTER && isConfiguredFilterValue(value)
+  ).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/sourceFilterUtils.test.mjs
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/sourceFilterUtils.test.mjs
@@ -21,6 +21,11 @@ test("does not count an empty upgraded source filter object", () => {
   expect(getSourceFilterCount([{}])).toBe(0);
 });
 
+test("handles missing source filters", () => {
+  expect(getSourceFilterCount(null)).toBe(0);
+  expect(getSourceFilterCount(undefined)).toBe(0);
+});
+
 test("does not count empty source filter values", () => {
   expect(
     getSourceFilterCount([
@@ -29,6 +34,18 @@ test("does not count empty source filter values", () => {
         resourceType: [],
         requestMethod: [],
         requestPayload: {},
+      },
+    ])
+  ).toBe(0);
+});
+
+test("does not count whitespace-only source filter values", () => {
+  expect(
+    getSourceFilterCount([
+      {
+        pageDomains: ["   "],
+        requestMethod: ["\t"],
+        requestPayload: { key: "\n" },
       },
     ])
   ).toBe(0);
@@ -55,6 +72,32 @@ test("counts configured source filters", () => {
       },
     ])
   ).toBe(4);
+});
+
+test("counts configured filters mixed with empty filters", () => {
+  expect(
+    getSourceFilterCount([
+      {
+        pageDomains: ["", "example.com"],
+        resourceType: [],
+        requestMethod: ["  ", "POST"],
+        requestPayload: { key: "", value: "operationName" },
+      },
+    ])
+  ).toBe(3);
+});
+
+test("counts deeply nested configured filter values only", () => {
+  expect(
+    getSourceFilterCount([
+      {
+        requestPayload: {
+          all: [{ key: "" }, { nested: { value: "userId" } }],
+        },
+        resourceType: [{ values: [] }],
+      },
+    ])
+  ).toBe(1);
 });
 
 test("counts legacy source filter objects", () => {

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/sourceFilterUtils.test.mjs
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/sourceFilterUtils.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+
+import { getSourceFilterCount } from "./sourceFilterUtils.mjs";
+
+const { test, expect } = await (async () => {
+  try {
+    const vitest = await import("vitest");
+    return { test: vitest.test, expect: vitest.expect };
+  } catch {
+    const nodeTest = await import("node:test");
+    return {
+      test: nodeTest.test,
+      expect: (actual) => ({
+        toBe: (expected) => assert.strictEqual(actual, expected),
+      }),
+    };
+  }
+})();
+
+test("does not count an empty upgraded source filter object", () => {
+  expect(getSourceFilterCount([{}])).toBe(0);
+});
+
+test("does not count empty source filter values", () => {
+  expect(
+    getSourceFilterCount([
+      {
+        pageDomains: [],
+        resourceType: [],
+        requestMethod: [],
+        requestPayload: {},
+      },
+    ])
+  ).toBe(0);
+});
+
+test("ignores legacy pageUrl when counting source filters", () => {
+  expect(
+    getSourceFilterCount([
+      {
+        pageUrl: { operator: "Contains", value: "example.com" },
+      },
+    ])
+  ).toBe(0);
+});
+
+test("counts configured source filters", () => {
+  expect(
+    getSourceFilterCount([
+      {
+        pageDomains: ["example.com"],
+        resourceType: ["xmlhttprequest"],
+        requestMethod: ["POST"],
+        requestPayload: { key: "operationName" },
+      },
+    ])
+  ).toBe(4);
+});
+
+test("counts legacy source filter objects", () => {
+  expect(
+    getSourceFilterCount({
+      requestMethod: ["GET"],
+      pageUrl: { operator: "Contains", value: "example.com" },
+    })
+  ).toBe(1);
+});


### PR DESCRIPTION
Closes issue: https://github.com/requestly/requestly/issues/3826

## Summary of changes:

- Extracted source filter badge counting into a small tested helper.
- Ignore empty source filter values such as {}, [], and blank strings when deciding whether to show the applied filter badge.
- Preserve counting for configured filters and continue ignoring legacy pageUrl entries.

## Demo Video:

**Video/Demo:** Not applicable for this focused logic fix. The regression is covered by a targeted unit test for the badge count helper.

## Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [x] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## Test instructions:

`ash
node --test app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/sourceFilterUtils.test.mjs
node --check app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/sourceFilterUtils.mjs
git diff --check
`

## Other references:

- The regression test covers imported/shared rules whose upgraded source.filters contains an empty filter object or empty filter fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized source-filter counting into a reusable utility to improve accuracy and handle both current and legacy filter formats.

* **Tests**
  * Added unit tests covering empty/unconfigured filters, legacy entries, nested values, and correct counting of configured filters to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->