### PR TITLE
fix: correct filter count when no filters are applied (#3826)

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -71,13 +71,17 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
   const getFilterCount = useCallback(
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const filters = isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters || {};
+
+      return Object.keys(filters).filter(
+        (key) =>
+          key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL &&
+          filters[key] !== undefined &&
+          filters[key] !== null &&
+          filters[key] !== ""
+      ).length;
     },
     [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
   );


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #3826

### Problem
When viewing a rule with no filters configured, the UI incorrectly displays "1 applied filter".

### Root Cause
The `getFilterCount` function in `RequestSourceRow/index.js` was counting filter keys even when their values were `undefined`, `null`, or empty strings.

For example, when `filters = { pageUrl: "...", resourceType: undefined }`, the function would count `resourceType` as a valid filter even though it has no actual value.

### Solution
Updated `getFilterCount` to filter out keys with falsy values (`undefined`, `null`, `""`) in addition to excluding `PAGE_URL`.

### Changes
- Modified `getFilterCount` function to check filter values before counting
- Added checks for `undefined`, `null`, and empty string values

### Testing
- [x] Verified filter count shows 0 when no filters are applied
- [x] Verified filter count correctly shows the number of valid filters when filters are configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request source filter count calculation to properly exclude empty filter values when computing active filters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->