### PR TITLE
Fix source filter count for empty filters

### DIFF
--- a/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
+++ b/app/src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js
@@ -68,18 +68,34 @@ const RequestSourceRow = ({ rowIndex, pair, pairIndex, ruleDetails, isInputDisab
     trackRuleFilterModalToggled(false, currentlySelectedRuleData?.ruleType);
   }, [currentlySelectedRuleData?.ruleType]);
 
+  const isFilterValueApplied = useCallback((filterValue) => {
+    if (!filterValue) {
+      return false;
+    }
+
+    if (Array.isArray(filterValue)) {
+      return filterValue.length > 0;
+    }
+
+    if (typeof filterValue === "object") {
+      return Object.keys(filterValue).some((key) => isFilterValueApplied(filterValue[key]));
+    }
+
+    return Boolean(filterValue);
+  }, []);
+
   const getFilterCount = useCallback(
     (pairIndex) => {
       const copyOfCurrentlySelectedRule = JSON.parse(JSON.stringify(currentlySelectedRuleData));
-      return isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
-        ? Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length
-        : Object.keys(currentlySelectedRuleData.pairs[pairIndex].source.filters || {}).filter(
-            (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL
-          ).length;
+      const filters = isSourceFilterFormatUpgraded(pairIndex, copyOfCurrentlySelectedRule)
+        ? currentlySelectedRuleData.pairs[pairIndex].source.filters[0] || {}
+        : currentlySelectedRuleData.pairs[pairIndex].source.filters || {};
+
+      return Object.keys(filters).filter(
+        (key) => key !== GLOBAL_CONSTANTS.RULE_SOURCE_FILTER_TYPES.PAGE_URL && isFilterValueApplied(filters[key])
+      ).length;
     },
-    [currentlySelectedRuleData, isSourceFilterFormatUpgraded]
+    [currentlySelectedRuleData, isFilterValueApplied, isSourceFilterFormatUpgraded]
   );
 
   const sourceKeys = useMemo(


### PR DESCRIPTION
## Summary\n- count only source filters that have a real non-empty value\n- keep excluding the default page URL filter from the advanced filter badge\n- fixes the badge showing one applied filter for empty imported filters\n\nFixes #3826\n\n## Test\n- cd app && npx eslint src/components/features/rules/RulePairs/Pairs/Rows/RowsMarkup/RequestSourceRow/index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of applied advanced filter counts to better handle nested filter structures and properly exclude empty or undefined values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->