### PR TITLE
Fix empty source filter badge count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -23,6 +23,7 @@ import { sampleRegex } from "./sampleRegex";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
 import "./RequestSourceRow.css";
+import { getAppliedSourceFilterCount } from "./utils";
 
 const { Text } = Typography;
 
@@ -70,16 +71,12 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      return getAppliedSourceFilterCount(
+        currentlySelectedRuleData.pairs[pairIndex].source.filters,
+        GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
+      );
     },
-    [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
+    [currentlySelectedRuleData]
   );
 
   const sourceKeys = useMemo(

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
@@ -1,0 +1,54 @@
+const DEFAULT_PAGE_URL_FILTER_KEY = "pageUrl";
+const REQUEST_PAYLOAD_FILTER_KEY = "requestPayload";
+
+const hasMeaningfulPrimitiveValue = (value) => {
+  if (value === null || typeof value === "undefined") {
+    return false;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  return true;
+};
+
+const hasMeaningfulNestedValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.some(hasMeaningfulNestedValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(hasMeaningfulNestedValue);
+  }
+
+  return hasMeaningfulPrimitiveValue(value);
+};
+
+const hasMeaningfulRequestPayloadFilter = (requestPayloadFilter) => {
+  if (!requestPayloadFilter || typeof requestPayloadFilter !== "object") {
+    return false;
+  }
+
+  return (
+    hasMeaningfulPrimitiveValue(requestPayloadFilter.key) &&
+    hasMeaningfulPrimitiveValue(requestPayloadFilter.value)
+  );
+};
+
+export const hasAppliedSourceFilterValue = (filterKey, filterValue) => {
+  if (filterKey === REQUEST_PAYLOAD_FILTER_KEY) {
+    return hasMeaningfulRequestPayloadFilter(filterValue);
+  }
+
+  return hasMeaningfulNestedValue(filterValue);
+};
+
+export const getAppliedSourceFilterCount = (sourceFilters, pageUrlFilterKey = DEFAULT_PAGE_URL_FILTER_KEY) => {
+  const sourceFilter = Array.isArray(sourceFilters) ? sourceFilters[0] || {} : sourceFilters || {};
+
+  return Object.entries(sourceFilter).filter(
+    ([filterKey, filterValue]) =>
+      filterKey !== pageUrlFilterKey && hasAppliedSourceFilterValue(filterKey, filterValue)
+  ).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getAppliedSourceFilterCount } from "./utils";
+
+describe("getAppliedSourceFilterCount", () => {
+  it("does not count empty source filter defaults", () => {
+    expect(
+      getAppliedSourceFilterCount([
+        {
+          pageUrl: [{ operator: "Contains", value: "" }],
+          pageDomains: [],
+          requestMethod: [],
+          resourceType: [],
+          requestPayload: { operator: "Equals" },
+        },
+      ])
+    ).toBe(0);
+  });
+
+  it("counts only filters with meaningful values", () => {
+    expect(
+      getAppliedSourceFilterCount([
+        {
+          requestMethod: ["POST"],
+          resourceType: [],
+          requestPayload: { key: "user.id", operator: "Equals", value: "123" },
+        },
+      ])
+    ).toBe(2);
+  });
+
+  it("supports legacy object-shaped source filters", () => {
+    expect(
+      getAppliedSourceFilterCount({
+        pageUrl: [{ operator: "Contains", value: "app.example.com" }],
+        resourceType: ["xmlhttprequest"],
+      })
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- count only source filters with meaningful values in the RequestSourceRow badge
- ignore empty arrays and operator-only requestPayload defaults so imported shared rules without configured filters show no applied filter badge
- keep legacy object-shaped source filters supported

Fixes #3826.

## Verification
- npm test -- src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js --run
- npx eslint src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the accuracy of filter count indicators for request source configurations, with enhanced support for different filter format variations.

* **Tests**
  * Added comprehensive test coverage for filter validation and counting logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->