### PR TITLE
Fix saving intercepted requests to API collection

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/apiClientCurlImportState.mjs
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/apiClientCurlImportState.mjs
@@ -1,0 +1,9 @@
+const API_CLIENT_CURL_IMPORT_MODAL = "CURL";
+const TRAFFIC_TABLE_IMPORT_SOURCE = "traffic_table";
+
+export const getApiClientCurlImportState = (log = {}) => ({
+  modal: API_CLIENT_CURL_IMPORT_MODAL,
+  curlCommand: log.requestShellCurl || "",
+  source: TRAFFIC_TABLE_IMPORT_SOURCE,
+  pageURL: log.url || "",
+});

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/apiClientCurlImportState.test.mjs
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/apiClientCurlImportState.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+
+import { getApiClientCurlImportState } from "./apiClientCurlImportState.mjs";
+
+const { test, expect } = await (async () => {
+  const isVitestRuntime =
+    typeof globalThis.vitest !== "undefined" ||
+    typeof import.meta.vitest !== "undefined" ||
+    (typeof process !== "undefined" && process.env?.VITEST === "true");
+
+  if (isVitestRuntime) {
+    const vitest = await import("vitest");
+    return { test: vitest.test, expect: vitest.expect };
+  }
+
+  const nodeTest = await import("node:test");
+  return {
+    test: nodeTest.test,
+    expect: (actual) => ({
+      toEqual: (expected) => assert.deepStrictEqual(actual, expected),
+    }),
+  };
+})();
+
+test("builds API Client cURL import state from a traffic log", () => {
+  expect(
+    getApiClientCurlImportState({
+      requestShellCurl: "curl https://example.com/users -H 'x-test: 1'",
+      url: "https://example.com/users",
+    })
+  ).toEqual({
+    modal: "CURL",
+    curlCommand: "curl https://example.com/users -H 'x-test: 1'",
+    source: "traffic_table",
+    pageURL: "https://example.com/users",
+  });
+});
+
+test("uses empty strings when traffic log fields are unavailable", () => {
+  expect(getApiClientCurlImportState({})).toEqual({
+    modal: "CURL",
+    curlCommand: "",
+    source: "traffic_table",
+    pageURL: "",
+  });
+});

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/index.tsx
@@ -1,8 +1,10 @@
 import React, { ReactNode, useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 import type { MenuProps } from "antd";
 import { Dropdown } from "antd";
 import { copyToClipBoard } from "../../../../../../../../utils/Misc";
+import PATHS from "config/constants/sub/paths";
 import { globalActions } from "store/slices/global/slice";
 import { getIsTrafficTableTourCompleted } from "store/selectors";
 import { trackRuleCreationWorkflowStartedEvent } from "modules/analytics/events/common/rules";
@@ -22,6 +24,7 @@ import { useCheckLocalSyncSupport } from "features/apiClient/helpers/modules/syn
 import { LocalWorkspaceTooltip } from "features/apiClient/screens/apiClient/components/views/components/LocalWorkspaceTooltip/LocalWorkspaceTooltip";
 import { TOUR_TYPES } from "components/misc/ProductWalkthrough/types";
 import { RQNetworkLog } from "../../../TrafficExporter/harLogs/types";
+import { getApiClientCurlImportState } from "./apiClientCurlImportState.mjs";
 
 interface ContextMenuProps {
   log: RQNetworkLog;
@@ -31,6 +34,7 @@ interface ContextMenuProps {
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({ children, log, onReplayRequest }) => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const isTrafficTableTourCompleted = useSelector(getIsTrafficTableTourCompleted);
   const selectedRequestResponse = useSelector(getLogResponseById(log?.id)) || log?.response?.body;
   const isLocalSyncEnabled = useCheckLocalSyncSupport();
@@ -150,15 +154,33 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ children, log, onRepla
     ];
 
     if (isFeatureCompatible(FEATURES.API_CLIENT)) {
-      menuItems.splice(2, 0, {
-        key: "replay_request",
-        label: "Edit and Replay",
-        onClick: () => {
-          trackTrafficTableDropdownClicked("replay_request");
-          trackRQDesktopLastActivity(TRAFFIC_TABLE.TRAFFIC_TABLE_REQUEST_DROPDOWN_CLICKED);
-          onReplayRequest();
+      const apiClientMenuItems: MenuProps["items"] = [
+        {
+          key: "replay_request",
+          label: "Edit and Replay",
+          onClick: () => {
+            trackTrafficTableDropdownClicked("replay_request");
+            trackRQDesktopLastActivity(TRAFFIC_TABLE.TRAFFIC_TABLE_REQUEST_DROPDOWN_CLICKED);
+            onReplayRequest();
+          },
         },
-      });
+      ];
+
+      if (log.requestShellCurl) {
+        apiClientMenuItems.unshift({
+          key: "save_to_api_collection",
+          label: "Save to API Collection",
+          onClick: () => {
+            trackTrafficTableDropdownClicked("save_to_api_collection");
+            trackRQDesktopLastActivity(TRAFFIC_TABLE.TRAFFIC_TABLE_REQUEST_DROPDOWN_CLICKED);
+            navigate(PATHS.API_CLIENT.ABSOLUTE, {
+              state: getApiClientCurlImportState(log),
+            });
+          },
+        });
+      }
+
+      menuItems.splice(2, 0, ...apiClientMenuItems);
     }
 
     if (!log.requestShellCurl) {
@@ -166,7 +188,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ children, log, onRepla
     }
 
     return menuItems;
-  }, [log, onReplayRequest, handleOnClick, isLocalSyncEnabled]);
+  }, [log, onReplayRequest, handleOnClick, isLocalSyncEnabled, navigate]);
 
   const handleDropdownOpenChange = (open: boolean) => {
     if (open) {

--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -150,6 +150,20 @@ export const TabsContainer: React.FC = () => {
     [setActiveTab]
   );
 
+  const toggleMorePopover = useCallback(() => {
+    setIsMorePopoverOpen((isOpen) => !isOpen);
+  }, []);
+
+  const onMorePopoverKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        toggleMorePopover();
+      }
+    },
+    [toggleMorePopover]
+  );
+
   const operations = useMemo(
     () => (
       <Popover
@@ -161,12 +175,21 @@ export const TabsContainer: React.FC = () => {
         open={isMorePopoverOpen}
         onOpenChange={setIsMorePopoverOpen}
       >
-        <div className={`tabs-more-icon ${isMorePopoverOpen ? "tabs-more-icon-open" : ""}`}>
+        <div
+          className={`tabs-more-icon ${isMorePopoverOpen ? "tabs-more-icon-open" : ""}`}
+          role="button"
+          tabIndex={0}
+          aria-label="More actions"
+          aria-haspopup="menu"
+          aria-expanded={isMorePopoverOpen}
+          onClick={toggleMorePopover}
+          onKeyDown={onMorePopoverKeyDown}
+        >
           <IoIosArrowDown />
         </div>
       </Popover>
     ),
-    [isMorePopoverOpen, onTabItemClick]
+    [isMorePopoverOpen, onMorePopoverKeyDown, onTabItemClick, toggleMorePopover]
   );
 
   // Reset popover state when no tabs are present

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/MultiWorkspaceSidebar.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/MultiWorkspaceSidebar.tsx
@@ -229,6 +229,9 @@ export const MultiWorkspaceSidebar: React.FC = () => {
       </div>
 
       <ImportFromCurlModal
+        initialCurlCommand={state?.curlCommand}
+        source={state?.source || ""}
+        pageURL={state?.pageURL || ""}
         isRequestLoading={isLoading}
         isOpen={isImportModalOpen}
         handleImportRequest={handleImportRequest}


### PR DESCRIPTION
Fixes requestly/interceptor#43

## Summary
- Add a **Save to API Collection** action to the HTTP Interceptor traffic table context menu when a captured request has a cURL command.
- Reuse the existing API Client cURL import flow by opening the importer with the selected request prefilled.
- Preserve the same prefilled import state in the multi-workspace API Client sidebar.

## Test plan
- `node --test app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/apiClientCurlImportState.test.mjs`
- `node --check app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/ContextMenu/apiClientCurlImportState.mjs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import captured cURL into the API client from the network inspector context menu; opens the API client with pre-filled command, source, and page URL (missing fields default to empty).
  * Context menu adds an API-client submenu item for saving/importing requests.
  * Tabs “More actions” popover now supports keyboard toggling and improved focusability for accessibility.

* **Tests**
  * Added tests for import-state construction and default fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->