### PR TITLE
feat: hide sensitive auth fields

### DIFF
--- a/app/src/componentsV2/RevealableSecretField/RevealableSecretField.test.ts
+++ b/app/src/componentsV2/RevealableSecretField/RevealableSecretField.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { getMaskedSecretValue, getSecretToggleAriaLabel } from "./secretFieldUtils";
+
+describe("RevealableSecretField", () => {
+  it("masks secret values with generated placeholder text", () => {
+    expect(getMaskedSecretValue("super-secret-token")).toBe("***************");
+    expect(getMaskedSecretValue("short")).toBe("*****");
+    expect(getMaskedSecretValue("")).toBe("");
+  });
+
+  it("describes the next reveal action for assistive technology", () => {
+    expect(getSecretToggleAriaLabel(false)).toBe("Reveal secret");
+    expect(getSecretToggleAriaLabel(true)).toBe("Hide secret");
+  });
+});

--- a/app/src/componentsV2/RevealableSecretField/RevealableSecretField.tsx
+++ b/app/src/componentsV2/RevealableSecretField/RevealableSecretField.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { RQButton } from "lib/design-system-v2/components";
 import { RiEyeLine } from "@react-icons/all-files/ri/RiEyeLine";
 import { RiEyeOffLine } from "@react-icons/all-files/ri/RiEyeOffLine";
+import { getMaskedSecretValue, getSecretToggleAriaLabel } from "./secretFieldUtils";
 import "./RevealableSecretField.scss";
 
 interface RevealableSecretFieldProps {
@@ -12,13 +13,14 @@ interface RevealableSecretFieldProps {
 export const RevealableSecretField: React.FC<RevealableSecretFieldProps> = ({ value, isRevealable }) => {
   const [revealed, setRevealed] = useState(false);
   const toggleVisibility = () => setRevealed((prev) => !prev);
+
   return (
     <div className="variable-secret-value">
       <span className="value-content">
         {revealed ? (
           <span className="secret-revealed">{String(value)}</span>
         ) : (
-          <span className="secret-masked">{"•".repeat(Math.min(String(value).length, 15))}</span>
+          <span className="secret-masked">{getMaskedSecretValue(value)}</span>
         )}
       </span>
       {isRevealable && (
@@ -27,6 +29,7 @@ export const RevealableSecretField: React.FC<RevealableSecretFieldProps> = ({ va
             type="transparent"
             size="small"
             icon={revealed ? <RiEyeLine /> : <RiEyeOffLine />}
+            aria-label={getSecretToggleAriaLabel(revealed)}
             onClick={toggleVisibility}
           />
         </div>

--- a/app/src/componentsV2/RevealableSecretField/secretFieldUtils.ts
+++ b/app/src/componentsV2/RevealableSecretField/secretFieldUtils.ts
@@ -1,0 +1,10 @@
+const MAX_MASK_LENGTH = 15;
+const SECRET_MASK_CHARACTER = "*";
+
+export const getMaskedSecretValue = (value: string): string => {
+  return SECRET_MASK_CHARACTER.repeat(Math.min(String(value).length, MAX_MASK_LENGTH));
+};
+
+export const getSecretToggleAriaLabel = (revealed: boolean): string => {
+  return revealed ? "Hide secret" : "Reveal secret";
+};

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/index.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/index.ts
@@ -12,7 +12,7 @@ export const AUTH_SELECTOR_LABELS = [
 const FORM_FIELDS_LAYOUT: Record<AuthConfigMeta.AuthWithConfig, AuthForm.FormField[]> = {
   [Authorization.Type.API_KEY]: [
     { id: "key", type: AuthForm.FIELD_TYPE.INPUT, label: "Key", placeholder: "Key" },
-    { id: "value", type: AuthForm.FIELD_TYPE.INPUT, label: "Value", placeholder: "Value" },
+    { id: "value", type: AuthForm.FIELD_TYPE.INPUT, label: "Value", placeholder: "Value", isSecret: true },
     {
       id: "addTo",
       type: AuthForm.FIELD_TYPE.SELECT,
@@ -25,11 +25,11 @@ const FORM_FIELDS_LAYOUT: Record<AuthConfigMeta.AuthWithConfig, AuthForm.FormFie
     },
   ],
   [Authorization.Type.BEARER_TOKEN]: [
-    { id: "bearer", type: AuthForm.FIELD_TYPE.INPUT, label: "Token", placeholder: "Token" },
+    { id: "bearer", type: AuthForm.FIELD_TYPE.INPUT, label: "Token", placeholder: "Token", isSecret: true },
   ],
   [Authorization.Type.BASIC_AUTH]: [
     { id: "username", type: AuthForm.FIELD_TYPE.INPUT, label: "Username", placeholder: "Username" },
-    { id: "password", type: AuthForm.FIELD_TYPE.INPUT, label: "Password", placeholder: "Password" },
+    { id: "password", type: AuthForm.FIELD_TYPE.INPUT, label: "Password", placeholder: "Password", isSecret: true },
   ],
 };
 

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/types.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/types.ts
@@ -19,6 +19,7 @@ export namespace AuthForm {
   export interface InputField extends BaseAuthFormField {
     type: FIELD_TYPE.INPUT;
     placeholder?: string;
+    isSecret?: boolean;
   }
 
   export interface SelectField extends BaseAuthFormField {

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/index.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/index.tsx
@@ -78,6 +78,7 @@ function generateFields(
             defaultValue={formState[field.id]}
             onChange={(value) => onChangeHandler(value, field.id)}
             variables={variables}
+            isSecret={field.isSecret}
           />
           <Conditional
             condition={hasInvalidCharacter && formType === Authorization.Type.API_KEY && field.id === "key" && isHeader}

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/authorizationView.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/authorizationView.scss
@@ -83,12 +83,17 @@
                 }
               }
             }
-            .input-container.error-state > .editor-popup-container {
+            .input-container.error-state > .single-line-editor-wrapper {
               width: 100%;
               height: 100%;
-              border: none;
-              padding: var(--requestly-space-0, 0px);
               margin-bottom: var(--requestly-space-4, 8px);
+
+              .editor-popup-container {
+                width: 100%;
+                height: 100%;
+                border: none;
+                padding: var(--requestly-space-0, 0px);
+              }
             }
           }
 

--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor.tsx
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from "react";
 import { EditorView, placeholder as cmPlaceHolder, keymap } from "@codemirror/view";
-import { EditorState } from "@codemirror/state";
+import { Compartment, EditorState } from "@codemirror/state";
 import { history, historyKeymap } from "@codemirror/commands";
 import { startCompletion } from "@codemirror/autocomplete"; // New Import
 import { VariablePopover } from "componentsV2/CodeEditor/components/EditorV2/components/VariablePopOver";
@@ -40,6 +40,7 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
 }) => {
   const editorRef = useRef<HTMLDivElement>(null);
   const editorViewRef = useRef<EditorView | null>(null);
+  const maskCompartmentRef = useRef(new Compartment());
 
   const { autocompleteState, autocompleteExtension, handleSelectVariable, handleCloseAutocomplete } =
     useVariableAutocomplete({ editorViewRef });
@@ -185,7 +186,7 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
             },
             variables || emptyVariables
           ),
-          useDecorationMask ? secretMaskExtension : null,
+          maskCompartmentRef.current.of(useDecorationMask ? secretMaskExtension : []),
           generateCompletionsForVariables(emptyVariables, suggestions),
           cmPlaceHolder(placeholder ?? "Input here"),
         ].filter((ext): ext is NonNullable<typeof ext> => ext !== null),
@@ -199,7 +200,13 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
     //Need to disable to implement the onChange handler
     // Shouldn't be recreated every render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [placeholder, variables, handleSetVariable, suggestions, useDecorationMask]);
+  }, [placeholder, variables, handleSetVariable, suggestions]);
+
+  useEffect(() => {
+    editorViewRef.current?.dispatch({
+      effects: maskCompartmentRef.current.reconfigure(useDecorationMask ? secretMaskExtension : []),
+    });
+  }, [useDecorationMask]);
 
   useEffect(() => {
     if (defaultValue !== previousDefaultValueRef.current) {

--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor.tsx
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor.tsx
@@ -15,6 +15,9 @@ import {
 } from "componentsV2/CodeEditor/components/EditorV2/plugins";
 import { VariableAutocompletePopover } from "../VariableAutocompletePopover/VariableAutocompletePopover";
 import { useVariableAutocomplete } from "../hooks/useVariableAutocomplete";
+import { RQButton } from "lib/design-system-v2/components";
+import { RiEyeLine } from "@react-icons/all-files/ri/RiEyeLine";
+import { RiEyeOffLine } from "@react-icons/all-files/ri/RiEyeOffLine";
 
 export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
   className,
@@ -26,16 +29,13 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
   onPaste,
   variables,
   suggestions,
+  isSecret = false,
 }) => {
   const editorRef = useRef<HTMLDivElement>(null);
   const editorViewRef = useRef<EditorView | null>(null);
 
-  const {
-    autocompleteState,
-    autocompleteExtension,
-    handleSelectVariable,
-    handleCloseAutocomplete,
-  } = useVariableAutocomplete({ editorViewRef });
+  const { autocompleteState, autocompleteExtension, handleSelectVariable, handleCloseAutocomplete } =
+    useVariableAutocomplete({ editorViewRef });
 
   /*
   onKeyDown, onBlur and onChange is in the useEffect dependencies (implicitly through the editor setup),
@@ -60,6 +60,7 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
   const [hoveredVariable, setHoveredVariable] = useState<string | null>(null);
   const [popupPosition, setPopupPosition] = useState({ x: 0, y: 0 });
   const [isPopoverPinned, setIsPopoverPinned] = useState(false);
+  const [isSecretRevealed, setIsSecretRevealed] = useState(false);
 
   useEffect(() => {
     isPopoverPinnedRef.current = isPopoverPinned;
@@ -204,19 +205,31 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
 
   return (
     <>
-      <div
-        ref={editorRef}
-        className={`${className ?? ""} editor-popup-container ant-input`}
-        onMouseLeave={handleMouseLeave}
-      >
-        <Conditional condition={!!hoveredVariable}>
-          <VariablePopover
-            editorRef={editorRef as React.RefObject<HTMLDivElement>}
-            hoveredVariable={hoveredVariable || ""}
-            popupPosition={popupPosition}
-            variables={variables || emptyVariables}
-            onClose={handleClosePopover}
-            onPinChange={setIsPopoverPinned}
+      <div className={`single-line-editor-wrapper ${isSecret && !isSecretRevealed ? "single-line-editor-secret" : ""}`}>
+        <div
+          ref={editorRef}
+          className={`${className ?? ""} editor-popup-container ant-input ${isSecret ? "has-secret-toggle" : ""}`}
+          onMouseLeave={handleMouseLeave}
+        >
+          <Conditional condition={!!hoveredVariable}>
+            <VariablePopover
+              editorRef={editorRef as React.RefObject<HTMLDivElement>}
+              hoveredVariable={hoveredVariable || ""}
+              popupPosition={popupPosition}
+              variables={variables || emptyVariables}
+              onClose={handleClosePopover}
+              onPinChange={setIsPopoverPinned}
+            />
+          </Conditional>
+        </div>
+
+        <Conditional condition={isSecret}>
+          <RQButton
+            className="single-line-editor-secret-toggle"
+            type="transparent"
+            size="small"
+            icon={isSecretRevealed ? <RiEyeLine /> : <RiEyeOffLine />}
+            onClick={() => setIsSecretRevealed((prev) => !prev)}
           />
         </Conditional>
       </div>

--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor.tsx
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/SingleLineEditor.tsx
@@ -18,6 +18,13 @@ import { useVariableAutocomplete } from "../hooks/useVariableAutocomplete";
 import { RQButton } from "lib/design-system-v2/components";
 import { RiEyeLine } from "@react-icons/all-files/ri/RiEyeLine";
 import { RiEyeOffLine } from "@react-icons/all-files/ri/RiEyeOffLine";
+import {
+  getSecretToggleAriaLabel,
+  secretMaskExtension,
+  shouldResetSecretReveal,
+  shouldUseSecretMask,
+  supportsTextSecurity,
+} from "./secretMaskUtils";
 
 export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
   className,
@@ -48,6 +55,8 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
   const onPasteRef = useRef(onPaste);
   const previousDefaultValueRef = useRef(defaultValue);
   const isPopoverPinnedRef = useRef(false);
+  const didChangeFromEditorRef = useRef(false);
+  const isSyncingDefaultValueRef = useRef(false);
 
   const emptyVariables = useMemo(() => new Map(), []);
 
@@ -61,6 +70,20 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
   const [popupPosition, setPopupPosition] = useState({ x: 0, y: 0 });
   const [isPopoverPinned, setIsPopoverPinned] = useState(false);
   const [isSecretRevealed, setIsSecretRevealed] = useState(false);
+  const shouldMaskSecret = shouldUseSecretMask({ isSecret, isSecretRevealed });
+  const useTextSecurityMask = shouldMaskSecret && supportsTextSecurity();
+  const useDecorationMask = shouldMaskSecret && !useTextSecurityMask;
+
+  useEffect(() => {
+    if (shouldResetSecretReveal(isSecret)) {
+      if (didChangeFromEditorRef.current) {
+        didChangeFromEditorRef.current = false;
+        return;
+      }
+
+      setIsSecretRevealed(false);
+    }
+  }, [isSecret, defaultValue]);
 
   useEffect(() => {
     isPopoverPinnedRef.current = isPopoverPinned;
@@ -108,6 +131,9 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
           }),
           EditorView.updateListener.of((update) => {
             if (update.docChanged) {
+              if (!isSyncingDefaultValueRef.current) {
+                didChangeFromEditorRef.current = true;
+              }
               onChangeRef.current?.(update.state.doc.toString());
             }
           }),
@@ -159,6 +185,7 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
             },
             variables || emptyVariables
           ),
+          useDecorationMask ? secretMaskExtension : null,
           generateCompletionsForVariables(emptyVariables, suggestions),
           cmPlaceHolder(placeholder ?? "Input here"),
         ].filter((ext): ext is NonNullable<typeof ext> => ext !== null),
@@ -172,7 +199,7 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
     //Need to disable to implement the onChange handler
     // Shouldn't be recreated every render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [placeholder, variables, handleSetVariable, suggestions]);
+  }, [placeholder, variables, handleSetVariable, suggestions, useDecorationMask]);
 
   useEffect(() => {
     if (defaultValue !== previousDefaultValueRef.current) {
@@ -191,8 +218,13 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
           // Prevent calling onChange when default value is changed through this useEffect
           const originalOnChange = onChangeRef.current;
           onChangeRef.current = () => {};
-          editorViewRef.current.dispatch(transaction);
-          onChangeRef.current = originalOnChange;
+          isSyncingDefaultValueRef.current = true;
+          try {
+            editorViewRef.current.dispatch(transaction);
+          } finally {
+            isSyncingDefaultValueRef.current = false;
+            onChangeRef.current = originalOnChange;
+          }
         }
       }
     }
@@ -205,7 +237,11 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
 
   return (
     <>
-      <div className={`single-line-editor-wrapper ${isSecret && !isSecretRevealed ? "single-line-editor-secret" : ""}`}>
+      <div
+        className={`single-line-editor-wrapper ${
+          useTextSecurityMask ? "single-line-editor-secret single-line-editor-secret--text-security" : ""
+        }`}
+      >
         <div
           ref={editorRef}
           className={`${className ?? ""} editor-popup-container ant-input ${isSecret ? "has-secret-toggle" : ""}`}
@@ -229,6 +265,8 @@ export const RQSingleLineEditor: React.FC<SingleLineEditorProps> = ({
             type="transparent"
             size="small"
             icon={isSecretRevealed ? <RiEyeLine /> : <RiEyeOffLine />}
+            aria-label={getSecretToggleAriaLabel(isSecretRevealed)}
+            aria-pressed={isSecretRevealed}
             onClick={() => setIsSecretRevealed((prev) => !prev)}
           />
         </Conditional>

--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/secretMaskUtils.test.ts
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/secretMaskUtils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { getSecretToggleAriaLabel, shouldResetSecretReveal, shouldUseSecretMask } from "./secretMaskUtils";
+
+describe("secretMaskUtils", () => {
+  it("describes the reveal toggle action", () => {
+    expect(getSecretToggleAriaLabel(false)).toBe("Reveal secret");
+    expect(getSecretToggleAriaLabel(true)).toBe("Hide secret");
+  });
+
+  it("resets revealed state only for secret editors", () => {
+    expect(shouldResetSecretReveal(true)).toBe(true);
+    expect(shouldResetSecretReveal(false)).toBe(false);
+  });
+
+  it("uses secret masking only when a secret is hidden", () => {
+    expect(shouldUseSecretMask({ isSecret: true, isSecretRevealed: false })).toBe(true);
+    expect(shouldUseSecretMask({ isSecret: true, isSecretRevealed: true })).toBe(false);
+    expect(shouldUseSecretMask({ isSecret: false, isSecretRevealed: false })).toBe(false);
+  });
+});

--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/secretMaskUtils.ts
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/secretMaskUtils.ts
@@ -1,0 +1,52 @@
+import { RangeSetBuilder } from "@codemirror/state";
+import { Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate, WidgetType } from "@codemirror/view";
+
+export const getSecretToggleAriaLabel = (isSecretRevealed: boolean) =>
+  isSecretRevealed ? "Hide secret" : "Reveal secret";
+
+export const shouldResetSecretReveal = (isSecret: boolean) => isSecret;
+
+export const shouldUseSecretMask = ({ isSecret, isSecretRevealed }: { isSecret: boolean; isSecretRevealed: boolean }) =>
+  isSecret && !isSecretRevealed;
+
+export const supportsTextSecurity = () =>
+  typeof CSS !== "undefined" && typeof CSS.supports === "function" && CSS.supports("-webkit-text-security", "disc");
+
+class SecretMaskWidget extends WidgetType {
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = "cm-secret-mask-bullet";
+    span.textContent = "•";
+    return span;
+  }
+}
+
+const buildSecretMaskDecorations = (view: EditorView) => {
+  const builder = new RangeSetBuilder<Decoration>();
+  const docLength = view.state.doc.length;
+
+  for (let position = 0; position < docLength; position++) {
+    builder.add(position, position + 1, Decoration.replace({ widget: new SecretMaskWidget() }));
+  }
+
+  return builder.finish();
+};
+
+export const secretMaskExtension = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildSecretMaskDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged) {
+        this.decorations = buildSecretMaskDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (value) => value.decorations,
+  }
+);

--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/singleLineEditor.scss
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/singleLineEditor.scss
@@ -6,7 +6,7 @@
     padding-right: 34px;
   }
 
-  &.single-line-editor-secret {
+  &.single-line-editor-secret--text-security {
     .cm-content {
       -webkit-text-security: disc;
     }
@@ -14,6 +14,10 @@
     .cm-placeholder {
       -webkit-text-security: none;
     }
+  }
+
+  .cm-secret-mask-bullet {
+    color: var(--requestly-color-text-default);
   }
 
   .single-line-editor-secret-toggle {

--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/singleLineEditor.scss
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/singleLineEditor.scss
@@ -1,3 +1,41 @@
+.single-line-editor-wrapper {
+  position: relative;
+  width: 100%;
+
+  .has-secret-toggle {
+    padding-right: 34px;
+  }
+
+  &.single-line-editor-secret {
+    .cm-content {
+      -webkit-text-security: disc;
+    }
+
+    .cm-placeholder {
+      -webkit-text-security: none;
+    }
+  }
+
+  .single-line-editor-secret-toggle {
+    position: absolute;
+    top: 50%;
+    right: 6px;
+    transform: translateY(-50%);
+    padding: 4px;
+    min-height: unset;
+
+    svg {
+      width: 16px;
+      height: 16px;
+      color: var(--requestly-color-text-subtle);
+    }
+
+    &:hover svg {
+      color: var(--requestly-color-text-default);
+    }
+  }
+}
+
 .editor-popup-container {
   .popup-option {
     background-color: var(--requestly-color-surface-0);

--- a/app/src/features/apiClient/screens/environment/components/SingleLineEditor/types.ts
+++ b/app/src/features/apiClient/screens/environment/components/SingleLineEditor/types.ts
@@ -10,4 +10,5 @@ export interface SingleLineEditorProps {
   onPaste?: (event: ClipboardEvent, text: string) => void;
   variables?: ScopedVariables;
   suggestions?: Array<{ value: string }>;
+  isSecret?: boolean;
 }


### PR DESCRIPTION
Fixes #3725

## Summary
- Adds a reveal/hide toggle to the API Client single-line editor for secret fields.
- Masks API key values, bearer tokens, and basic auth passwords by default.

## Verification
- Ran Prettier on changed files.
- Ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sensitive authorization fields (API keys, bearer tokens, passwords) are now masked by default with a reveal/hide toggle in editors and form inputs.
  * Editors include secret-mode support with improved masking behavior.

* **Style**
  * Improved input and error-state styling and layout for secret-mode fields and their toggle.

* **Tests**
  * Added unit tests for mask helpers and reveal-toggle accessibility labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->