### PR TITLE
fix: count only applied source filters

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -26,6 +26,42 @@ import "./RequestSourceRow.css";
 
 const { Text } = Typography;
 
+const isFilterValueApplied = (value) => {
+  if (Array.isArray(value)) {
+    return value.some(isFilterValueApplied);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(isFilterValueApplied);
+  }
+
+  return Boolean(value);
+};
+
+const isRequestPayloadFilterApplied = (requestPayloadFilter) => {
+  return isFilterValueApplied(requestPayloadFilter?.key) && isFilterValueApplied(requestPayloadFilter?.value);
+};
+
+const getAppliedSourceFilterCount = (sourceFilters) => {
+  const filterConfig = Array.isArray(sourceFilters) ? sourceFilters[0] : sourceFilters;
+
+  if (!filterConfig || typeof filterConfig !== "object") {
+    return 0;
+  }
+
+  return Object.entries(filterConfig).filter(([key, value]) => {
+    if (key === GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL) {
+      return false;
+    }
+
+    if (key === GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.REQUEST_DATA) {
+      return isRequestPayloadFilterApplied(value);
+    }
+
+    return isFilterValueApplied(value);
+  }).length;
+};
+
 const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabled }) => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -70,16 +106,9 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      return getAppliedSourceFilterCount(currentlySelectedRuleData.pairs[pairIndex].source.filters);
     },
-    [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
+    [currentlySelectedRuleData]
   );
 
   const sourceKeys = useMemo(


### PR DESCRIPTION
Fixes #3826

## Summary
- Counts only source filters with actual applied values.
- Ignores empty request payload filters and pageUrl metadata when showing applied filter count.

## Verification
- Ran Prettier on changed file.
- Ran git diff --check.
- Manually checked empty/non-empty filter count cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Filters badge calculation in request source settings to more reliably reflect applied filters across varied inputs and formats.
  * The badge now excludes page-URL filters from the count.
  * Request-data filters are counted only when both key and value are present.
  * This prevents overstated filter counts and improves clarity when configuring rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->