### PR TITLE
fix: add missing API client icon tooltips

### DIFF
--- a/app/src/componentsV2/BottomSheet/BottomSheet.tsx
+++ b/app/src/componentsV2/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Tabs, TabsProps } from "antd";
+import { Tabs, TabsProps, Tooltip } from "antd";
 import { useBottomSheetContext } from "./context";
 import { BiDockRight } from "@react-icons/all-files/bi/BiDockRight";
 import { BiDockBottom } from "@react-icons/all-files/bi/BiDockBottom";
@@ -38,14 +38,15 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
         {utilities}
 
         {disableDocking ? null : (
-          <RQButton
-            size="small"
-            type="transparent"
-            title="Toggle"
-            onClick={() => toggleSheetPlacement()}
-            className="bottom-sheet-toggle-btn"
-            icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-          />
+          <Tooltip title={isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom"} color="#000">
+            <RQButton
+              size="small"
+              type="transparent"
+              onClick={() => toggleSheetPlacement()}
+              className="bottom-sheet-toggle-btn"
+              icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+            />
+          </Tooltip>
         )}
 
         <RQButton
@@ -82,14 +83,15 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
       </div>
     ),
     right: (
-      <RQButton
-        size="small"
-        type="transparent"
-        title="Toggle"
-        onClick={() => toggleSheetPlacement()}
-        className="bottom-sheet-toggle-btn"
-        icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-      />
+      <Tooltip title={isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom"} color="#000">
+        <RQButton
+          size="small"
+          type="transparent"
+          onClick={() => toggleSheetPlacement()}
+          className="bottom-sheet-toggle-btn"
+          icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+        />
+      </Tooltip>
     ),
   };
 

--- a/app/src/componentsV2/InlineInput/InlineInput.tsx
+++ b/app/src/componentsV2/InlineInput/InlineInput.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Row, Input, Typography } from "antd";
+import { Row, Input, Typography, Tooltip } from "antd";
 import { MdOutlineEdit } from "@react-icons/all-files/md/MdOutlineEdit";
 import "./inlineInput.scss";
 
@@ -67,10 +67,12 @@ export const InlineInput: React.FC<Props> = ({
               {value || placeholder}
             </Typography.Text>
             {!disabled && (
-              <MdOutlineEdit
-                className={`${textarea ? "align-self-start" : "align-self-center"}`}
-                onClick={() => setIsEditable(true)}
-              />
+              <Tooltip title="Edit" color="#000">
+                <MdOutlineEdit
+                  className={`${textarea ? "align-self-start" : "align-self-center"}`}
+                  onClick={() => setIsEditable(true)}
+                />
+              </Tooltip>
             )}
           </div>
         )}

--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Tabs, TabsProps, Typography, Popover } from "antd";
+import { Tabs, TabsProps, Typography, Popover, Tooltip } from "antd";
 import { TabItem } from "./TabItem";
 import { Outlet, unstable_useBlocker } from "react-router-dom";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdClose } from "@react-icons/all-files/md/MdClose";
+import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { IoIosArrowDown } from "@react-icons/all-files/io/IoIosArrowDown";
 import { useSetUrl } from "../hooks/useSetUrl";
 import { useCloseActiveTabShortcut } from "hooks/useCloseActiveTabShortcut";
@@ -312,6 +313,13 @@ export const TabsContainer: React.FC = () => {
         className="tabs-content"
         popupClassName="tabs-content-more-dropdown"
         size="small"
+        addIcon={
+          <Tooltip title="New request" color="#000">
+            <span>
+              <MdAdd />
+            </span>
+          </Tooltip>
+        }
         onChange={(key) => {
           setActiveTab(key.toString());
         }}

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/ContextualEnvironmentsSidebar/ContextualEnvironmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/ContextualEnvironmentsSidebar/ContextualEnvironmentsList/components/environmentsListItem/EnvironmentsListItem.tsx
@@ -273,13 +273,15 @@ export const EnvironmentsListItem: React.FC<EnvironmentsListItemProps> = ({
         <div onClick={(e) => e.stopPropagation()}>
           {!isGlobalEnvironment(environment.id) ? (
             <Dropdown menu={{ items: menuItems }} trigger={["click"]} placement="bottomRight">
-              <RQButton
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-                className="environment-list-item-dropdown-button"
-                onClick={(e) => e.stopPropagation()}
-              />
+              <Tooltip title="More actions" color="#000">
+                <RQButton
+                  size="small"
+                  type="transparent"
+                  icon={<MdOutlineMoreHoriz />}
+                  className="environment-list-item-dropdown-button"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </Tooltip>
             </Dropdown>
           ) : null}
         </div>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
 import { MdOutlineArrowForwardIos } from "@react-icons/all-files/md/MdOutlineArrowForwardIos";
-import { Collapse, Dropdown, MenuProps, Typography } from "antd";
+import { Collapse, Dropdown, MenuProps, Typography, Tooltip } from "antd";
 import { Conditional } from "components/common/Conditional";
 import { useRBAC } from "features/rbac";
 import { RQButton } from "lib/design-system-v2/components";
@@ -63,12 +63,8 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
   const user = useSelector(getUserAuthDetails);
   const userId = user?.details?.profile?.uid;
 
-  const {
-    handleWorkspaceSwitch,
-    confirmWorkspaceSwitch,
-    isWorkspaceLoading,
-    setIsWorkspaceLoading,
-  } = useWorkspaceSwitcher();
+  const { handleWorkspaceSwitch, confirmWorkspaceSwitch, isWorkspaceLoading, setIsWorkspaceLoading } =
+    useWorkspaceSwitcher();
 
   const { onNewClickV2 } = useApiClientContext();
 
@@ -157,20 +153,22 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                     {showNewRecordBtn ? (
                       <>
                         {type === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-                          <RQButton
-                            size="small"
-                            type="transparent"
-                            icon={<MdAdd />}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onNewClickV2({
-                                contextId: workspaceId,
-                                analyticEventSource: "api_client_sidebar_header",
-                                recordType: RQAPI.RecordType.ENVIRONMENT,
-                                collectionId: undefined,
-                              });
-                            }}
-                          />
+                          <Tooltip title="New environment" color="#000">
+                            <RQButton
+                              size="small"
+                              type="transparent"
+                              icon={<MdAdd />}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onNewClickV2({
+                                  contextId: workspaceId,
+                                  analyticEventSource: "api_client_sidebar_header",
+                                  recordType: RQAPI.RecordType.ENVIRONMENT,
+                                  collectionId: undefined,
+                                });
+                              }}
+                            />
+                          </Tooltip>
                         ) : (
                           <NewApiRecordDropdown
                             invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
@@ -186,12 +184,14 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                               });
                             }}
                           >
-                            <RQButton
-                              size="small"
-                              type="transparent"
-                              icon={<MdAdd />}
-                              onClick={(e) => e.stopPropagation()}
-                            />
+                            <Tooltip title="New request or collection" color="#000">
+                              <RQButton
+                                size="small"
+                                type="transparent"
+                                icon={<MdAdd />}
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                            </Tooltip>
                           </NewApiRecordDropdown>
                         )}
                       </>
@@ -203,14 +203,16 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                       placement="bottomRight"
                       overlayClassName="collection-dropdown-menu"
                     >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
+                      <Tooltip title="More actions" color="#000">
+                        <RQButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                          size="small"
+                          type="transparent"
+                          icon={<MdOutlineMoreHoriz />}
+                        />
+                      </Tooltip>
                     </Dropdown>
                   </div>
                 </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
-import { Checkbox, Dropdown, MenuProps, Skeleton, Typography, notification } from "antd";
+import { Checkbox, Dropdown, MenuProps, Skeleton, Typography, notification, Tooltip } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQAPI as SharedRQAPI } from "@requestly/shared/types/entities/apiClient";
 import { RQButton } from "lib/design-system-v2/components";
@@ -493,7 +493,14 @@ export const CollectionRow: React.FC<Props> = ({
                         });
                       }}
                     >
-                      <RQButton size="small" type="transparent" icon={<MdAdd />} onClick={(e) => e.stopPropagation()} />
+                      <Tooltip title="New request or collection" color="#000">
+                        <RQButton
+                          size="small"
+                          type="transparent"
+                          icon={<MdAdd />}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      </Tooltip>
                     </NewApiRecordDropdown>
                     <Dropdown
                       trigger={["click"]}
@@ -501,15 +508,17 @@ export const CollectionRow: React.FC<Props> = ({
                       placement="bottomRight"
                       overlayClassName="collection-dropdown-menu"
                     >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowSelection(false);
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
+                      <Tooltip title="More actions" color="#000">
+                        <RQButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setShowSelection(false);
+                          }}
+                          size="small"
+                          type="transparent"
+                          icon={<MdOutlineMoreHoriz />}
+                        />
+                      </Tooltip>
                     </Dropdown>
                   </div>
                 </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps } from "antd";
+import { Typography, Dropdown, MenuProps, Tooltip } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
@@ -275,14 +275,16 @@ export const ExampleRow: React.FC<Props> = ({ record, isReadOnly, handleRecordsT
               open={isDropdownVisible}
               onOpenChange={setIsDropdownVisible}
             >
-              <RQButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-              />
+              <Tooltip title="More actions" color="#000">
+                <RQButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  size="small"
+                  type="transparent"
+                  icon={<MdOutlineMoreHoriz />}
+                />
+              </Tooltip>
             </Dropdown>
           </div>
         </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps, Checkbox, notification } from "antd";
+import { Typography, Dropdown, MenuProps, Checkbox, notification, Tooltip } from "antd";
 import { REQUEST_METHOD_BACKGROUND_COLORS, REQUEST_METHOD_COLORS } from "../../../../../../../../../constants";
 import { RequestMethod, RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
@@ -500,15 +500,17 @@ export const RequestRow: React.FC<Props> = ({
             open={isDropdownVisible}
             onOpenChange={handleDropdownVisibleChange}
           >
-            <RQButton
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowSelection(false);
-              }}
-              size="small"
-              type="transparent"
-              icon={<MdOutlineMoreHoriz />}
-            />
+            <Tooltip title="More actions" color="#000">
+              <RQButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowSelection(false);
+                }}
+                size="small"
+                type="transparent"
+                icon={<MdOutlineMoreHoriz />}
+              />
+            </Tooltip>
           </Dropdown>
         </div>
       </Conditional>
@@ -646,15 +648,17 @@ export const RequestRow: React.FC<Props> = ({
                   open={isDropdownVisible}
                   onOpenChange={handleDropdownVisibleChange}
                 >
-                  <RQButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowSelection(false);
-                    }}
-                    size="small"
-                    type="transparent"
-                    icon={<MdOutlineMoreHoriz />}
-                  />
+                  <Tooltip title="More actions" color="#000">
+                    <RQButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowSelection(false);
+                      }}
+                      size="small"
+                      type="transparent"
+                      icon={<MdOutlineMoreHoriz />}
+                    />
+                  </Tooltip>
                 </Dropdown>
               </div>
             </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
@@ -55,16 +55,17 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
 
       {listType ? (
         listType === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-          <RQButton
-            size="small"
-            type="transparent"
-            icon={<MdAdd />}
-            title="Create new environment"
-            className="sidebar-list-header-button"
-            onClick={() => {
-              onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
-            }}
-          />
+          <Tooltip title="New environment">
+            <RQButton
+              size="small"
+              type="transparent"
+              icon={<MdAdd />}
+              className="sidebar-list-header-button"
+              onClick={() => {
+                onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
+              }}
+            />
+          </Tooltip>
         ) : null
       ) : (
         showNewRecordAction && (
@@ -74,7 +75,9 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
               onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
             }}
           >
-            <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            <Tooltip title="New request or collection">
+              <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            </Tooltip>
           </NewApiRecordDropdown>
         )
       )}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/FileDropdown.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/FileDropdown.tsx
@@ -48,12 +48,14 @@ const FileDropdown: React.FC<FileDropdownProps> = ({ onAddMoreFiles, onDeleteFil
             </div>
             <div className="file-details">
               <span className="file-size">{formatBytes(file.size)}</span>
-              <RQButton
-                className="file-dropdown-remove-button"
-                icon={<RiDeleteBinLine />}
-                size="small"
-                onClick={() => onDeleteFile(file.id)}
-              />
+              <RQTooltip title="Delete" placement="bottom">
+                <RQButton
+                  className="file-dropdown-remove-button"
+                  icon={<RiDeleteBinLine />}
+                  size="small"
+                  onClick={() => onDeleteFile(file.id)}
+                />
+              </RQTooltip>
             </div>
           </div>
         ))}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -260,13 +260,15 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
           }
 
           return (
-            <RQButton
-              className="key-value-delete-btn"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title="Delete" color="#000">
+              <RQButton
+                className="key-value-delete-btn"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTableSettingsDropdown.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dropdown, Checkbox } from "antd";
+import { Dropdown, Checkbox, Tooltip } from "antd";
 import { MdMoreHoriz } from "@react-icons/all-files/md/MdMoreHoriz";
 import { RQButton } from "lib/design-system-v2/components";
 
@@ -33,7 +33,9 @@ export const KeyValueTableSettingsDropdown: React.FC<KeyValueTableSettingsDropdo
   return (
     <div className="key-value-settings-header">
       <Dropdown menu={{ items }} trigger={["click"]} placement="bottomLeft">
-        <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
+        <Tooltip title="More actions" color="#000">
+          <RQButton type="transparent" size="small" icon={<MdMoreHoriz />} className="key-value-settings-icon" />
+        </Tooltip>
       </Dropdown>
     </div>
   );

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/MultiPartFormTable.tsx
@@ -3,7 +3,7 @@ import { FormDropDownOptions, RQAPI } from "features/apiClient/types";
 import React, { useCallback, useMemo } from "react";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
-import { TableProps } from "antd";
+import { TableProps, Tooltip } from "antd";
 import { RiDeleteBin6Line } from "@react-icons/all-files/ri/RiDeleteBin6Line";
 import { MultiEditableCell, MultiEditableRow } from "./MultipartFormRowTable";
 import "./MultiPartFormTable.scss";
@@ -158,13 +158,15 @@ export const MultipartFormTable: React.FC<KeyValueTableProps> = ({
             return null;
           }
           return (
-            <RQButton
-              className="key-value-delete-icon"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <Tooltip title="Delete" color="#000">
+              <RQButton
+                className="key-value-delete-icon"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                onClick={() => handleDeletePair(record)}
+              />
+            </Tooltip>
           );
         },
       },

--- a/app/src/layouts/DashboardLayout/MenuHeader/MenuHeader.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/MenuHeader.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { isSafariBrowser } from "actions/ExtensionActions";
 import { getAppMode, getRequestBot } from "store/selectors";
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
-import { Col } from "antd";
+import { Col, Tooltip } from "antd";
 import PremiumPlanBadge from "./PremiumPlanBadge/PremiumPlanBadge";
 import { getUserAuthDetails } from "store/slices/global/user/selectors";
 import GitHubButton from "react-github-btn";
@@ -103,11 +103,13 @@ export const MenuHeader = () => {
         </div>
 
         <div className="app-primary-header__right-section">
-          <RQButton
-            type="transparent"
-            icon={<Settings />}
-            onClick={() => redirectToSettings(navigate, window.location.pathname, "header")}
-          />
+          <Tooltip title="Settings" color="#000">
+            <RQButton
+              type="transparent"
+              icon={<Settings />}
+              onClick={() => redirectToSettings(navigate, window.location.pathname, "header")}
+            />
+          </Tooltip>
           <HeaderUser />
         </div>
       </div>


### PR DESCRIPTION
Fixes #3868

## Summary
- Added missing tooltips for unlabeled API Client icon actions.
- Covered create, edit, dock, more actions, settings, and delete controls.

## Verification
- Ran Prettier on changed files.
- Ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual tooltips across the app for action buttons (Edit, Delete, Settings, More actions, New environment/request/collection, New request on tabs, Dock to right/bottom) to improve discoverability and clarify button purpose.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->