### PR TITLE
feat: add Private Workspace option to share dropdown (#3825)

### DIFF
--- a/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
@@ -3,10 +3,11 @@ import { useSelector } from "react-redux";
 import { Avatar, Row, Dropdown } from "antd";
 import { RQButton } from "lib/design-system/components";
 import { MdOutlineKeyboardArrowDown } from "@react-icons/all-files/md/MdOutlineKeyboardArrowDown";
+import { LockOutlined } from "@ant-design/icons";
 import type { MenuProps } from "antd";
 import { trackShareModalWorkspaceDropdownClicked } from "modules/analytics/events/misc/sharing";
 import { getActiveWorkspace, getAllWorkspaces } from "store/slices/workspaces/selectors";
-import { Workspace } from "features/workspaces/types";
+import { Workspace, PrivateWorkspaceStub } from "features/workspaces/types";
 import WorkspaceAvatar from "features/workspaces/components/WorkspaceAvatar";
 
 interface Props {
@@ -43,7 +44,7 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
   );
 
   const menuItems: MenuProps["items"] = useMemo(() => {
-    return sortedTeams
+    const items = sortedTeams
       .slice(defaultActiveWorkspaces || 0)
       .map((team: Workspace, index: number) => {
         if (!defaultActiveWorkspaces && team?.id === activeWorkspace?.id) return null;
@@ -53,7 +54,41 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
         };
       })
       .filter(Boolean);
-  }, [sortedTeams, activeWorkspace?.id, onTransferClick, defaultActiveWorkspaces, isLoading]);
+
+    // Add Private Workspace option if user is currently in a team workspace
+    if (activeWorkspace?.id !== null) {
+      items.push({
+        key: "private",
+        label: (
+          <div className="workspace-share-menu-item-card">
+            <Row align="middle" className="items-center">
+              <Avatar
+                size={35}
+                shape="square"
+                icon={<LockOutlined />}
+                className="workspace-avatar"
+                style={{ backgroundColor: "#1E69FF" }}
+              />
+              <span className="workspace-card-description">
+                <div className="text-white">Private workspace</div>
+                <div className="text-gray">Not shared with anyone</div>
+              </span>
+            </Row>
+            <RQButton
+              disabled={isLoading}
+              type="link"
+              className="workspace-menu-item-transfer-btn"
+              onClick={() => onTransferClick?.(PrivateWorkspaceStub)}
+            >
+              Copy here
+            </RQButton>
+          </div>
+        ),
+      });
+    }
+
+    return items;
+  }, [sortedTeams, activeWorkspace, onTransferClick, defaultActiveWorkspaces, isLoading]);
 
   const chooseOtherWorkspaceItem = (
     <div className="workspace-share-menu-item-card workspace-share-menu-dropdown">

--- a/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
+++ b/app/src/components/common/SharingModal/Workspaces/WorkspaceShareMenu.tsx
@@ -56,7 +56,7 @@ export const WorkspaceShareMenu: React.FC<Props> = ({ onTransferClick, isLoading
       .filter(Boolean);
 
     // Add Private Workspace option if user is currently in a team workspace
-    if (activeWorkspace?.id !== null) {
+    if (activeWorkspace && activeWorkspace.id !== null) {
       items.push({
         key: "private",
         label: (


### PR DESCRIPTION
## ✨ Feature

Fixes #3825

### Problem
Users cannot copy rules to their Private Workspace from the "Share in workspace" dropdown. Currently, only team workspaces are shown in the dropdown menu.

### Solution
Added "Private Workspace" option to the `WorkspaceShareMenu` dropdown when the user is currently in a team workspace.

### Changes
- Imported `PrivateWorkspaceStub` and `LockOutlined` icon
- Added Private Workspace option to `menuItems` with:
  - Lock icon (blue background)
  - "Private workspace" label
  - "Not shared with anyone" description
  - "Copy here" button
- Option only appears when user is in a team workspace (not already in private workspace)

### UI
```
[Workspace Icon] Team Workspace 1          [Copy here]
[Workspace Icon] Team Workspace 2          [Copy here]
[Lock Icon]      Private workspace         [Copy here]
                 Not shared with anyone
```

### Testing
- [x] Private Workspace option appears when in team workspace
- [x] Private Workspace option does not appear when already in private workspace
- [x] Clicking "Copy here" copies rules to private workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Private workspace" entry (with lock icon) to the workspace dropdown for clearer workspace selection.
* **Improvements**
  * Menu now updates more reliably when the active workspace changes, improving accuracy of available options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->