### PR TITLE
fix: filter count shows 1 when no filter values are set (#3826)

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -71,13 +71,24 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
   const getFilterCount = useCallback(
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const filters = isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters || {};
+
+      return Object.entries(filters).filter(([key, value]) => {
+        // PAGE_URL is the base URL field — always present, not a user-applied filter
+        if (key === GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL) {
+          return false;
+        }
+        // Only count filters that have meaningful values set
+        if (Array.isArray(value)) {
+          return value.length > 0;
+        }
+        if (typeof value === "object" && value !== null) {
+          return Object.keys(value).length > 0;
+        }
+        return value !== undefined && value !== null && value !== "";
+      }).length;
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );


### PR DESCRIPTION
## Summary

Fixes the bug where the rule editor incorrectly displays "1 applied filter" even when no filter values have been configured.

## Root Cause

The `getFilterCount` function in `RequestSourceRow/index.js` was counting filter **keys** present in the source filters object, without checking whether those keys had meaningful values. When a rule is imported from a shared list, filter keys (like `resourceType`, `requestMethod`, `pageDomains`) can exist in the object with empty arrays or null/undefined values, causing a misleading filter count badge.

## What Was Fixed

Modified `getFilterCount` to validate each filter's value before counting it:
- **Arrays** (`resourceType`, `requestMethod`, `pageDomains`): must have `length > 0`
- **Objects** (`requestPayload`): must have at least one key
- **Strings/Other**: must be non-empty, non-null, non-undefined
- `PAGE_URL` is still excluded as it represents the base URL field (always present)

## Testing Done

- Code review of the filter count logic
- Verified the fix handles both old and upgraded filter formats
- The change is backwards compatible — only affects the display count, not filter behavior

## Related Issue

Fixes #3826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filter counting to accurately reflect only active request source filters with meaningful values set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->