### PR TITLE
Fix source filter badge count for empty filters

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.js
@@ -1,0 +1,31 @@
+const SOURCE_FILTER_KEYS = {
+  RESOURCE_TYPE: "resourceType",
+  REQUEST_METHOD: "requestMethod",
+  REQUEST_DATA: "requestPayload",
+  PAGE_DOMAINS: "pageDomains",
+};
+
+const hasNonEmptyArray = (value) => Array.isArray(value) && value.length > 0;
+
+const hasNonEmptyText = (value) => typeof value === "string" && value.trim().length > 0;
+
+const hasAppliedRequestPayloadFilter = (requestPayload) => {
+  if (!requestPayload || typeof requestPayload !== "object" || Array.isArray(requestPayload)) {
+    return false;
+  }
+
+  return hasNonEmptyText(requestPayload.key) || hasNonEmptyText(requestPayload.value);
+};
+
+export const countAppliedSourceFilters = (filters = {}) => {
+  if (!filters || typeof filters !== "object" || Array.isArray(filters)) {
+    return 0;
+  }
+
+  return [
+    hasNonEmptyArray(filters[SOURCE_FILTER_KEYS.RESOURCE_TYPE]),
+    hasNonEmptyArray(filters[SOURCE_FILTER_KEYS.REQUEST_METHOD]),
+    hasNonEmptyArray(filters[SOURCE_FILTER_KEYS.PAGE_DOMAINS]),
+    hasAppliedRequestPayloadFilter(filters[SOURCE_FILTER_KEYS.REQUEST_DATA]),
+  ].filter(Boolean).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.test.js
@@ -5,6 +5,11 @@ describe("countAppliedSourceFilters", () => {
   it("returns 0 for empty filters", () => {
     expect(countAppliedSourceFilters()).toBe(0);
     expect(countAppliedSourceFilters({})).toBe(0);
+    expect(countAppliedSourceFilters(null)).toBe(0);
+    expect(countAppliedSourceFilters([])).toBe(0);
+    expect(countAppliedSourceFilters("")).toBe(0);
+    expect(countAppliedSourceFilters(0)).toBe(0);
+    expect(countAppliedSourceFilters(false)).toBe(0);
   });
 
   it("ignores pageUrl and empty array filters", () => {

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { countAppliedSourceFilters } from "./filterCount";
+
+describe("countAppliedSourceFilters", () => {
+  it("returns 0 for empty filters", () => {
+    expect(countAppliedSourceFilters()).toBe(0);
+    expect(countAppliedSourceFilters({})).toBe(0);
+  });
+
+  it("ignores pageUrl and empty array filters", () => {
+    expect(
+      countAppliedSourceFilters({
+        pageUrl: { operator: "Contains", value: "example.com" },
+        resourceType: [],
+        requestMethod: [],
+        pageDomains: [],
+      })
+    ).toBe(0);
+  });
+
+  it("does not count requestPayload when only operator is present", () => {
+    expect(
+      countAppliedSourceFilters({
+        requestPayload: { operator: "Contains" },
+      })
+    ).toBe(0);
+  });
+
+  it("counts requestPayload when key or value has content", () => {
+    expect(
+      countAppliedSourceFilters({
+        requestPayload: { key: "operationName", operator: "Contains", value: "" },
+      })
+    ).toBe(1);
+
+    expect(
+      countAppliedSourceFilters({
+        requestPayload: { key: "", operator: "Contains", value: "getUsers" },
+      })
+    ).toBe(1);
+  });
+
+  it("counts each populated filter type once", () => {
+    expect(
+      countAppliedSourceFilters({
+        resourceType: ["xhr"],
+        requestMethod: ["GET"],
+        pageDomains: ["example.com"],
+        requestPayload: { key: "operationName", operator: "Equals", value: "getUsers" },
+      })
+    ).toBe(4);
+  });
+});

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -39,7 +39,7 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
   const { MODE } = getModeData(window.location);
 
   const isSourceFilterFormatUpgraded = useCallback((pairIndex, rule) => {
-    return Array.isArray(rule.pairs[pairIndex].source.filters);
+    return Array.isArray(rule?.pairs?.[pairIndex]?.source?.filters);
   }, []);
 
   const migrateToNewSourceFilterFormat = useCallback(
@@ -71,10 +71,9 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      const sourceFilters = isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0]
-        : currentlySelectedRuleData.pairs[pairIndex].source.filters;
+      const sourceFilters = isSourceFilterFormatUpgraded(pairIndex, currentlySelectedRuleData)
+        ? currentlySelectedRuleData?.pairs?.[pairIndex]?.source?.filters?.[0]
+        : currentlySelectedRuleData?.pairs?.[pairIndex]?.source?.filters;
 
       return countAppliedSourceFilters(sourceFilters);
     },

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -20,6 +20,7 @@ import { isFeatureCompatible } from "utils/CompatibilityUtils";
 import FEATURES from "config/constants/sub/features";
 import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
+import { countAppliedSourceFilters } from "./filterCount";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
 import "./RequestSourceRow.css";
@@ -71,13 +72,11 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
   const getFilterCount = useCallback(
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const sourceFilters = isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0]
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters;
+
+      return countAppliedSourceFilters(sourceFilters);
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );


### PR DESCRIPTION
## Summary
- count source filter badges only when a filter has an applied value
- keep pageUrl excluded from the count to preserve existing behavior
- add focused tests for empty arrays, pageUrl, and requestPayload operator-only cases

Fixes #3826.

## Test plan
- `npx vitest run src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.test.js`
- `npx prettier --check src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.test.js`
- `npx eslint --ext .js,.jsx src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/filterCount.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized filter-counting logic used to compute the filter badge, improving reliability and preventing edge-case errors when reading filter data.

* **Tests**
  * Added comprehensive tests to validate filter-count behavior across empty, partial, and fully populated filter scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->