### PR TITLE
Fix traffic table row cursor

### DIFF
--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.scss
@@ -2,6 +2,12 @@
   height: 100%;
   table {
     tbody {
+      .network-log-row,
+      .network-log-row td,
+      .network-log-row [class*="Table-content"] {
+        cursor: pointer;
+      }
+
       tr[aria-selected="true"] {
         .graphql-operation-name {
           color: var(--requestly-color-text-default);

--- a/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
+++ b/app/src/components/mode-specific/desktop/InterceptTraffic/WebTraffic/TrafficTableV2/NetworkInspector/NetworkTable/index.tsx
@@ -236,6 +236,7 @@ const NetworkTable: React.FC<Props> = ({
         <Table.Row
           key={index}
           id={log.id}
+          className="network-log-row"
           onContextMenu={() => setSelectedRowData(log)}
           {...rowProps}
           data-tour-id={index === 0 && !isTrafficTableTourCompleted ? "traffic-table-row" : null}


### PR DESCRIPTION
Fixes requestly/interceptor#49.

## Summary
- mark network traffic log rows as clickable
- keep the pointer cursor on the row, cells, and table content while hovering a traffic row

## Verification
- git diff --check

Note: I did not run the desktop app locally in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Network log rows in the web traffic inspection table now display a pointer cursor, providing visual feedback that these rows are interactive and clickable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->