### PR TITLE
Allow sharing rules to private workspace

### DIFF
--- a/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
@@ -82,7 +82,7 @@ export const ShareFromWorkspace: React.FC<Props> = ({
   const handleTransferToOtherWorkspace = useCallback(
     (teamData: Workspace) => {
       setIsLoading(true);
-      duplicateRulesToTargetWorkspace(appMode, teamData.id!, selectedRules).then(() => {
+      duplicateRulesToTargetWorkspace(appMode, teamData.id, selectedRules).then(() => {
         setIsLoading(false);
         trackSharingModalRulesDuplicated("team", selectedRules.length);
         setPostShareViewData({
@@ -99,7 +99,11 @@ export const ShareFromWorkspace: React.FC<Props> = ({
 
   return (
     <>
-      <WorkspaceShareMenu onTransferClick={handleTransferToOtherWorkspace} isLoading={isLoading} />
+      <WorkspaceShareMenu
+        includePrivateWorkspace
+        onTransferClick={handleTransferToOtherWorkspace}
+        isLoading={isLoading}
+      />
       <div className="subheader mt-1">Share with Teammates</div>
       <div className="mt-8 text-gray">Collaborate in real-time with your teammates within a shared workspace.</div>
       <div className="mt-1">

--- a/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
@@ -82,17 +82,25 @@ export const ShareFromWorkspace: React.FC<Props> = ({
   const handleTransferToOtherWorkspace = useCallback(
     (teamData: Workspace) => {
       setIsLoading(true);
-      duplicateRulesToTargetWorkspace(appMode, teamData.id, selectedRules).then(() => {
-        setIsLoading(false);
-        trackSharingModalRulesDuplicated("team", selectedRules.length);
-        setPostShareViewData({
-          type: WorkspaceSharingTypes.EXISTING_WORKSPACE,
-          targetTeamData: teamData,
-          sourceTeamData: activeWorkspace,
-        });
+      duplicateRulesToTargetWorkspace(appMode, teamData.id, selectedRules)
+        .then(() => {
+          trackSharingModalRulesDuplicated("team", selectedRules.length);
+          setPostShareViewData({
+            type: WorkspaceSharingTypes.EXISTING_WORKSPACE,
+            targetTeamData: teamData,
+            sourceTeamData: activeWorkspace,
+          });
 
-        onRulesShared();
-      });
+          onRulesShared();
+        })
+        .catch(() => {
+          const errorMessage = "Could not copy rules to the selected workspace.";
+          toast.error(errorMessage);
+          trackSharingModalToastViewed(errorMessage);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
     },
     [appMode, onRulesShared, selectedRules, activeWorkspace, setPostShareViewData]
   );

--- a/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx
@@ -23,6 +23,14 @@ import { getAvailableBillingTeams } from "store/features/billing/selectors";
 import TEAM_WORKSPACES from "config/constants/sub/team-workspaces";
 import { getActiveWorkspace } from "store/slices/workspaces/selectors";
 import { Workspace } from "features/workspaces/types";
+import {
+  executeWorkspaceShareAction,
+  WORKSPACE_COPY_ERROR_MESSAGE,
+  WORKSPACE_INVITE_ERROR_MESSAGE,
+} from "./workspaceShareUtils";
+
+const WORKSPACE_MEMBER_ALREADY_INVITED_ERROR_MESSAGE =
+  "The user is either in the workspace or has a pending invite.";
 
 interface Props {
   selectedRules: string[];
@@ -40,50 +48,62 @@ export const ShareFromWorkspace: React.FC<Props> = ({
   const billingTeams = useSelector(getAvailableBillingTeams);
   const [memberEmails, setMemberEmails] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const showShareError = useCallback((errorMessage: string) => {
+    toast.error(errorMessage);
+    trackSharingModalToastViewed(errorMessage);
+  }, []);
 
   const handleInviteMembers = useCallback(() => {
-    setIsLoading(true);
     const createTeamInvites = httpsCallable(getFunctions(), "invites-createTeamInvites");
-    createTeamInvites({
-      teamId: activeWorkspace.id,
-      emails: memberEmails,
-      role: TeamRole.write,
-      teamName: activeWorkspace.name,
-      numberOfMembers: activeWorkspace.accessCount,
-      source: "sharing_modal_from_workspace",
-    }).then((res: any) => {
-      const hasSuccessfulInvite = res?.data.results.some((result: any) => result.success);
+    void executeWorkspaceShareAction({
+      action: () =>
+        createTeamInvites({
+          teamId: activeWorkspace.id,
+          emails: memberEmails,
+          role: TeamRole.write,
+          teamName: activeWorkspace.name,
+          numberOfMembers: activeWorkspace.accessCount,
+          source: "sharing_modal_from_workspace",
+        }).then((res: any) => {
+          const hasSuccessfulInvite = res?.data.results.some((result: any) => result.success);
 
-      if (hasSuccessfulInvite) {
-        trackAddTeamMemberSuccess({
-          team_id: activeWorkspace.id,
-          email: memberEmails,
-          is_admin: false,
-          source: "sharing_modal",
-          num_users_added: memberEmails.length,
-          workspace_type: isWorkspaceMappedToBillingTeam(activeWorkspace.id!, billingTeams)
-            ? TEAM_WORKSPACES.WORKSPACE_TYPE.MAPPED_TO_BILLING_TEAM
-            : TEAM_WORKSPACES.WORKSPACE_TYPE.NOT_MAPPED_TO_BILLING_TEAM,
-        });
+          if (!hasSuccessfulInvite) {
+            throw Object.assign(new Error("pending invite"), {
+              userFacingMessage: WORKSPACE_MEMBER_ALREADY_INVITED_ERROR_MESSAGE,
+            });
+          }
+
+          trackAddTeamMemberSuccess({
+            team_id: activeWorkspace.id,
+            email: memberEmails,
+            is_admin: false,
+            source: "sharing_modal",
+            num_users_added: memberEmails.length,
+            workspace_type: isWorkspaceMappedToBillingTeam(activeWorkspace.id!, billingTeams)
+              ? TEAM_WORKSPACES.WORKSPACE_TYPE.MAPPED_TO_BILLING_TEAM
+              : TEAM_WORKSPACES.WORKSPACE_TYPE.NOT_MAPPED_TO_BILLING_TEAM,
+          });
+        }),
+      errorMessage: WORKSPACE_INVITE_ERROR_MESSAGE,
+      onError: showShareError,
+      onSuccess: () => {
         setPostShareViewData({
           type: WorkspaceSharingTypes.USERS_INVITED,
         });
 
         onRulesShared();
-      } else {
-        const errorMessage = "The user is either in the workspace or has a pending invite.";
-        toast.error(errorMessage);
-        trackSharingModalToastViewed(errorMessage);
-      }
-      setIsLoading(false);
+      },
+      setIsLoading,
     });
-  }, [memberEmails, onRulesShared, activeWorkspace, setPostShareViewData, billingTeams]);
+  }, [memberEmails, onRulesShared, activeWorkspace, setPostShareViewData, billingTeams, showShareError]);
 
   const handleTransferToOtherWorkspace = useCallback(
     (teamData: Workspace) => {
-      setIsLoading(true);
-      duplicateRulesToTargetWorkspace(appMode, teamData.id, selectedRules)
-        .then(() => {
+      void executeWorkspaceShareAction({
+        action: () => duplicateRulesToTargetWorkspace(appMode, teamData.id, selectedRules),
+        errorMessage: WORKSPACE_COPY_ERROR_MESSAGE,
+        onError: showShareError,
+        onSuccess: () => {
           trackSharingModalRulesDuplicated("team", selectedRules.length);
           setPostShareViewData({
             type: WorkspaceSharingTypes.EXISTING_WORKSPACE,
@@ -92,17 +112,11 @@ export const ShareFromWorkspace: React.FC<Props> = ({
           });
 
           onRulesShared();
-        })
-        .catch(() => {
-          const errorMessage = "Could not copy rules to the selected workspace.";
-          toast.error(errorMessage);
-          trackSharingModalToastViewed(errorMessage);
-        })
-        .finally(() => {
-          setIsLoading(false);
-        });
+        },
+        setIsLoading,
+      });
     },
-    [appMode, onRulesShared, selectedRules, activeWorkspace, setPostShareViewData]
+    [appMode, onRulesShared, selectedRules, activeWorkspace, setPostShareViewData, showShareError]
   );
 
   return (

--- a/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
@@ -5,7 +5,7 @@ import { RQButton } from "lib/design-system/components";
 import { MdOutlineKeyboardArrowDown } from "@react-icons/all-files/md/MdOutlineKeyboardArrowDown";
 import type { MenuProps } from "antd";
 import { trackShareModalWorkspaceDropdownClicked } from "modules/analytics/events/misc/sharing";
-import { getActiveWorkspace, getAllWorkspaces } from "store/slices/workspaces/selectors";
+import { dummyPersonalWorkspace, getActiveWorkspace, getAllWorkspaces } from "store/slices/workspaces/selectors";
 import { Workspace } from "features/workspaces/types";
 import WorkspaceAvatar from "features/workspaces/components/WorkspaceAvatar";
 
@@ -14,6 +14,7 @@ interface Props {
    * The default number of active workspaces to display before dropdown menu.
    */
   defaultActiveWorkspaces?: number;
+  includePrivateWorkspace?: boolean;
   onTransferClick: (teamData: Workspace) => void;
   isLoading: boolean;
 }
@@ -26,20 +27,32 @@ interface WorkspaceItemProps {
   isLoading?: boolean;
 }
 
-export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading, defaultActiveWorkspaces = 0 }) => {
+export const WorkspaceShareMenu: React.FC<Props> = ({
+  onTransferClick,
+  isLoading,
+  defaultActiveWorkspaces = 0,
+  includePrivateWorkspace = false,
+}) => {
   const availableWorkspaces = useSelector(getAllWorkspaces);
   const activeWorkspace = useSelector(getActiveWorkspace);
 
-  const filteredAvailableWorkspaces = availableWorkspaces.filter((workspace) => !workspace.browserstackDetails); // Filtering our Browserstack Workspaces)
+  const filteredAvailableWorkspaces = useMemo(
+    () => availableWorkspaces.filter((workspace) => !workspace.browserstackDetails),
+    [availableWorkspaces]
+  ); // Filtering our Browserstack Workspaces)
+
+  const shareableWorkspaces = useMemo(
+    () =>
+      includePrivateWorkspace ? [dummyPersonalWorkspace, ...filteredAvailableWorkspaces] : filteredAvailableWorkspaces,
+    [filteredAvailableWorkspaces, includePrivateWorkspace]
+  );
 
   const sortedTeams: Workspace[] = useMemo(
     () =>
-      filteredAvailableWorkspaces
-        ? [...filteredAvailableWorkspaces].sort(
-            (a: Workspace, b: Workspace) => (b.accessCount ?? 0) - (a.accessCount ?? 0)
-          )
+      shareableWorkspaces
+        ? [...shareableWorkspaces].sort((a: Workspace, b: Workspace) => (b.accessCount ?? 0) - (a.accessCount ?? 0))
         : [],
-    [filteredAvailableWorkspaces]
+    [shareableWorkspaces]
   );
 
   const menuItems: MenuProps["items"] = useMemo(() => {
@@ -103,7 +116,7 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
           menu={{ items: menuItems }}
           placement="bottom"
           overlayClassName="workspace-share-menu-wrapper"
-          trigger={filteredAvailableWorkspaces?.length > 1 ? ["click"] : undefined}
+          trigger={shareableWorkspaces?.length > 1 ? ["click"] : undefined}
           onOpenChange={(open) => {
             if (open) trackShareModalWorkspaceDropdownClicked();
           }}
@@ -124,6 +137,8 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   showArrow = false,
   isLoading = false,
 }) => {
+  const memberCount = workspace.accessCount ?? workspace.membersCount ?? 0;
+
   return (
     <div
       className={`workspace-share-menu-item-card ${
@@ -135,7 +150,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         <span className="workspace-card-description">
           <div className="text-white">{workspace.name}</div>
           <div className="text-gray">
-            {workspace.accessCount ?? 0} {(workspace.accessCount ?? 0) !== 1 ? "members" : "member"}
+            {memberCount} {memberCount !== 1 ? "members" : "member"}
           </div>
         </span>
       </Row>

--- a/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
@@ -68,6 +68,8 @@ export const WorkspaceShareMenu: React.FC<Props> = ({
       .filter(Boolean);
   }, [sortedTeams, activeWorkspace?.id, onTransferClick, defaultActiveWorkspaces, isLoading]);
 
+  const isDropdownEnabled = shareableWorkspaces.length > 1;
+
   const chooseOtherWorkspaceItem = (
     <div className="workspace-share-menu-item-card workspace-share-menu-dropdown">
       <Row align="middle" className="items-center">
@@ -116,13 +118,17 @@ export const WorkspaceShareMenu: React.FC<Props> = ({
           menu={{ items: menuItems }}
           placement="bottom"
           overlayClassName="workspace-share-menu-wrapper"
-          trigger={shareableWorkspaces?.length > 1 ? ["click"] : undefined}
+          trigger={isDropdownEnabled ? ["click"] : undefined}
           onOpenChange={(open) => {
             if (open) trackShareModalWorkspaceDropdownClicked();
           }}
         >
           <div>
-            <WorkspaceItem workspace={activeWorkspace} showArrow availableWorkspaces={filteredAvailableWorkspaces} />
+            <WorkspaceItem
+              workspace={activeWorkspace}
+              showArrow={isDropdownEnabled}
+              availableWorkspaces={shareableWorkspaces}
+            />
           </div>
         </Dropdown>
       )}

--- a/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
@@ -8,6 +8,7 @@ import { trackShareModalWorkspaceDropdownClicked } from "modules/analytics/event
 import { dummyPersonalWorkspace, getActiveWorkspace, getAllWorkspaces } from "store/slices/workspaces/selectors";
 import { Workspace } from "features/workspaces/types";
 import WorkspaceAvatar from "features/workspaces/components/WorkspaceAvatar";
+import { isWorkspaceShareDropdownEnabled } from "./workspaceShareUtils";
 
 interface Props {
   /**
@@ -21,7 +22,6 @@ interface Props {
 
 interface WorkspaceItemProps {
   workspace: Workspace;
-  availableWorkspaces?: Workspace[];
   onTransferClick?: (teamData: Workspace) => void;
   showArrow?: boolean;
   isLoading?: boolean;
@@ -68,7 +68,7 @@ export const WorkspaceShareMenu: React.FC<Props> = ({
       .filter(Boolean);
   }, [sortedTeams, activeWorkspace?.id, onTransferClick, defaultActiveWorkspaces, isLoading]);
 
-  const isDropdownEnabled = shareableWorkspaces.length > 1;
+  const isDropdownEnabled = isWorkspaceShareDropdownEnabled(shareableWorkspaces);
 
   const chooseOtherWorkspaceItem = (
     <div className="workspace-share-menu-item-card workspace-share-menu-dropdown">
@@ -124,11 +124,7 @@ export const WorkspaceShareMenu: React.FC<Props> = ({
           }}
         >
           <div>
-            <WorkspaceItem
-              workspace={activeWorkspace}
-              showArrow={isDropdownEnabled}
-              availableWorkspaces={shareableWorkspaces}
-            />
+            <WorkspaceItem workspace={activeWorkspace} showArrow={isDropdownEnabled} />
           </div>
         </Dropdown>
       )}
@@ -139,18 +135,13 @@ export const WorkspaceShareMenu: React.FC<Props> = ({
 const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   workspace,
   onTransferClick,
-  availableWorkspaces,
   showArrow = false,
   isLoading = false,
 }) => {
   const memberCount = workspace.accessCount ?? workspace.membersCount ?? 0;
 
   return (
-    <div
-      className={`workspace-share-menu-item-card ${
-        showArrow && (availableWorkspaces?.length ?? 0) > 1 ? "workspace-share-menu-dropdown" : ""
-      }`}
-    >
+    <div className={`workspace-share-menu-item-card ${showArrow ? "workspace-share-menu-dropdown" : ""}`}>
       <Row align="middle" className="items-center">
         <WorkspaceAvatar workspace={workspace} size={35} />
         <span className="workspace-card-description">
@@ -161,9 +152,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         </span>
       </Row>
       {showArrow ? (
-        availableWorkspaces?.length && availableWorkspaces?.length > 1 ? (
-          <MdOutlineKeyboardArrowDown className="text-gray header mr-8" />
-        ) : null
+        <MdOutlineKeyboardArrowDown className="text-gray header mr-8" />
       ) : (
         <RQButton
           disabled={isLoading}

--- a/app/src/components/common/SharingModal/Workspaces/workspaceShareUtils.test.ts
+++ b/app/src/components/common/SharingModal/Workspaces/workspaceShareUtils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WORKSPACE_COPY_ERROR_MESSAGE,
+  WORKSPACE_INVITE_ERROR_MESSAGE,
+  executeWorkspaceShareAction,
+  isWorkspaceShareDropdownEnabled,
+} from "./workspaceShareUtils";
+
+describe("workspaceShareUtils", () => {
+  it("enables the dropdown when private workspace adds a second destination", () => {
+    expect(isWorkspaceShareDropdownEnabled([{ id: "workspace-1" }])).toBe(false);
+    expect(
+      isWorkspaceShareDropdownEnabled([
+        { id: "workspace-1" },
+        { id: "private-workspace" },
+      ])
+    ).toBe(true);
+  });
+
+  it("surfaces copy failures and always clears loading", async () => {
+    const setIsLoading = vi.fn();
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    await executeWorkspaceShareAction({
+      action: () => Promise.reject(new Error("copy failed")),
+      errorMessage: WORKSPACE_COPY_ERROR_MESSAGE,
+      onError,
+      onSuccess,
+      setIsLoading,
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(WORKSPACE_COPY_ERROR_MESSAGE);
+    expect(setIsLoading.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it("surfaces invite failures and always clears loading", async () => {
+    const setIsLoading = vi.fn();
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    await executeWorkspaceShareAction({
+      action: () => Promise.reject(new Error("invite failed")),
+      errorMessage: WORKSPACE_INVITE_ERROR_MESSAGE,
+      onError,
+      onSuccess,
+      setIsLoading,
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(WORKSPACE_INVITE_ERROR_MESSAGE);
+    expect(setIsLoading.mock.calls).toEqual([[true], [false]]);
+  });
+});

--- a/app/src/components/common/SharingModal/Workspaces/workspaceShareUtils.ts
+++ b/app/src/components/common/SharingModal/Workspaces/workspaceShareUtils.ts
@@ -1,0 +1,39 @@
+import type { Workspace } from "features/workspaces/types";
+
+export const WORKSPACE_COPY_ERROR_MESSAGE = "Could not copy rules to the selected workspace.";
+export const WORKSPACE_INVITE_ERROR_MESSAGE = "Could not send workspace invites.";
+
+interface ExecuteWorkspaceShareActionOptions {
+  action: () => Promise<unknown>;
+  errorMessage: string;
+  onError: (message: string) => void;
+  onSuccess: () => void;
+  setIsLoading: (isLoading: boolean) => void;
+}
+
+type UserFacingError = Error & {
+  userFacingMessage?: string;
+};
+
+export const isWorkspaceShareDropdownEnabled = (shareableWorkspaces: Pick<Workspace, "id">[] = []): boolean =>
+  shareableWorkspaces.length > 1;
+
+export const executeWorkspaceShareAction = async ({
+  action,
+  errorMessage,
+  onError,
+  onSuccess,
+  setIsLoading,
+}: ExecuteWorkspaceShareActionOptions): Promise<void> => {
+  setIsLoading(true);
+
+  try {
+    await action();
+    onSuccess();
+  } catch (error) {
+    const userFacingMessage = (error as UserFacingError)?.userFacingMessage;
+    onError(userFacingMessage || errorMessage);
+  } finally {
+    setIsLoading(false);
+  }
+};

--- a/app/src/components/common/SharingModal/actions.ts
+++ b/app/src/components/common/SharingModal/actions.ts
@@ -77,7 +77,7 @@ export const prepareContentToExport = (appMode: string, selectedRuleIds: string[
 
 export const duplicateRulesToTargetWorkspace = async (
   appMode: string,
-  workspaceId: string,
+  workspaceId: Workspace["id"],
   ruleIdsToShare: string[]
 ) => {
   const { rules, groups } = await getRulesAndGroupsFromRuleIds(appMode, ruleIdsToShare);


### PR DESCRIPTION
## Summary
- include Private Workspace in the Share in workspace dropdown when sharing from a shared workspace
- pass the private workspace `null` id through the existing duplicate flow
- keep the workspace menu reusable by making private-workspace inclusion opt-in

Fixes #3825.

## Test plan
- `npx prettier --check src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx src/components/common/SharingModal/actions.ts`
- `npx eslint --ext .ts,.tsx src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx src/components/common/SharingModal/Workspaces/ShareFromWorkspace.tsx src/components/common/SharingModal/actions.ts`
- `git diff --check`

Note: I also tried `npx tsc --noEmit --pretty false`, but it currently fails on existing project-wide missing-module/type errors unrelated to these files, including `@requestly/shared/types/entities/rules` and several `features/apiClient/...` imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to include the personal workspace in the workspace-sharing dropdown.
  * Shared handling for loading, success, and user-facing error toasts across invite and transfer flows.

* **Bug Fixes**
  * Member count display falls back correctly and handles singular/plural.
  * More robust rule transfer behavior with cleaner loading/error handling.

* **Tests**
  * Added tests covering dropdown enablement and error/display behavior for share flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->