### PR TITLE
fix: use pointer cursor on traffic rows

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -2,6 +2,11 @@
   height: 100%;
   table {
     tbody {
+      tr,
+      td {
+        cursor: pointer;
+      }
+
       tr[aria-selected="true"] {
         .graphql-operation-name {
           color: var(--requestly-color-text-default);


### PR DESCRIPTION
Fixes requestly/interceptor#49

## Summary
- Applies pointer cursor styling to network traffic table body rows and cells.

## Verification
- Ran Prettier on changed file.
- Ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual feedback in the Network Inspector's web traffic table by adding a pointer cursor to rows and cells to indicate interactivity.
  * Makes table entries appear clickable, aiding discoverability and encouraging user interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->