### PR TITLE
fix: allow excluding errored api client files

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/ErrorFilesList/ErrorFileslist.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/ErrorFilesList/ErrorFileslist.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { MdEdit } from "@react-icons/all-files/md/MdEdit";
 import { MdWarningAmber } from "@react-icons/all-files/md/MdWarningAmber";
 import { RiDeleteBin6Line } from "@react-icons/all-files/ri/RiDeleteBin6Line";
+import { StopOutlined } from "@ant-design/icons";
 import { ErroredRecord, FileType } from "features/apiClient/helpers/modules/sync/local/services/types";
 import { ErrorFileViewerModal } from "../../../modals/ErrorFileViewerModal/ErrorFileViewerModal";
 import { toast } from "utils/Toast";
@@ -12,7 +13,11 @@ import "./errorFilesList.scss";
 import { RiDeleteBinLine } from "@react-icons/all-files/ri/RiDeleteBinLine";
 import { ApiClientViewMode, useViewMode } from "features/apiClient/slices/workspaceView";
 import { useApiClientFeatureContext } from "features/apiClient/slices/workspaceView/helpers/ApiClientContextRegistry/hooks";
-import { useApiErroredRecords, useEnvironmentErroredRecords } from "features/apiClient/slices/erroredRecords";
+import {
+  erroredRecordsActions,
+  useApiErroredRecords,
+  useEnvironmentErroredRecords,
+} from "features/apiClient/slices/erroredRecords";
 import { forceRefreshRecords } from "features/apiClient/slices/apiRecords/thunks";
 import { forceRefreshEnvironments } from "features/apiClient/slices/environments/thunks";
 import { useSelector } from "react-redux";
@@ -105,8 +110,9 @@ const ErrorFileItemTitle: React.FC<{ file: ErroredRecord }> = ({ file }) => {
 const ErrorFileItem: React.FC<{
   file: ErroredRecord;
   openErrorFile: (file: ErroredRecord) => void;
+  excludeErrorFile(file: ErroredRecord): void;
   deleteErrorFile(file: ErroredRecord): void;
-}> = ({ file, openErrorFile, deleteErrorFile }) => {
+}> = ({ file, openErrorFile, excludeErrorFile, deleteErrorFile }) => {
   return (
     <div key={file.path} className="error-file-item">
       <ErrorFileItemTitle file={file} />
@@ -114,6 +120,16 @@ const ErrorFileItem: React.FC<{
       <div className="error-file-item-actions">
         <Tooltip title="Edit file" color="var(--requestly-color-black)" placement="top">
           <MdEdit className="error-file-item-action-icon" onClick={() => openErrorFile(file)} />
+        </Tooltip>
+        <Tooltip title="Exclude file" color="var(--requestly-color-black)" placement="top">
+          <button
+            type="button"
+            className="error-file-item-action-button"
+            aria-label={`Exclude ${file.name}`}
+            onClick={() => excludeErrorFile(file)}
+          >
+            <StopOutlined className="error-file-item-action-icon" />
+          </button>
         </Tooltip>
         <DeleteErrorFileButton
           onDelete={() => {
@@ -184,6 +200,19 @@ export const ErrorFilesList: React.FC<{ updateErrorRecordsCount?: (value: number
     [apiClientRecordsRepository, environmentVariablesRepository, context]
   );
 
+  const handleExcludeErrorFile = useCallback(
+    (errorFile: ErroredRecord) => {
+      if (errorFile.type === FileType.ENVIRONMENT) {
+        context.store.dispatch(erroredRecordsActions.excludeEnvironmentErroredRecord(errorFile.id));
+      } else {
+        context.store.dispatch(erroredRecordsActions.excludeApiErroredRecord(errorFile.id));
+      }
+
+      toast.success("Error file excluded successfully");
+    },
+    [context.store]
+  );
+
   const handleOpenErrorFile = (file: ErroredRecord) => {
     setErrorFileToView(file);
     setIsErrorFileViewerModalOpen(true);
@@ -217,6 +246,7 @@ export const ErrorFilesList: React.FC<{ updateErrorRecordsCount?: (value: number
                 file={file}
                 key={file.path}
                 openErrorFile={handleOpenErrorFile}
+                excludeErrorFile={handleExcludeErrorFile}
                 deleteErrorFile={handleDeleteErrorFile}
               />
             );

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/ErrorFilesList/errorFilesList.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/ErrorFilesList/errorFilesList.scss
@@ -59,7 +59,8 @@
     &:hover {
       background: var(--requestly-color-white-t-10);
       .error-file-item-actions {
-        display: flex;
+        opacity: 1;
+        pointer-events: auto;
       }
     }
 
@@ -67,7 +68,32 @@
       display: flex;
       align-items: center;
       gap: 8px;
-      display: none;
+      opacity: 0;
+      pointer-events: none;
+
+      &:focus-within {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      .error-file-item-action-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 14px;
+        height: 14px;
+        padding: 0;
+        border: none;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+
+        &:focus-visible {
+          outline: 1px solid var(--requestly-color-primary);
+          outline-offset: 2px;
+          border-radius: 2px;
+        }
+      }
 
       .error-file-item-action-icon {
         width: 14px;

--- a/app/src/features/apiClient/slices/erroredRecords/erroredRecords.utils.js
+++ b/app/src/features/apiClient/slices/erroredRecords/erroredRecords.utils.js
@@ -1,0 +1,17 @@
+const excludeErroredRecordById = (records, recordId) => {
+  return records.filter((record) => record.id !== recordId);
+};
+
+const addExcludedErroredRecordId = (recordIds, recordId) => {
+  return recordIds.includes(recordId) ? recordIds : [...recordIds, recordId];
+};
+
+const getVisibleErroredRecords = (records, excludedRecordIds) => {
+  return records.filter((record) => !excludedRecordIds.includes(record.id));
+};
+
+module.exports = {
+  addExcludedErroredRecordId,
+  excludeErroredRecordById,
+  getVisibleErroredRecords,
+};

--- a/app/src/features/apiClient/slices/erroredRecords/erroredRecords.utils.test.cjs
+++ b/app/src/features/apiClient/slices/erroredRecords/erroredRecords.utils.test.cjs
@@ -1,0 +1,23 @@
+const assert = require("node:assert/strict");
+
+const {
+  addExcludedErroredRecordId,
+  excludeErroredRecordById,
+  getVisibleErroredRecords,
+} = require("./erroredRecords.utils");
+
+const records = [
+  { id: "request-1", name: "request.json", path: "/workspace/request.json" },
+  { id: "request-2", name: "broken.txt", path: "/workspace/broken.txt" },
+];
+
+assert.deepEqual(excludeErroredRecordById(records, "request-2"), [records[0]]);
+assert.deepEqual(excludeErroredRecordById(records, "missing-id"), records);
+assert.notEqual(excludeErroredRecordById(records, "request-2"), records);
+
+assert.deepEqual(addExcludedErroredRecordId([], "request-2"), ["request-2"]);
+assert.deepEqual(addExcludedErroredRecordId(["request-2"], "request-2"), ["request-2"]);
+assert.deepEqual(getVisibleErroredRecords(records, ["request-2"]), [records[0]]);
+assert.deepEqual(getVisibleErroredRecords(records, []), records);
+
+console.log("erroredRecords utils tests passed");

--- a/app/src/features/apiClient/slices/erroredRecords/slice.ts
+++ b/app/src/features/apiClient/slices/erroredRecords/slice.ts
@@ -2,10 +2,15 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { ErroredRecord } from "features/apiClient/helpers/modules/sync/local/services/types";
 import { API_CLIENT_ERRORED_RECORDS_SLICE_NAME } from "../common/constants";
 import { ErroredRecordsState } from "./types";
+import erroredRecordsUtils from "./erroredRecords.utils";
+
+const { addExcludedErroredRecordId, excludeErroredRecordById, getVisibleErroredRecords } = erroredRecordsUtils;
 
 const initialState: ErroredRecordsState = {
   apiErroredRecords: [],
   environmentErroredRecords: [],
+  excludedApiErroredRecordIds: [],
+  excludedEnvironmentErroredRecordIds: [],
 };
 
 export const erroredRecordsSlice = createSlice({
@@ -13,11 +18,27 @@ export const erroredRecordsSlice = createSlice({
   initialState,
   reducers: {
     setApiErroredRecords(state, action: PayloadAction<ErroredRecord[]>) {
-      state.apiErroredRecords = action.payload;
+      state.apiErroredRecords = getVisibleErroredRecords(action.payload, state.excludedApiErroredRecordIds);
     },
 
     setEnvironmentErroredRecords(state, action: PayloadAction<ErroredRecord[]>) {
-      state.environmentErroredRecords = action.payload;
+      state.environmentErroredRecords = getVisibleErroredRecords(
+        action.payload,
+        state.excludedEnvironmentErroredRecordIds
+      );
+    },
+
+    excludeApiErroredRecord(state, action: PayloadAction<ErroredRecord["id"]>) {
+      state.excludedApiErroredRecordIds = addExcludedErroredRecordId(state.excludedApiErroredRecordIds, action.payload);
+      state.apiErroredRecords = excludeErroredRecordById(state.apiErroredRecords, action.payload);
+    },
+
+    excludeEnvironmentErroredRecord(state, action: PayloadAction<ErroredRecord["id"]>) {
+      state.excludedEnvironmentErroredRecordIds = addExcludedErroredRecordId(
+        state.excludedEnvironmentErroredRecordIds,
+        action.payload
+      );
+      state.environmentErroredRecords = excludeErroredRecordById(state.environmentErroredRecords, action.payload);
     },
 
     hydrate(
@@ -25,15 +46,27 @@ export const erroredRecordsSlice = createSlice({
       action: PayloadAction<{
         apiErroredRecords: ErroredRecord[];
         environmentErroredRecords: ErroredRecord[];
+        excludedApiErroredRecordIds?: ErroredRecord["id"][];
+        excludedEnvironmentErroredRecordIds?: ErroredRecord["id"][];
       }>
     ) {
-      state.apiErroredRecords = action.payload.apiErroredRecords;
-      state.environmentErroredRecords = action.payload.environmentErroredRecords;
+      state.excludedApiErroredRecordIds = action.payload.excludedApiErroredRecordIds ?? [];
+      state.excludedEnvironmentErroredRecordIds = action.payload.excludedEnvironmentErroredRecordIds ?? [];
+      state.apiErroredRecords = getVisibleErroredRecords(
+        action.payload.apiErroredRecords,
+        state.excludedApiErroredRecordIds
+      );
+      state.environmentErroredRecords = getVisibleErroredRecords(
+        action.payload.environmentErroredRecords,
+        state.excludedEnvironmentErroredRecordIds
+      );
     },
 
     clearAll(state) {
       state.apiErroredRecords = [];
       state.environmentErroredRecords = [];
+      state.excludedApiErroredRecordIds = [];
+      state.excludedEnvironmentErroredRecordIds = [];
     },
   },
 });

--- a/app/src/features/apiClient/slices/erroredRecords/types.ts
+++ b/app/src/features/apiClient/slices/erroredRecords/types.ts
@@ -3,4 +3,6 @@ import { ErroredRecord } from "features/apiClient/helpers/modules/sync/local/ser
 export interface ErroredRecordsState {
   apiErroredRecords: ErroredRecord[];
   environmentErroredRecords: ErroredRecord[];
+  excludedApiErroredRecordIds: ErroredRecord["id"][];
+  excludedEnvironmentErroredRecordIds: ErroredRecord["id"][];
 }

--- a/app/src/features/apiClient/slices/workspaceView/helpers/ApiClientContextService/ApiClientContextService.ts
+++ b/app/src/features/apiClient/slices/workspaceView/helpers/ApiClientContextService/ApiClientContextService.ts
@@ -324,6 +324,8 @@ class ApiClientContextService {
       erroredRecordsSlice.actions.hydrate({
         apiErroredRecords: erroredRecords.apiErroredRecords,
         environmentErroredRecords: erroredRecords.environmentErroredRecords,
+        excludedApiErroredRecordIds: erroredRecords.excludedApiErroredRecordIds,
+        excludedEnvironmentErroredRecordIds: erroredRecords.excludedEnvironmentErroredRecordIds,
       })
     );
   }
@@ -439,6 +441,8 @@ class ApiClientContextService {
       erroredRecords: {
         apiErroredRecords: result.apiClientRecords.erroredRecords,
         environmentErroredRecords: result.environments.erroredRecords,
+        excludedApiErroredRecordIds: [],
+        excludedEnvironmentErroredRecordIds: [],
       },
     });
 


### PR DESCRIPTION
Adds a non-destructive **Exclude file** action for errored local workspace files.

Changes:
- Adds an Exclude file action next to Edit/Delete in the errored files UI.
- Removes excluded errored API/environment files from the current errored file list.
- Stores excluded errored record IDs in the workspace errored-records slice so subsequent refreshes keep filtering those excluded files during the current workspace session.
- Keeps Delete as the only destructive filesystem operation.
- Adds a small regression test for the pure errored-record exclusion helpers.

Verification:
- `node app/src/features/apiClient/slices/erroredRecords/erroredRecords.utils.test.cjs`
- `node --check app/src/features/apiClient/slices/erroredRecords/erroredRecords.utils.js`
- `git diff --check`

Note: I could not run the full app test suite in this environment because npm/node_modules are not available.

Fixes #3746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Exclude file" action added to error file items so users can hide errored files (API- or environment-scoped).
  * Excluded files are removed from the visible list and show a success notification.

* **Behavior**
  * Exclusions persist across views and context reloads so hidden files remain out of the list.

* **Style**
  * Error-file action buttons now reveal on hover/focus and have improved focus outlines.

* **Tests**
  * Added unit tests covering exclusion and visibility logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->