### PR TITLE
fix: ignore empty source filters in rule badge count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -26,6 +26,18 @@ import "./RequestSourceRow.css";
 
 const { Text } = Typography;
 
+const hasFilterValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.some(hasFilterValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(hasFilterValue);
+  }
+
+  return value !== undefined && value !== null && value !== "";
+};
+
 const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabled }) => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -70,14 +82,13 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const filters = isSourceFilterFormatUpgraded(pairIndex, currentlySelectedRuleData)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters || {};
+
+      return Object.entries(filters).filter(
+        ([key, value]) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL && hasFilterValue(value)
+      ).length;
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );


### PR DESCRIPTION
## Summary
- Count only source filters that contain meaningful values when rendering the rule filter badge
- Ignore empty arrays, empty nested objects, empty strings, null, undefined, and the page URL filter
- Remove an unnecessary deep clone while computing the badge count

Fixes #3826

## Testing
- Not run: local dependencies are not installed, and `npm ci` is currently blocked because `app/package.json` and `app/package-lock.json` are out of sync (`@requestly/shared@1.0.10` missing from lock file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed filter counting to properly detect active advanced source filters when nested values are configured, ensuring accurate filter status displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->