### PR TITLE
fix: ignore empty source filters in badge count

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -92,14 +92,13 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
 
   const getFilterCount = useCallback(
     (pairIndex) => {
-      const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
       const sourceFilters = currentlySelectedRuleData.pairs[pairIndex].source.filters;
 
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
+      return Array.isArray(sourceFilters)
         ? getAdvancedFiltersCount(sourceFilters[0])
         : getAdvancedFiltersCount(sourceFilters);
     },
-    [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
+    [currentlySelectedRuleData]
   );
 
   const sourceKeys = useMemo(

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -26,6 +26,28 @@ import "./RequestSourceRow.css";
 
 const { Text } = Typography;
 
+const hasFilterValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(hasFilterValue);
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  return value !== null && value !== undefined;
+};
+
+const getAdvancedFiltersCount = (filters) => {
+  return Object.entries(filters || {}).filter(([key, value]) => {
+    return key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL && hasFilterValue(value);
+  }).length;
+};
+
 const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabled }) => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -71,13 +93,11 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
   const getFilterCount = useCallback(
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
+      const sourceFilters = currentlySelectedRuleData.pairs[pairIndex].source.filters;
+
       return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+        ? getAdvancedFiltersCount(sourceFilters[0])
+        : getAdvancedFiltersCount(sourceFilters);
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -22,31 +22,10 @@ import { RQButton } from "lib/design-system-v2/components";
 import { sampleRegex } from "./sampleRegex";
 import { useLocation } from "react-router-dom";
 import PATHS from "config/constants/sub/paths";
+import { getAdvancedFiltersCount } from "./utils";
 import "./RequestSourceRow.css";
 
 const { Text } = Typography;
-
-const hasFilterValue = (value) => {
-  if (Array.isArray(value)) {
-    return value.length > 0;
-  }
-
-  if (value && typeof value === "object") {
-    return Object.values(value).some(hasFilterValue);
-  }
-
-  if (typeof value === "string") {
-    return value.trim().length > 0;
-  }
-
-  return value !== null && value !== undefined;
-};
-
-const getAdvancedFiltersCount = (filters) => {
-  return Object.entries(filters || {}).filter(([key, value]) => {
-    return key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL && hasFilterValue(value);
-  }).length;
-};
 
 const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisabled }) => {
   const dispatch = useDispatch();

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
@@ -1,0 +1,23 @@
+import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
+
+export const hasFilterValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.some(hasFilterValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(hasFilterValue);
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  return value !== null && value !== undefined;
+};
+
+export const getAdvancedFiltersCount = (filters) => {
+  return Object.entries(filters || {}).filter(([key, value]) => {
+    return key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL && hasFilterValue(value);
+  }).length;
+};

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.js
@@ -1,5 +1,7 @@
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
 
+const hasTextValue = (value) => typeof value === "string" && value.trim().length > 0;
+
 export const hasFilterValue = (value) => {
   if (Array.isArray(value)) {
     return value.some(hasFilterValue);
@@ -16,8 +18,20 @@ export const hasFilterValue = (value) => {
   return value !== null && value !== undefined;
 };
 
+const hasRequestPayloadFilterValue = (requestPayloadFilter) => {
+  return hasTextValue(requestPayloadFilter?.key) && hasTextValue(requestPayloadFilter?.value);
+};
+
 export const getAdvancedFiltersCount = (filters) => {
   return Object.entries(filters || {}).filter(([key, value]) => {
-    return key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL && hasFilterValue(value);
+    if (key === GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL) {
+      return false;
+    }
+
+    if (key === GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.REQUEST_DATA) {
+      return hasRequestPayloadFilterValue(value);
+    }
+
+    return hasFilterValue(value);
   }).length;
 };

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
@@ -25,6 +25,8 @@ describe("getAdvancedFiltersCount", () => {
     expect(getAdvancedFiltersCount({})).toBe(0);
     expect(getAdvancedFiltersCount({ requestPayload: {} })).toBe(0);
     expect(getAdvancedFiltersCount({ requestPayload: { key: "", value: "", operator: "" } })).toBe(0);
+    expect(getAdvancedFiltersCount({ requestPayload: { key: "operationName", value: "" } })).toBe(0);
+    expect(getAdvancedFiltersCount({ requestPayload: { key: "", value: "ProductsQuery" } })).toBe(0);
     expect(getAdvancedFiltersCount({ resourceType: [] })).toBe(0);
     expect(getAdvancedFiltersCount({ requestMethod: [""] })).toBe(0);
     expect(getAdvancedFiltersCount({ pageDomains: [{}] })).toBe(0);
@@ -37,7 +39,7 @@ describe("getAdvancedFiltersCount", () => {
   it("counts only meaningful advanced filters", () => {
     expect(getAdvancedFiltersCount({ resourceType: ["xhr"] })).toBe(1);
     expect(getAdvancedFiltersCount({ requestMethod: ["GET"], resourceType: [] })).toBe(1);
-    expect(getAdvancedFiltersCount({ requestPayload: { key: "operationName", value: "" } })).toBe(1);
+    expect(getAdvancedFiltersCount({ requestPayload: { key: "operationName", value: "ProductsQuery" } })).toBe(1);
     expect(getAdvancedFiltersCount({ pageUrl: { value: "https://example.com" }, pageDomains: ["example.com"] })).toBe(1);
   });
 });

--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/utils.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getAdvancedFiltersCount, hasFilterValue } from "./utils";
+
+describe("hasFilterValue", () => {
+  it("treats empty values as inactive", () => {
+    expect(hasFilterValue(null)).toBe(false);
+    expect(hasFilterValue(undefined)).toBe(false);
+    expect(hasFilterValue("")).toBe(false);
+    expect(hasFilterValue("   ")).toBe(false);
+    expect(hasFilterValue([])).toBe(false);
+    expect(hasFilterValue({})).toBe(false);
+    expect(hasFilterValue(["", null, {}])).toBe(false);
+  });
+
+  it("treats nested meaningful values as active", () => {
+    expect(hasFilterValue("xhr")).toBe(true);
+    expect(hasFilterValue(["", "xhr"])).toBe(true);
+    expect(hasFilterValue([{ value: "POST" }])).toBe(true);
+    expect(hasFilterValue({ requestPayload: { key: "operationName", value: "" } })).toBe(true);
+  });
+});
+
+describe("getAdvancedFiltersCount", () => {
+  it("does not count empty/default source filters", () => {
+    expect(getAdvancedFiltersCount({})).toBe(0);
+    expect(getAdvancedFiltersCount({ requestPayload: {} })).toBe(0);
+    expect(getAdvancedFiltersCount({ requestPayload: { key: "", value: "", operator: "" } })).toBe(0);
+    expect(getAdvancedFiltersCount({ resourceType: [] })).toBe(0);
+    expect(getAdvancedFiltersCount({ requestMethod: [""] })).toBe(0);
+    expect(getAdvancedFiltersCount({ pageDomains: [{}] })).toBe(0);
+  });
+
+  it("excludes page URL from the advanced filter count", () => {
+    expect(getAdvancedFiltersCount({ pageUrl: { value: "https://example.com" } })).toBe(0);
+  });
+
+  it("counts only meaningful advanced filters", () => {
+    expect(getAdvancedFiltersCount({ resourceType: ["xhr"] })).toBe(1);
+    expect(getAdvancedFiltersCount({ requestMethod: ["GET"], resourceType: [] })).toBe(1);
+    expect(getAdvancedFiltersCount({ requestPayload: { key: "operationName", value: "" } })).toBe(1);
+    expect(getAdvancedFiltersCount({ pageUrl: { value: "https://example.com" }, pageDomains: ["example.com"] })).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Count only source filters that have an actual configured value
- Ignore empty objects, empty arrays, arrays with empty entries, blank strings, and nullish values when rendering the advanced filters badge
- Require request payload filters to have both key and value before counting them as applied
- Keep page URL excluded from the advanced filters count
- Move the filter-counting logic into a small utility with regression coverage

Fixes #3826

## Testing
- Added unit coverage for empty/default filters, arrays with empty entries, meaningful filters, incomplete requestPayload defaults, pageUrl exclusion, and legacy object-shaped filters
- Verified the helper logic locally with a standalone Node check because this fresh clone does not have node_modules installed

## Demo
- No video attached because this is a small badge-counting logic fix; the regression cases are covered by the added unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate counting and activation detection of request-source filters, improving the displayed filter badges.
  * Correct handling of both legacy and upgraded filter formats so counts remain reliable.
  * Excludes page URL from advanced-filter totals to prevent inflated counts.

* **Tests**
  * Added tests validating filter detection and advanced-filter counting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->