### PR TITLE
Fix source filter badge count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -20,6 +20,7 @@ import { isFeatureCompatible } from "utils/CompatibilityUtils";
 import FEATURES from "config/constants/sub/features";
 import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
+import { getAppliedSourceFilterCount } from "./utils";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
 import "./RequestSourceRow.css";
@@ -70,16 +71,11 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const sourceFilters = currentlySelectedRuleData.pairs[pairIndex].source.filters;
+
+      return getAppliedSourceFilterCount(sourceFilters, GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL);
     },
-    [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
+    [currentlySelectedRuleData]
   );
 
   const sourceKeys = useMemo(

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
@@ -1,0 +1,25 @@
+const getSourceFilterObject = (sourceFilters) => {
+  return Array.isArray(sourceFilters) ? sourceFilters[0] || {} : sourceFilters || {};
+};
+
+const hasMeaningfulValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value).some(([key, nestedValue]) => key !== "operator" && hasMeaningfulValue(nestedValue));
+  }
+
+  return value !== null && value !== undefined && value !== false;
+};
+
+export const getAppliedSourceFilterCount = (sourceFilters, pageUrlFilterKey = "pageUrl") => {
+  const filters = getSourceFilterObject(sourceFilters);
+
+  return Object.entries(filters).filter(([key, value]) => key !== pageUrlFilterKey && hasMeaningfulValue(value)).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { getAppliedSourceFilterCount } from "./utils";
+
+describe("getAppliedSourceFilterCount", () => {
+  it("does not count page URL filters", () => {
+    expect(
+      getAppliedSourceFilterCount([
+        {
+          pageUrl: {
+            operator: "Contains",
+            value: "example.com",
+          },
+        },
+      ])
+    ).toBe(0);
+  });
+
+  it("does not count empty request payload filters", () => {
+    expect(
+      getAppliedSourceFilterCount([
+        {
+          requestPayload: {
+            key: "",
+            operator: "Contains",
+            value: "",
+          },
+        },
+      ])
+    ).toBe(0);
+  });
+
+  it("does not count filters with empty arrays or operator-only objects", () => {
+    expect(
+      getAppliedSourceFilterCount([
+        {
+          requestMethod: [],
+          resourceType: [],
+          requestPayload: {
+            operator: "Contains",
+          },
+        },
+      ])
+    ).toBe(0);
+  });
+
+  it("counts request payload filters with meaningful values", () => {
+    expect(
+      getAppliedSourceFilterCount([
+        {
+          requestPayload: {
+            key: "operationName",
+            operator: "Contains",
+            value: "GetUser",
+          },
+        },
+      ])
+    ).toBe(1);
+  });
+
+  it("counts legacy non-array source filters", () => {
+    expect(
+      getAppliedSourceFilterCount({
+        requestMethod: ["GET"],
+        resourceType: ["xmlhttprequest"],
+      })
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes issue: #3826

## 📜 Summary of changes:

- Counts only source filters with meaningful values for the rule source filter badge.
- Keeps page URL filters excluded from the applied-filter badge count.
- Adds unit coverage for empty request payload/default filters and meaningful source filters.

## 🎥 Demo Video:

**Video/Demo:** Not attached. This is a focused count-logic fix covered by unit tests.

## ✅ Checklist:

- [x] Make sure linting and unit tests pass.
- [x] No install/build warnings introduced.
- [ ] Verified UI in browser.
- [ ] For UI changes, added/updated analytics events (if applicable).
- [ ] For changes in extension's code, manually tested in Chrome and Firefox.
- [x] Added/updated unit tests for this change.
- [ ] Raised pull request to update corresponding documentation (if already exists).
- [ ] **Added demo video showing the changes in action** (if applicable).

## 🧪 Test instructions:

```bash
cd app
npm test -- src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js --run
npx eslint src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
```

## 🔗 Other references:

Bounty issue: #3826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by extracting and centralizing request source filter counting logic into a shared utility module.

* **Tests**
  * Added comprehensive test coverage for the new filter counting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->