### PR TITLE
fix: keep request bot within viewport

### DIFF
--- a/app/src/features/requestBot/RequestBot.tsx
+++ b/app/src/features/requestBot/RequestBot.tsx
@@ -40,7 +40,7 @@ export const RequestBot: React.FC<RequestBotProps> = ({ isOpen, onClose, modelTy
     <>
       <m.div
         initial={{ opacity: 0, right: -450 }}
-        animate={{ opacity: shouldShowBot ? 1 : 0, right: shouldShowBot ? 65 : -450 }}
+        animate={{ opacity: shouldShowBot ? 1 : 0, right: shouldShowBot ? 16 : -450 }}
         transition={{ duration: 0.2 }}
         className="request-bot"
         style={{ pointerEvents: shouldShowBot ? "auto" : "none" }}

--- a/app/src/features/requestBot/requestBot.css
+++ b/app/src/features/requestBot/requestBot.css
@@ -4,14 +4,17 @@
 
 .request-bot {
   position: fixed;
-  bottom: 30px;
-  right: 20px;
+  bottom: 16px;
+  right: 16px;
   z-index: 100;
-  width: 424px;
-  height: 640px;
+  width: min(424px, calc(100vw - 32px));
+  height: min(640px, calc(100vh - 32px));
+  max-width: calc(100vw - 32px);
+  max-height: calc(100vh - 32px);
   background-color: var(--requestly-color-surface-2);
   padding: 8px;
   border-radius: 1rem;
+  overflow: hidden;
 }
 
 .request-bot iframe {


### PR DESCRIPTION
## Summary
- keep the RequestBot panel inside the viewport by clamping width/height against `100vw` and `100vh`
- reduce the fixed visible right offset so the panel does not overflow horizontally on narrow screens
- hide overflow inside the rounded panel container

Fixes #3846

## Tests
- `npx prettier --check app/src/features/requestBot/RequestBot.tsx app/src/features/requestBot/requestBot.css`
- `git diff --check`

Note: `npx tsc --noEmit --pretty false app/src/features/requestBot/RequestBot.tsx` could not run in this local checkout because dependencies are not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved request bot positioning on screen for better visibility.
  * Updated request bot sizing to be responsive, adapting to different screen dimensions instead of fixed sizes.
  * Enhanced overflow handling to ensure content displays properly across all device types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->