### PR TITLE
chore: add misfiled-issue redirect bot (with transfer + close fallback)

### DIFF
--- a/.github/workflows/misfiled-issue-redirect.yml
+++ b/.github/workflows/misfiled-issue-redirect.yml
@@ -1,11 +1,14 @@
 name: Misfiled Issue Redirect
 
-# Auto-detects HTTP Interceptor issues filed on this (API Client) repo and
-# redirects them to requestly/interceptor. Closes the misfiled issue with a
-# templated comment.
+# Auto-detects HTTP Interceptor issues filed on this (API Client) repo and:
+# 1. Tries to TRANSFER them to requestly/interceptor using REQUESTLY_CLOUD_TOKEN.
+#    - Preserves original author + comments + history
+#    - Old URL auto-redirects to new
+# 2. If transfer fails (token missing, no perm, rate limit) — gracefully falls
+#    back to: label + comment + close behavior.
 #
 # Threshold: 2+ HI keyword matches in title/body before triggering (conservative).
-# If false-positive, comment + reopen by hand.
+# Safe to merge before the token is configured — falls back to close+comment.
 
 on:
   issues:
@@ -15,19 +18,17 @@ permissions:
   issues: write
 
 jobs:
-  detect-misfile:
+  detect-and-route:
     runs-on: ubuntu-latest
     if: github.event.issue.user.type != 'Bot'
 
     steps:
-      - name: Detect and redirect misfiled HI issues
+      # ── Step 1: detect HI misfile ─────────────────────────────────────────
+      - name: Detect HI misfile
+        id: detect
         uses: actions/github-script@v7
         with:
           script: |
-            const SIBLING_REPO = 'requestly/interceptor';
-            const MISFILE_LABEL = 'migration:misfiled-interceptor';
-
-            // Strong HI keywords (avoid generic "api" which is also API Client)
             const HI_PATTERNS = [
               /\bredirect\s+rule\b/i,
               /\bmodify\s+header/i,
@@ -56,28 +57,73 @@ jobs:
 
             const { issue } = context.payload;
             const haystack = `${issue.title}\n${issue.body || ''}`;
-
             const matched = HI_PATTERNS.filter(re => re.test(haystack));
-            if (matched.length < 2) {
-              core.info(`Not a confident misfile (matched ${matched.length} keyword group(s)). Skipping.`);
-              return;
+
+            const isMisfile = matched.length >= 2;
+            core.setOutput('is_misfile', isMisfile ? 'true' : 'false');
+            core.setOutput('matched_count', String(matched.length));
+
+            if (isMisfile) {
+              core.info(`Misfile detected — matched ${matched.length} keyword(s).`);
+            } else {
+              core.info(`Not a confident misfile (matched ${matched.length}). Skipping.`);
             }
 
-            const matchedNames = matched.map(re => re.source).slice(0, 4).join(', ');
-            core.info(`Misfile detected — matched: ${matchedNames}`);
-
-            // Apply label
+      # ── Step 2: apply label (always, if misfile) — same regardless of route ──
+      - name: Apply migration:misfiled-interceptor label
+        if: steps.detect.outputs.is_misfile == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
             try {
               await github.rest.issues.addLabels({
                 ...context.repo,
-                issue_number: issue.number,
-                labels: [MISFILE_LABEL],
+                issue_number: context.payload.issue.number,
+                labels: ['migration:misfiled-interceptor'],
               });
             } catch (e) {
-              core.warning(`Could not add label ${MISFILE_LABEL}: ${e.message}`);
+              core.warning(`Could not add label: ${e.message}`);
             }
 
-            // Comment
+      # ── Step 3 (preferred): try TRANSFER using REQUESTLY_CLOUD_TOKEN ──────
+      - name: Try transfer to requestly/interceptor
+        if: steps.detect.outputs.is_misfile == 'true'
+        id: transfer
+        env:
+          GH_TOKEN: ${{ secrets.REQUESTLY_CLOUD_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          SRC_REPO: ${{ github.repository }}
+        run: |
+          # If no token, skip transfer — fallback step handles it
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::REQUESTLY_CLOUD_TOKEN not set; will fall back to close+comment."
+            echo "did_transfer=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no_token" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Try the transfer
+          if NEW_URL=$(gh issue transfer "$ISSUE_NUM" requestly/interceptor --repo "$SRC_REPO" 2>&1); then
+            NEW_URL=$(echo "$NEW_URL" | tr -d '[:space:]')
+            echo "::notice::Transferred ${SRC_REPO}#${ISSUE_NUM} -> ${NEW_URL}"
+            echo "did_transfer=true" >> "$GITHUB_OUTPUT"
+            echo "new_url=${NEW_URL}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Transfer failed: $NEW_URL. Will fall back to close+comment."
+            echo "did_transfer=false" >> "$GITHUB_OUTPUT"
+            echo "reason=transfer_error" >> "$GITHUB_OUTPUT"
+          fi
+        continue-on-error: true
+
+      # ── Step 4 (fallback): close + comment if transfer didn't happen ─────
+      - name: Fallback - close + comment if transfer didn't happen
+        if: |
+          steps.detect.outputs.is_misfile == 'true' &&
+          steps.transfer.outputs.did_transfer != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const SIBLING_REPO = 'requestly/interceptor';
+
             const comment = [
               `Thanks for filing!`,
               ``,
@@ -87,7 +133,7 @@ jobs:
               ``,
               `This repository (\`${context.repo.owner}/${context.repo.repo}\`) is the community hub for the **Requestly API Client**.`,
               ``,
-              `Closing this issue — no problem re-opening if I got this wrong. The team triages \`${MISFILE_LABEL}\`-tagged issues weekly.`,
+              `Closing this issue — no problem re-opening if I got this wrong. The team triages \`migration:misfiled-interceptor\`-tagged issues weekly.`,
               ``,
               `---`,
               `🤖 _Auto-detected based on keywords. If this is wrong, comment and a human will reopen._`,
@@ -95,16 +141,15 @@ jobs:
 
             await github.rest.issues.createComment({
               ...context.repo,
-              issue_number: issue.number,
+              issue_number: context.payload.issue.number,
               body: comment,
             });
 
-            // Close
             await github.rest.issues.update({
               ...context.repo,
-              issue_number: issue.number,
+              issue_number: context.payload.issue.number,
               state: 'closed',
               state_reason: 'not_planned',
             });
 
-            core.info(`Closed and redirected issue #${issue.number}`);
+            core.info(`Closed and redirected issue #${context.payload.issue.number} (transfer path was unavailable)`);

--- a/.github/workflows/misfiled-issue-redirect.yml
+++ b/.github/workflows/misfiled-issue-redirect.yml
@@ -1,0 +1,110 @@
+name: Misfiled Issue Redirect
+
+# Auto-detects HTTP Interceptor issues filed on this (API Client) repo and
+# redirects them to requestly/interceptor. Closes the misfiled issue with a
+# templated comment.
+#
+# Threshold: 2+ HI keyword matches in title/body before triggering (conservative).
+# If false-positive, comment + reopen by hand.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  detect-misfile:
+    runs-on: ubuntu-latest
+    if: github.event.issue.user.type != 'Bot'
+
+    steps:
+      - name: Detect and redirect misfiled HI issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const SIBLING_REPO = 'requestly/interceptor';
+            const MISFILE_LABEL = 'migration:misfiled-interceptor';
+
+            // Strong HI keywords (avoid generic "api" which is also API Client)
+            const HI_PATTERNS = [
+              /\bredirect\s+rule\b/i,
+              /\bmodify\s+header/i,
+              /\bmodify\s+response\s+body/i,
+              /\bmodify\s+request\s+body/i,
+              /\brule\s+engine\b/i,
+              /\brules\s+engine\b/i,
+              /\bmap\s+local\b/i,
+              /\bresource[- ]override\b/i,
+              /\bsession\s+replay\b/i,
+              /\bsession\s+recording\b/i,
+              /\bnetwork\s+inspector\b/i,
+              /\bhttp\s+interceptor\b/i,
+              /\binterception\b/i,
+              /\bchrome\s+extension\b/i,
+              /\bfirefox\s+extension\b/i,
+              /\bedge\s+extension\b/i,
+              /\bmanifest\s+v[23]\b/i,
+              /\bcontent[- ]script\b/i,
+              /\bcharles\s+proxy\b/i,
+              /\bfiddler\b/i,
+              /\bmodheader\b/i,
+              /\bmock\s+server\b/i,
+              /\bapi\s+mocking\b/i,
+            ];
+
+            const { issue } = context.payload;
+            const haystack = `${issue.title}\n${issue.body || ''}`;
+
+            const matched = HI_PATTERNS.filter(re => re.test(haystack));
+            if (matched.length < 2) {
+              core.info(`Not a confident misfile (matched ${matched.length} keyword group(s)). Skipping.`);
+              return;
+            }
+
+            const matchedNames = matched.map(re => re.source).slice(0, 4).join(', ');
+            core.info(`Misfile detected — matched: ${matchedNames}`);
+
+            // Apply label
+            try {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issue.number,
+                labels: [MISFILE_LABEL],
+              });
+            } catch (e) {
+              core.warning(`Could not add label ${MISFILE_LABEL}: ${e.message}`);
+            }
+
+            // Comment
+            const comment = [
+              `Thanks for filing!`,
+              ``,
+              `It looks like this issue is about the **open-source HTTP Interceptor**, which has its own repository.`,
+              ``,
+              `👉 Please re-file at **[${SIBLING_REPO}](https://github.com/${SIBLING_REPO}/issues/new/choose)** so the right team sees it.`,
+              ``,
+              `This repository (\`${context.repo.owner}/${context.repo.repo}\`) is the community hub for the **Requestly API Client**.`,
+              ``,
+              `Closing this issue — no problem re-opening if I got this wrong. The team triages \`${MISFILE_LABEL}\`-tagged issues weekly.`,
+              ``,
+              `---`,
+              `🤖 _Auto-detected based on keywords. If this is wrong, comment and a human will reopen._`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: issue.number,
+              body: comment,
+            });
+
+            // Close
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });
+
+            core.info(`Closed and redirected issue #${issue.number}`);


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-detects HTTP Interceptor issues filed on this repo (the **Requestly API Client community hub**) and **tries to transfer them** to [`requestly/interceptor`](https://github.com/requestly/interceptor). Falls back to close+comment if transfer can't run.

## Behavior

1. **Detect**: regex/keyword match on title+body. Requires **2+ HI keyword hits** before triggering (conservative — avoids false positives on generic terms like "api").
2. **Label** (always, when triggered): applies `migration:misfiled-interceptor`.
3. **Try transfer** (preferred): runs `gh issue transfer` using `REQUESTLY_CLOUD_TOKEN`. On success:
   - Issue moves to `requestly/interceptor` with full attribution
   - Original author, comments, timestamps preserved
   - Old URL auto-redirects to new (`requestly/requestly#NNN` → `requestly/interceptor#MMM`)
4. **Fallback** (transfer failed or token absent): close + comment with redirect instructions.

## Graceful degradation

**Safe to merge even before `REQUESTLY_CLOUD_TOKEN` is configured.** If the secret is empty or transfer fails for any reason, the workflow falls back to the original close+comment behavior — same UX as the first version of this PR.

When the token lands (or if it already has the right scopes — `REQUESTLY_CLOUD_TOKEN` is already used by this repo for cross-repo dispatch), behavior automatically upgrades to transfer.

## Token expectations

The workflow uses `secrets.REQUESTLY_CLOUD_TOKEN`. This secret already exists on this repo (used by the cross-repo dispatch flow). It likely has `repo` scope — which includes the permission needed for `gh issue transfer`. If the scope turns out to be insufficient, the workflow logs a warning and falls back to close+comment — no broken state.

## False positive recovery

- **Transfer-based path**: re-open the issue on `requestly/interceptor` and transfer it back via the GH UI or `gh issue transfer`. The migration label can be removed.
- **Fallback path**: re-open the issue on this repo and remove the misfile label.

Conservative threshold (2+ keywords) keeps false positives low.

## Test plan

After merge:
1. File a test issue on `requestly/requestly` titled "Chrome extension redirect rule doesn't work" with a body mentioning "modify header" + "session replay"
2. Within ~30s the bot fires
3. **Expected (with token)**: issue transferred to `requestly/interceptor`, old URL redirects
4. **Expected (without token / token insufficient)**: issue closed on this repo with redirect comment
5. Either way: `migration:misfiled-interceptor` label applied; no broken state

## Rollback

Disable the workflow:
```
gh workflow disable misfiled-issue-redirect.yml --repo requestly/requestly
```

Single-command rollback.

## What changed in this PR (vs first push)

- First version: close + comment (always)
- **This version**: try transfer first, fall back to close + comment
- Same detection logic, same threshold, same label
- Only the action-taken-on-misfile changed from \"close\" to \"transfer-or-close\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated detection of likely misfiled issues: applies a migration label, attempts to transfer the issue to the appropriate repository, and—if transfer isn’t performed—posts a redirect comment and closes the original issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->