### PR TITLE
fix: preserve schema builder query state

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/SchemaBuilder.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/SchemaBuilder.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo } from "react";
 import Explorer from "graphiql-explorer";
-import { buildClientSchema, parse } from "graphql";
+import { buildClientSchema } from "graphql";
 import "@graphiql/plugin-explorer/style.css";
 import { Checkbox } from "antd";
 import { RQButton } from "lib/design-system-v2/components";
@@ -10,6 +10,7 @@ import { useGraphQLRecordStore } from "features/apiClient/hooks/useGraphQLRecord
 import { MdClose } from "@react-icons/all-files/md/MdClose";
 import { BufferedGraphQLRecordEntity } from "features/apiClient/slices/entities";
 import { useApiClientSelector } from "features/apiClient/slices/hooks/base.hooks";
+import { getExplorerQuery } from "./schemaBuilderUtils";
 import "./schemaBuilder.scss";
 
 interface Props {
@@ -29,10 +30,10 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
     url,
   });
 
-  const [hasParsedSuccessfully, setHasParsedSuccessfully] = useState(false);
+  const explorerQuery = useMemo(() => getExplorerQuery(operation), [operation]);
 
   /*
-   * This effect is added due to Explorer component's internal query caching logic.
+   * Explorer is gated due to the component's internal query caching logic.
    * The graphiql-explorer package uses module-level memoization that caches parsed queries
    * across all component instances. When multiple SchemaBuilder components are rendered
    * (e.g., in different tabs), they share the same parsed query cache, causing field
@@ -42,21 +43,10 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
    * using a previously cached query, which can lead to unexpected behavior and further
    * state sharing issues between different instances.
    *
-   * By only passing the query to Explorer after it has been successfully parsed once,
+   * By only passing the current query to Explorer after it has been successfully parsed,
    * we prevent the Explorer from caching invalid queries and reduce the likelihood of
    * shared state issues between different instances.
    */
-  useEffect(() => {
-    if (!hasParsedSuccessfully) {
-      try {
-        parse(operation);
-        setHasParsedSuccessfully(true);
-      } catch (e) {
-        // NO OP
-      }
-    }
-  }, [hasParsedSuccessfully, operation]);
-
   const handleEdit = (query: string) => {
     entity.setOperation(query);
   };
@@ -80,7 +70,7 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
           <div className="schema-builder__content">
             <Explorer
               schema={introspectionData ? buildClientSchema(introspectionData) : {}}
-              query={hasParsedSuccessfully ? operation : ""}
+              query={explorerQuery}
               explorerIsOpen={true}
               arrowClosed={<Checkbox checked={false} className="schema-builder__checkbox" />}
               arrowOpen={<Checkbox checked={true} className="schema-builder__checkbox" />}

--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/SchemaBuilder.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/SchemaBuilder.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import Explorer from "graphiql-explorer";
 import { buildClientSchema, parse } from "graphql";
 import "@graphiql/plugin-explorer/style.css";
@@ -29,7 +29,7 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
     url,
   });
 
-  const hasParsedSuccessfully = useRef(false);
+  const [hasParsedSuccessfully, setHasParsedSuccessfully] = useState(false);
 
   /*
    * This effect is added due to Explorer component's internal query caching logic.
@@ -47,15 +47,15 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
    * shared state issues between different instances.
    */
   useEffect(() => {
-    if (!hasParsedSuccessfully.current) {
+    if (!hasParsedSuccessfully) {
       try {
         parse(operation);
-        hasParsedSuccessfully.current = true;
+        setHasParsedSuccessfully(true);
       } catch (e) {
         // NO OP
       }
     }
-  }, [operation]);
+  }, [hasParsedSuccessfully, operation]);
 
   const handleEdit = (query: string) => {
     entity.setOperation(query);
@@ -80,7 +80,7 @@ export const SchemaBuilder: React.FC<Props> = ({ entity, setIsSchemaBuilderOpen 
           <div className="schema-builder__content">
             <Explorer
               schema={introspectionData ? buildClientSchema(introspectionData) : {}}
-              query={hasParsedSuccessfully.current ? operation : ""}
+              query={hasParsedSuccessfully ? operation : ""}
               explorerIsOpen={true}
               arrowClosed={<Checkbox checked={false} className="schema-builder__checkbox" />}
               arrowOpen={<Checkbox checked={true} className="schema-builder__checkbox" />}

--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilder.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilder.scss
@@ -64,6 +64,7 @@
 
     .doc-explorer-contents {
       height: 100%;
+      min-width: max-content;
       font-size: var(--requestly-font-size-sm);
 
       form.graphiql-explorer-actions.variable-editor-title {
@@ -200,6 +201,8 @@
 
 // Styling to make field types more visible
 .graphiql-explorer-root {
+  min-width: max-content;
+
   & > div:first-child {
     flex-grow: unset !important;
     height: calc(100% - 48px) !important;

--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilderUtils.test.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilderUtils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { getExplorerQuery } from "./schemaBuilderUtils";
+
+describe("getExplorerQuery", () => {
+  it("returns the current operation only when it parses successfully", () => {
+    const validOperation = "query GetViewer { viewer { id } }";
+
+    expect(getExplorerQuery(validOperation)).toBe(validOperation);
+    expect(getExplorerQuery("query Broken {")).toBe("");
+  });
+});

--- a/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilderUtils.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/graphql/components/SchemaBuilder/schemaBuilderUtils.ts
@@ -1,0 +1,10 @@
+import { parse } from "graphql";
+
+export const getExplorerQuery = (operation: string) => {
+  try {
+    parse(operation);
+    return operation;
+  } catch (e) {
+    return "";
+  }
+};


### PR DESCRIPTION
Fixes #3823

## Summary
- Re-renders the GraphQL Schema Builder after the current query parses successfully, preserving selections after layout toggles/remounts.
- Adds minimum content width so the schema explorer can scroll horizontally instead of clipping content.

## Verification
- Ran Prettier on changed files.
- Ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL explorer layout so content areas display correctly with better minimum widths.
  * Made explorer behavior more stable by ensuring only validated queries are shown, reducing parse-related glitches.

* **Tests**
  * Added unit tests to verify explorer query validation and handling of invalid operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->