### PR TITLE
Add missing API client icon tooltips

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/MultiWorkspaceSidebar/WorkspaceProvider/WorkspaceCollapse/WorkspaceCollapse.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
 import { MdOutlineArrowForwardIos } from "@react-icons/all-files/md/MdOutlineArrowForwardIos";
-import { Collapse, Dropdown, MenuProps, Typography } from "antd";
+import { Collapse, Dropdown, MenuProps, Tooltip, Typography } from "antd";
 import { Conditional } from "components/common/Conditional";
 import { useRBAC } from "features/rbac";
 import { RQButton } from "lib/design-system-v2/components";
@@ -157,20 +157,22 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                     {showNewRecordBtn ? (
                       <>
                         {type === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-                          <RQButton
-                            size="small"
-                            type="transparent"
-                            icon={<MdAdd />}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onNewClickV2({
-                                contextId: workspaceId,
-                                analyticEventSource: "api_client_sidebar_header",
-                                recordType: RQAPI.RecordType.ENVIRONMENT,
-                                collectionId: undefined,
-                              });
-                            }}
-                          />
+                          <Tooltip title="New environment">
+                            <RQButton
+                              size="small"
+                              type="transparent"
+                              icon={<MdAdd />}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onNewClickV2({
+                                  contextId: workspaceId,
+                                  analyticEventSource: "api_client_sidebar_header",
+                                  recordType: RQAPI.RecordType.ENVIRONMENT,
+                                  collectionId: undefined,
+                                });
+                              }}
+                            />
+                          </Tooltip>
                         ) : (
                           <NewApiRecordDropdown
                             invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
@@ -186,12 +188,14 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                               });
                             }}
                           >
-                            <RQButton
-                              size="small"
-                              type="transparent"
-                              icon={<MdAdd />}
-                              onClick={(e) => e.stopPropagation()}
-                            />
+                            <Tooltip title="New request or collection">
+                              <RQButton
+                                size="small"
+                                type="transparent"
+                                icon={<MdAdd />}
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                            </Tooltip>
                           </NewApiRecordDropdown>
                         )}
                       </>
@@ -203,14 +207,16 @@ export const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
                       placement="bottomRight"
                       overlayClassName="collection-dropdown-menu"
                     >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
+                      <Tooltip title="More actions">
+                        <RQButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                          size="small"
+                          type="transparent"
+                          icon={<MdOutlineMoreHoriz />}
+                        />
+                      </Tooltip>
                     </Dropdown>
                   </div>
                 </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/ErrorFilesList/ErrorFileslist.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/ErrorFilesList/ErrorFileslist.tsx
@@ -53,7 +53,9 @@ const DeleteErrorFileButton = ({ onDelete }: { onDelete: () => void }) => {
       }}
     >
       {/* TODO: Use RQ icononly button */}
-      <RiDeleteBin6Line className="error-file-item-action-icon" onClick={() => setIsConfirmationPopupOpen(true)} />
+      <Tooltip title="Delete" color="var(--requestly-color-black)" placement="top">
+        <RiDeleteBin6Line className="error-file-item-action-icon" onClick={() => setIsConfirmationPopupOpen(true)} />
+      </Tooltip>
     </Popconfirm>
   );
 };

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/collectionRow/CollectionRow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
-import { Checkbox, Dropdown, MenuProps, Skeleton, Typography, notification } from "antd";
+import { Checkbox, Dropdown, MenuProps, Skeleton, Tooltip, Typography, notification } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQAPI as SharedRQAPI } from "@requestly/shared/types/entities/apiClient";
 import { RQButton } from "lib/design-system-v2/components";
@@ -493,7 +493,14 @@ export const CollectionRow: React.FC<Props> = ({
                         });
                       }}
                     >
-                      <RQButton size="small" type="transparent" icon={<MdAdd />} onClick={(e) => e.stopPropagation()} />
+                      <Tooltip title="New request or collection">
+                        <RQButton
+                          size="small"
+                          type="transparent"
+                          icon={<MdAdd />}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      </Tooltip>
                     </NewApiRecordDropdown>
                     <Dropdown
                       trigger={["click"]}
@@ -501,15 +508,17 @@ export const CollectionRow: React.FC<Props> = ({
                       placement="bottomRight"
                       overlayClassName="collection-dropdown-menu"
                     >
-                      <RQButton
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowSelection(false);
-                        }}
-                        size="small"
-                        type="transparent"
-                        icon={<MdOutlineMoreHoriz />}
-                      />
+                      <Tooltip title="More actions">
+                        <RQButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setShowSelection(false);
+                          }}
+                          size="small"
+                          type="transparent"
+                          icon={<MdOutlineMoreHoriz />}
+                        />
+                      </Tooltip>
                     </Dropdown>
                   </div>
                 </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/exampleRow/ExampleRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps } from "antd";
+import { Typography, Dropdown, MenuProps, Tooltip } from "antd";
 import { RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
@@ -275,14 +275,16 @@ export const ExampleRow: React.FC<Props> = ({ record, isReadOnly, handleRecordsT
               open={isDropdownVisible}
               onOpenChange={setIsDropdownVisible}
             >
-              <RQButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-                size="small"
-                type="transparent"
-                icon={<MdOutlineMoreHoriz />}
-              />
+              <Tooltip title="More actions">
+                <RQButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  size="small"
+                  type="transparent"
+                  icon={<MdOutlineMoreHoriz />}
+                />
+              </Tooltip>
             </Dropdown>
           </div>
         </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Typography, Dropdown, MenuProps, Checkbox, notification } from "antd";
+import { Typography, Dropdown, MenuProps, Checkbox, notification, Tooltip } from "antd";
 import { REQUEST_METHOD_BACKGROUND_COLORS, REQUEST_METHOD_COLORS } from "../../../../../../../../../constants";
 import { RequestMethod, RQAPI } from "features/apiClient/types";
 import { RQButton } from "lib/design-system-v2/components";
@@ -500,15 +500,17 @@ export const RequestRow: React.FC<Props> = ({
             open={isDropdownVisible}
             onOpenChange={handleDropdownVisibleChange}
           >
-            <RQButton
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowSelection(false);
-              }}
-              size="small"
-              type="transparent"
-              icon={<MdOutlineMoreHoriz />}
-            />
+            <Tooltip title="More actions">
+              <RQButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowSelection(false);
+                }}
+                size="small"
+                type="transparent"
+                icon={<MdOutlineMoreHoriz />}
+              />
+            </Tooltip>
           </Dropdown>
         </div>
       </Conditional>
@@ -646,15 +648,17 @@ export const RequestRow: React.FC<Props> = ({
                   open={isDropdownVisible}
                   onOpenChange={handleDropdownVisibleChange}
                 >
-                  <RQButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowSelection(false);
-                    }}
-                    size="small"
-                    type="transparent"
-                    icon={<MdOutlineMoreHoriz />}
-                  />
+                  <Tooltip title="More actions">
+                    <RQButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowSelection(false);
+                      }}
+                      size="small"
+                      type="transparent"
+                      icon={<MdOutlineMoreHoriz />}
+                    />
+                  </Tooltip>
                 </Dropdown>
               </div>
             </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
@@ -55,16 +55,17 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
 
       {listType ? (
         listType === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-          <RQButton
-            size="small"
-            type="transparent"
-            icon={<MdAdd />}
-            title="Create new environment"
-            className="sidebar-list-header-button"
-            onClick={() => {
-              onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
-            }}
-          />
+          <Tooltip title="New environment">
+            <RQButton
+              size="small"
+              type="transparent"
+              icon={<MdAdd />}
+              className="sidebar-list-header-button"
+              onClick={() => {
+                onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
+              }}
+            />
+          </Tooltip>
         ) : null
       ) : (
         showNewRecordAction && (
@@ -74,7 +75,9 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
               onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
             }}
           >
-            <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            <Tooltip title="New request or collection">
+              <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            </Tooltip>
           </NewApiRecordDropdown>
         )
       )}


### PR DESCRIPTION
Closes issue: #3868

## Summary of changes

Added missing hover tooltips for icon-only controls in the API client sidebar.

This covers:
- New environment buttons
- New request or collection buttons
- More actions buttons
- Delete action for errored files

## Test instructions

Open the API client and hover over sidebar icon-only actions. Confirm tooltips appear with labels such as `New environment`, `New request or collection`, `More actions`, and `Delete`.

## Local verification

Ran `git diff --check` successfully.

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->

## ✅ Checklist:

- [ ] Make sure linting and unit tests pass.
- [ ] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [ ] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

<!-- Add instructions to test these changes -->

## 🔗 Other references:

<!-- If this PR fixes more issues, list here. -->
<!-- If this PR is related to other PRs, list here. -->
<!-- List other important links here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hover tooltips to key sidebar action buttons across the API client—includes "New environment", "New request or collection", "More actions", and delete controls—improving discoverability and clarity of available actions in lists, rows, and collapse/expand views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->