### PR TITLE
docs: add claude.md for browser extension subdirectories

### DIFF
--- a/browser-extension/common/claude.md
+++ b/browser-extension/common/claude.md
@@ -1,0 +1,81 @@
+Shared code used by the MV3 browser extension (and previously MV2, now deprecated). Contains the storage abstraction layer, popup UI, devtools panel, custom elements (in-page widgets), and shared constants/types.
+
+# Code Organization
+
+## Core Modules (`src/`)
+
+- **`storage.ts`** — Abstraction over `chrome.storage.local`. Provides CRUD operations (`saveRecord`, `getRecord`, `removeRecord`, `getAllRecords`) and a reactive change listener (`onRecordChange`) with filtering by change type, key, and value. All extension storage access should go through this module.
+- **`rulesStore.ts`** — Rule/group retrieval layer built on top of `storage.ts`. Provides `getRules`, `getGroups`, `getEnabledRules` (filters by status and group status), `onRuleOrGroupChange` (reactive listener that only fires on meaningful changes).
+- **`constants.ts`** — Message action constants (`EXTENSION_MESSAGES`, `CLIENT_MESSAGES`, `APP_MESSAGES`), storage keys, rule title mappings, and the `PUBLIC_NAMESPACE` (`__REQUESTLY__`).
+- **`types.ts`** — Core extension types: `Rule`, `Group`, `RuleType`, `ObjectType`, `Status`, `SourceOperator`, `SourceKey`, DNR-related types (`UpdateDynamicRuleOptions`).
+- **`config.ts`** — Runtime config (log level).
+- **`eventUtils.ts`** — Event tracking utility helpers.
+- **`utils.ts`** — General-purpose utility functions.
+
+## Popup (`src/popup/`)
+
+The extension popup UI — a standalone React app (Ant Design dark theme) rendered in the popup window.
+
+- Entry point: `index.tsx` — Renders `<Popup>` inside `RecordsProvider` and Ant Design `ConfigProvider`.
+- **`components/Popup/`** — Main popup component with header and tab navigation.
+- **`components/PopupTabs/`** — Tab navigation (recent rules, pinned rules, executed rules, session recording).
+- **`components/ExecutedRules/`** — Shows rules that fired on the current tab.
+- **`components/RecentRecords/`**, **`PinnedRecords/`** — Rule lists with pin/unpin actions.
+- **`components/SessionRecording/`** — Session recording controls.
+- **`components/ApiClientContainer/`** — API client entry point in popup.
+- **`components/DesktopAppProxy/`** — Desktop app connection status and controls.
+- **`components/HttpsRuleOptions/`** — HTTPS rule configuration.
+- **`contexts/RecordsContext/`** — React context + reducer for managing records state (rules, groups, pinned items) in the popup.
+
+## Devtools Panel (`src/devtools/`)
+
+Chrome DevTools panel integration — adds a "Requestly" panel to Chrome DevTools.
+
+- **`devtools.js`** — Panel registration via `chrome.devtools.panels.create`. Firefox gets plain text title; Chrome/others get emoji prefix.
+- **`index.tsx`** — Devtools panel React app entry point.
+- **`containers/network/`** — Network log viewer with request/response details, headers, payload tabs, and filtering toolbars.
+- **`containers/executions/`** — Rule execution log viewer showing which rules were applied.
+- **`containers/analytics-inspector/`** — Analytics event inspector for debugging third-party tracking.
+- **`components/`** — Shared devtools UI components (resource type filter, icon button, empty state placeholder).
+
+## Custom Elements (`src/custom-elements/`)
+
+Web Components (Custom Elements) injected into target pages for in-page UI:
+
+- **`toast/`** — Toast notification widget.
+- **`test-rule-widget/`** — Widgets shown during rule testing:
+  - `explicit-test-rule-widget/` — Shown when user explicitly tests a rule.
+  - `implicit-test-rule-widget/` — Shown for automatic rule testing feedback.
+- **`session-recording-widgets/`** — Session recording UI:
+  - `manual-mode-widget/` — Controls for manual recording.
+  - `auto-mode-widget/` — Controls for auto recording.
+  - `draft-session-viewer/` — Preview of recorded session.
+  - `post-session-save-widget/` — Post-save confirmation widget.
+- **`abstract-classes/draggable-widget.ts`** — Base class for draggable floating widgets.
+
+All custom elements are registered in `index.ts`.
+
+# Build System
+
+- **Bundler**: Rollup (`rollup.config.js`)
+- **Build command**: `npm run build` (output to `dist/`)
+- **Dependencies**: React 18, Ant Design 5, CodeMirror 6, `@devtools-ds/*` for devtools UI, `@requestly/analytics-vendors` (local package).
+- **Preprocessor**: Uses PostCSS + Sass for styles.
+- **Pre-install hook**: Builds the analytics vendor package via `scripts/build-analytics-vendor.sh`.
+
+# How MV3 Depends on Common
+
+The MV3 extension imports from this package as `common/*` (resolved at build time to `../common/src/*`). Key imports:
+- `common/storage` — Storage abstraction
+- `common/rulesStore` — Rule retrieval and change listeners
+- `common/constants` — Message types and storage keys
+- `common/types` — TypeScript type definitions
+- `common/config` — Runtime config
+
+The popup and devtools UIs are built separately by this package's Rollup config and output as HTML/JS bundles that the MV3 extension includes in its `dist/`.
+
+# Development
+
+- `npm run build` — Full build
+- `npm run watch` — Rollup watch mode
+- Changes here require rebuilding: from `../mv3/`, run `npm run build:common` or `npm run build` (which does both)

--- a/browser-extension/mv3/claude.md
+++ b/browser-extension/mv3/claude.md
@@ -1,0 +1,108 @@
+Manifest V3 browser extension for Chrome, Edge, Firefox, and Safari. Uses `chrome.declarativeNetRequest` for rule-based request interception and `chrome.webRequest` for observational tracking (execution logging, not blocking).
+
+# Architecture
+
+## Dual Interception Strategy
+
+The extension uses **two complementary interception mechanisms**:
+
+1. **declarativeNetRequest (DNR)** — Handles Redirect, Replace, QueryParam, Cancel, Headers, and UserAgent rules. Rules are compiled into DNR format and registered as dynamic rules. This is the primary interception path for MV3.
+2. **webRequest (read-only)** — Listens to `onBeforeRequest`, `onBeforeSendHeaders`, `onHeadersReceived` to track which rules matched which requests (for the execution log in devtools/popup). Does NOT modify requests — purely observational in MV3.
+3. **Client-side interception** — Response, Request body, and Delay rules are handled via page scripts (`ajaxRequestInterceptor`) that monkey-patch `fetch`/`XHR` in the MAIN world. Rules are cached into `window.__REQUESTLY__` on each navigation.
+
+## Service Worker (`src/service-worker/`)
+
+Entry point: `index.ts` — initializes all services at startup.
+
+Key services in `services/`:
+- **`rulesManager.ts`** — Core DNR rule management. Converts Requestly rules → DNR rules via `rule.extensionRules`, registers them with `chrome.declarativeNetRequest.updateDynamicRules`. Re-applies on rule change, extension toggle, or block-list update. Also manages per-tab session rules via `updateRequestSpecificRules`.
+- **`webRequestInterceptor.ts`** — Read-only webRequest listeners for execution tracking. Adds/removes listeners based on extension enabled state.
+- **`clientHandler.ts`** — Registers MAIN-world content scripts (`ajaxRequestInterceptor`, `sessionRecorderHelper`) via `chrome.scripting.registerContentScripts`. Also handles client-side rule caching — injects rule data into `window.__REQUESTLY__` on every navigation.
+- **`messageHandler/`** — Central message router (`listener.ts`) handling 30+ message types from popup, content scripts, devtools, and the web app. `sender.ts` sends messages back to the app tab.
+- **`ruleExecutionHandler.ts`** — Tracks which rules were applied to which tabs/requests. Caches executions per tab.
+- **`scriptRuleHandler.ts`** — Injects user-defined scripts (Insert Scripts rule type) into matching tabs.
+- **`requestProcessor/`** — Handles edge cases: forwarding headers on redirect, CSP error handling, initiator domain functions.
+- **`sessionRecording.ts`** — Manages session recording lifecycle (start, stop, cache, replay).
+- **`desktopApp/`** — WebSocket connection to the Requestly desktop app for proxy-based interception. Port scanning, connection management, proxy toggling.
+- **`tabService.ts`** — Per-tab data store (session rules map, execution data).
+- **`extensionIconManager.ts`** — Manages extension icon state (active/inactive/recording).
+- **`globalStateManager.ts`** — Shared state caching between content script and service worker.
+
+## Content Scripts (`src/content-scripts/`)
+
+Two content script bundles:
+- **`client/`** — Injected into all pages. Handles page script message relay, rule execution notifications from client-side interception, and test-rule mode.
+- **`app/`** — Injected only into Requestly web app pages (`*.requestly.io`, `*.requestly.in`, `requestly.com`). Handles bidirectional sync between the web app and extension storage.
+
+Common modules in `content-scripts/common/`:
+- `sessionRecorder.ts` — Initializes session recording SDK in content script context.
+- `extensionMessageListener.ts` — Listens for messages from service worker.
+
+## Page Scripts (`src/page-scripts/`)
+
+Injected into the MAIN world (page's JS context):
+- **`ajaxRequestInterceptor/`** — Monkey-patches `fetch` and `XMLHttpRequest` to intercept and modify requests/responses. Reads rules from `window.__REQUESTLY__`.
+- **`sessionRecorderHelper.js`** — Bridges session recording events from the page to the content script.
+
+## Rule Matching (`src/common/ruleMatcher.ts`)
+
+Local rule matcher used by webRequest listeners and the request processor. Supports URL matching with Equals, Contains, Regex, and Wildcard operators. Also handles source filters (page domains, request method, resource type, request payload).
+
+This is separate from the `common/rule-processor/` shared package — it's a lighter-weight matcher specific to the extension's needs.
+
+# Safari Differences
+
+Safari uses separate entry points suffixed with `.safari.ts`:
+- `service-worker/index.safari.ts`
+- `content-scripts/app/index.safari.ts`
+- `content-scripts/client/index.safari.ts`
+- `service-worker/services/messageHandler.safari.ts`
+
+Safari's `declarativeNetRequest` API has differences — `ResourceType` enum is not defined, so resource types are hardcoded as string literals.
+
+Built with a separate Rollup config: `rollup.config.safari.js`.
+
+# Build System
+
+- **Bundler**: Rollup (`rollup.config.js`)
+- **Build command**: `npm run build` (builds `../common` first, then mv3)
+- **Output**: `dist/` directory
+- **Manifests**: Browser-specific manifests (`manifest.chrome.json`, `manifest.edge.json`, `manifest.firefox.json`, `manifest.safari.json`) are processed at build time — version injected from package.json, content script URL patterns generated from config.
+- **Config dependency**: `../config/` provides environment-specific values (`WEB_URL`, `OTHER_WEB_URLS`, `browser`).
+- **Tests**: Playwright-based E2E tests in `tests/`.
+
+# Web-to-Extension Communication
+
+Two channels allow external websites to communicate with the extension:
+
+## 1. Requestly Web App (content script bridge)
+
+The `app/` content script is injected only into Requestly pages (`*.requestly.io`, `*.requestly.in`, `requestly.com`) — URL patterns are set in the manifest's `content_scripts[0].matches` and dynamically generated from `WEB_URL`/`OTHER_WEB_URLS` config at build time.
+
+Communication flow: **Web app → `window.postMessage` → app content script (`messageHandler.ts`) → `chrome.runtime.sendMessage` → service worker**. Responses flow back the same path in reverse.
+
+This bridge gives the web app full access to:
+- Extension storage CRUD (`GET_STORAGE_OBJECT`, `SAVE_STORAGE_OBJECT`, `REMOVE_STORAGE_OBJECT`, `CLEAR_STORAGE`, `GET_STORAGE_SUPER_OBJECT`) — this is how rules sync from the web app into the extension.
+- Service worker actions delegated via `delegateMessageToBackground` (session recording, API client, rule testing, desktop app proxy, extension status).
+
+The content script also stamps DOM attributes on `<html>` so the web app can detect the extension: `rq-ext-version`, `rq-ext-mv` (= "3"), `rq-ext-id`.
+
+## 2. BrowserStack Domains (externally connectable)
+
+The manifest's `externally_connectable.matches` allows BrowserStack domains (`https://*.bsstag.com/*`, `https://*.browserstack.com/*`) to call `chrome.runtime.sendMessage(extensionId, ...)` directly from their page JS — no content script needed.
+
+The `initExternalMessageListener` handler in `messageHandler/listener.ts` responds to `GET_EXTENSION_METADATA` with the extension's name and version. This is how BrowserStack products detect and identify the Requestly extension.
+
+# Key Patterns
+
+- **Variable system** (`service-worker/variable.ts`): Extension state (like `IS_EXTENSION_ENABLED`) is stored in `chrome.storage.local` with `rq_var_` prefix. Changes are observed via `chrome.storage.onChanged` listeners.
+- **Block list**: Certain domains can be excluded from interception. Block list changes trigger re-registration of both DNR rules and content scripts.
+- **Storage**: All rule/group data lives in `chrome.storage.local` (via `common/storage.ts`). The extension does not use IndexedDB or localStorage.
+- **Imports from `common`**: Resolved to `../common/src/` at build time. Shared types, constants, storage layer, and rules store are imported as `common/*`.
+
+# Development
+
+- `npm run watch` — Rollup watch mode for development
+- `npm run start:firefox` — Launch Firefox with the extension loaded via `web-ext`
+- `npm test` — Runs Playwright E2E tests (requires build first)
+- Alt+T — Reload extension in development mode (non-production builds only)

--- a/claude.md
+++ b/claude.md
@@ -38,6 +38,10 @@ Browser extension implementation for Chrome, Firefox, Safari, Edge, and other br
 
 The extension shares the rule processor from `common/rule-processor`.
 
+Key subdirectories:
+- **`browser-extension/mv3/`** — MV3 extension: service worker, content scripts, page scripts, DNR rule management, Safari variants. See `browser-extension/mv3/claude.md` for details.
+- **`browser-extension/common/`** — Shared extension code: storage layer, popup UI, devtools panel, custom elements (in-page widgets), constants, and types. See `browser-extension/common/claude.md` for details.
+
 ## `common/rule-processor/` - Core Rule Processing Engine
 The core rule execution engine that processes Requestly rules. This code is shared across:
 - Browser extension (rule execution in browser)


### PR DESCRIPTION
## Summary
- Add `claude.md` for `browser-extension/common/` covering storage layer, popup UI, devtools panel, custom elements, and build system
- Add `claude.md` for `browser-extension/mv3/` covering service worker architecture, content scripts, DNR/webRequest strategy, Safari differences, and web-to-extension communication
- Update root `claude.md` with pointers to the new files

## Test plan
- [x] Verify claude.md files are well-structured and accurate
- [x] Verify root claude.md pointers reference correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for browser extension architecture and component organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->