### PR TITLE
fix: keep request bot within viewport

### DIFF
--- a/app/src/features/requestBot/RequestBot.tsx
+++ b/app/src/features/requestBot/RequestBot.tsx
@@ -40,7 +40,7 @@ export const RequestBot: React.FC<RequestBotProps> = ({ isOpen, onClose, modelTy
     <>
       <m.div
         initial={{ opacity: 0, right: -450 }}
-        animate={{ opacity: shouldShowBot ? 1 : 0, right: shouldShowBot ? 65 : -450 }}
+        animate={{ opacity: shouldShowBot ? 1 : 0, right: shouldShowBot ? 16 : -450 }}
         transition={{ duration: 0.2 }}
         className="request-bot"
         style={{ pointerEvents: shouldShowBot ? "auto" : "none" }}

--- a/app/src/features/requestBot/requestBot.css
+++ b/app/src/features/requestBot/requestBot.css
@@ -9,6 +9,9 @@
   z-index: 100;
   width: 424px;
   height: 640px;
+  max-width: calc(100vw - 32px);
+  max-height: calc(100vh - 60px);
+  box-sizing: border-box;
   background-color: var(--requestly-color-surface-2);
   padding: 8px;
   border-radius: 1rem;


### PR DESCRIPTION
Fixes #3846

## Summary
- Keeps the Ask AI/request bot container within viewport bounds.
- Adds viewport-based max width/height and adjusts the open animation right offset.

## Verification
- Ran Prettier on changed files.
- Ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined RequestBot slide-in panel placement so the widget appears closer to the viewport edge for improved visual alignment and accessibility.
  * Constrained RequestBot container sizing with maximum width/height and box-sizing adjustments to ensure the widget fits better within smaller viewports and avoids overflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->