### PR TITLE
fix: add missing api client tooltips

### DIFF
--- a/app/src/componentsV2/BottomSheet/BottomSheet.tsx
+++ b/app/src/componentsV2/BottomSheet/BottomSheet.tsx
@@ -4,7 +4,7 @@ import { useBottomSheetContext } from "./context";
 import { BiDockRight } from "@react-icons/all-files/bi/BiDockRight";
 import { BiDockBottom } from "@react-icons/all-files/bi/BiDockBottom";
 import { BottomSheetPlacement } from "./types";
-import { RQButton } from "lib/design-system-v2/components";
+import { RQButton, RQTooltip } from "lib/design-system-v2/components";
 import { MdOutlineKeyboardArrowLeft } from "@react-icons/all-files/md/MdOutlineKeyboardArrowLeft";
 import { MdOutlineKeyboardArrowRight } from "@react-icons/all-files/md/MdOutlineKeyboardArrowRight";
 import { MdOutlineKeyboardArrowUp } from "@react-icons/all-files/md/MdOutlineKeyboardArrowUp";
@@ -38,14 +38,16 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
         {utilities}
 
         {disableDocking ? null : (
-          <RQButton
-            size="small"
-            type="transparent"
-            title="Toggle"
-            onClick={() => toggleSheetPlacement()}
-            className="bottom-sheet-toggle-btn"
-            icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-          />
+          <RQTooltip title={isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom"}>
+            <RQButton
+              size="small"
+              type="transparent"
+              title="Toggle"
+              onClick={() => toggleSheetPlacement()}
+              className="bottom-sheet-toggle-btn"
+              icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+            />
+          </RQTooltip>
         )}
 
         <RQButton
@@ -82,14 +84,16 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
       </div>
     ),
     right: (
-      <RQButton
-        size="small"
-        type="transparent"
-        title="Toggle"
-        onClick={() => toggleSheetPlacement()}
-        className="bottom-sheet-toggle-btn"
-        icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
-      />
+      <RQTooltip title={isSheetPlacedAtBottom ? "Dock to right" : "Dock to bottom"}>
+        <RQButton
+          size="small"
+          type="transparent"
+          title="Toggle"
+          onClick={() => toggleSheetPlacement()}
+          className="bottom-sheet-toggle-btn"
+          icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
+        />
+      </RQTooltip>
     ),
   };
 

--- a/app/src/componentsV2/BottomSheet/BottomSheet.tsx
+++ b/app/src/componentsV2/BottomSheet/BottomSheet.tsx
@@ -42,7 +42,6 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
             <RQButton
               size="small"
               type="transparent"
-              title="Toggle"
               onClick={() => toggleSheetPlacement()}
               className="bottom-sheet-toggle-btn"
               icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}
@@ -88,7 +87,6 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
         <RQButton
           size="small"
           type="transparent"
-          title="Toggle"
           onClick={() => toggleSheetPlacement()}
           className="bottom-sheet-toggle-btn"
           icon={isSheetPlacedAtBottom ? <BiDockRight /> : <BiDockBottom />}

--- a/app/src/componentsV2/Tabs/components/TabsContainer.tsx
+++ b/app/src/componentsV2/Tabs/components/TabsContainer.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Tabs, TabsProps, Typography, Popover } from "antd";
 import { TabItem } from "./TabItem";
 import { Outlet, unstable_useBlocker } from "react-router-dom";
-import { RQButton } from "lib/design-system-v2/components";
+import { RQButton, RQTooltip } from "lib/design-system-v2/components";
 import { MdClose } from "@react-icons/all-files/md/MdClose";
 import { IoIosArrowDown } from "@react-icons/all-files/io/IoIosArrowDown";
 import { useSetUrl } from "../hooks/useSetUrl";
@@ -328,6 +328,11 @@ export const TabsContainer: React.FC = () => {
             });
           }
         }}
+        addIcon={
+          <RQTooltip title="New request">
+            <span>+</span>
+          </RQTooltip>
+        }
       />
       <ActiveWorkflowModal
         open={workflowModalTabId !== null}

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/collectionsList/requestRow/RequestRow.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Typography, Dropdown, MenuProps, Checkbox, notification } from "antd";
 import { REQUEST_METHOD_BACKGROUND_COLORS, REQUEST_METHOD_COLORS } from "../../../../../../../../../constants";
 import { RequestMethod, RQAPI } from "features/apiClient/types";
-import { RQButton } from "lib/design-system-v2/components";
+import { RQButton, RQTooltip } from "lib/design-system-v2/components";
 import { MdOutlineMoreHoriz } from "@react-icons/all-files/md/MdOutlineMoreHoriz";
 import { NewRecordNameInput } from "../newRecordNameInput/NewRecordNameInput";
 import { toast } from "utils/Toast";
@@ -500,15 +500,17 @@ export const RequestRow: React.FC<Props> = ({
             open={isDropdownVisible}
             onOpenChange={handleDropdownVisibleChange}
           >
-            <RQButton
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowSelection(false);
-              }}
-              size="small"
-              type="transparent"
-              icon={<MdOutlineMoreHoriz />}
-            />
+            <RQTooltip title="More Actions">
+              <RQButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowSelection(false);
+                }}
+                size="small"
+                type="transparent"
+                icon={<MdOutlineMoreHoriz />}
+              />
+            </RQTooltip>
           </Dropdown>
         </div>
       </Conditional>
@@ -646,15 +648,17 @@ export const RequestRow: React.FC<Props> = ({
                   open={isDropdownVisible}
                   onOpenChange={handleDropdownVisibleChange}
                 >
-                  <RQButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowSelection(false);
-                    }}
-                    size="small"
-                    type="transparent"
-                    icon={<MdOutlineMoreHoriz />}
-                  />
+                  <RQTooltip title="More Actions">
+                    <RQButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowSelection(false);
+                      }}
+                      size="small"
+                      type="transparent"
+                      icon={<MdOutlineMoreHoriz />}
+                    />
+                  </RQTooltip>
                 </Dropdown>
               </div>
             </Conditional>

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
@@ -60,7 +60,6 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
               size="small"
               type="transparent"
               icon={<MdAdd />}
-              title="Create new environment"
               className="sidebar-list-header-button"
               onClick={() => {
                 onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);

--- a/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/sidebar/components/sidebarListHeader/SidebarListHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Input, Tooltip } from "antd";
 import { SearchOutlined } from "@ant-design/icons";
-import { RQButton } from "lib/design-system-v2/components";
+import { RQButton, RQTooltip } from "lib/design-system-v2/components";
 import { BiSelectMultiple } from "@react-icons/all-files/bi/BiSelectMultiple";
 import { NewApiRecordDropdown, NewRecordDropdownItemType } from "../NewApiRecordDropdown/NewApiRecordDropdown";
 import { RQAPI } from "features/apiClient/types";
@@ -55,27 +55,31 @@ export const SidebarListHeader: React.FC<ListHeaderProps> = ({
 
       {listType ? (
         listType === ApiClientSidebarTabKey.ENVIRONMENTS ? (
-          <RQButton
-            size="small"
-            type="transparent"
-            icon={<MdAdd />}
-            title="Create new environment"
-            className="sidebar-list-header-button"
-            onClick={() => {
-              onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
-            }}
-          />
+          <RQTooltip title="Add New Environment">
+            <RQButton
+              size="small"
+              type="transparent"
+              icon={<MdAdd />}
+              title="Create new environment"
+              className="sidebar-list-header-button"
+              onClick={() => {
+                onNewRecordClick("api_client_sidebar_header", RQAPI.RecordType.ENVIRONMENT);
+              }}
+            />
+          </RQTooltip>
         ) : null
       ) : (
         showNewRecordAction && (
-          <NewApiRecordDropdown
-            invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
-            onSelect={(params) => {
-              onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
-            }}
-          >
-            <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
-          </NewApiRecordDropdown>
+          <RQTooltip title="New request or collection">
+            <NewApiRecordDropdown
+              invalidActions={[NewRecordDropdownItemType.ENVIRONMENT]}
+              onSelect={(params) => {
+                onNewRecordClick("api_client_sidebar_header", params.recordType, undefined, params.entryType);
+              }}
+            >
+              <RQButton size="small" type="transparent" icon={<MdAdd />} className="sidebar-list-header-button" />
+            </NewApiRecordDropdown>
+          </RQTooltip>
         )
       )}
     </div>

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/KeyValueTable/KeyValueTable.tsx
@@ -3,7 +3,7 @@ import type { TableProps } from "antd";
 import { Tooltip } from "antd";
 import { ContentListTable } from "componentsV2/ContentList";
 import { MdAdd } from "@react-icons/all-files/md/MdAdd";
-import { RQButton } from "lib/design-system-v2/components";
+import { RQButton, RQTooltip } from "lib/design-system-v2/components";
 import { KeyValueTableEditableRow, KeyValueTableEditableCell } from "./KeyValueTableRow";
 import { KeyValueTableSettingsDropdown } from "./KeyValueTableSettingsDropdown";
 import { KeyValuePair, KeyValueDataType } from "features/apiClient/types";
@@ -260,13 +260,15 @@ export const KeyValueTable: React.FC<React.PropsWithChildren<KeyValueTableProps>
           }
 
           return (
-            <RQButton
-              className="key-value-delete-btn"
-              icon={<RiDeleteBin6Line />}
-              type="transparent"
-              size="small"
-              onClick={() => handleDeletePair(record)}
-            />
+            <RQTooltip title="Delete">
+              <RQButton
+                className="key-value-delete-btn"
+                icon={<RiDeleteBin6Line />}
+                type="transparent"
+                size="small"
+                onClick={() => handleDeletePair(record)}
+              />
+            </RQTooltip>
           );
         },
       },

--- a/app/src/layouts/DashboardLayout/MenuHeader/MenuHeader.tsx
+++ b/app/src/layouts/DashboardLayout/MenuHeader/MenuHeader.tsx
@@ -5,7 +5,7 @@ import WorkspaceSelector from "./WorkspaceSelector/WorkspaceSelector";
 import DesktopAppProxyInfo from "components/sections/Navbars/NavbarRightContent/DesktopAppProxyInfo";
 import { trackHeaderClicked, trackTopbarClicked } from "modules/analytics/events/common/onboarding/header";
 import LINKS from "config/constants/sub/links";
-import { RQButton } from "lib/design-system-v2/components";
+import { RQButton, RQTooltip } from "lib/design-system-v2/components";
 import { globalActions } from "store/slices/global/slice";
 import BotIcon from "assets/icons/bot.svg?react";
 import Settings from "assets/icons/settings.svg?react";
@@ -103,11 +103,13 @@ export const MenuHeader = () => {
         </div>
 
         <div className="app-primary-header__right-section">
-          <RQButton
-            type="transparent"
-            icon={<Settings />}
-            onClick={() => redirectToSettings(navigate, window.location.pathname, "header")}
-          />
+          <RQTooltip title="Settings">
+            <RQButton
+              type="transparent"
+              icon={<Settings />}
+              onClick={() => redirectToSettings(navigate, window.location.pathname, "header")}
+            />
+          </RQTooltip>
           <HeaderUser />
         </div>
       </div>

--- a/app/src/lib/design-system-v2/components/RQBreadcrumb/RQBreadcrumb.tsx
+++ b/app/src/lib/design-system-v2/components/RQBreadcrumb/RQBreadcrumb.tsx
@@ -133,7 +133,7 @@ export const RQBreadcrumb: React.FC<Props> = ({
                     }}
                   />
                 ) : (
-                  <div key={index} className="rq-breadcrumb-record-name" title={name || placeholder}>
+                  <div key={index} className="rq-breadcrumb-record-name" title="Edit">
                     <Typography.Text className="record-name" ellipsis={true} onClick={handleRecordNameEditClick}>
                       {name || placeholder}
                     </Typography.Text>


### PR DESCRIPTION
### What changed

- Added tooltip wrappers for the API client settings icon, more-actions buttons, delete button, dock toggle, and new-tab add button.
- Updated the breadcrumb edit affordance to surface an explicit `Edit` title.
- Added a tooltip for the environment add button and the new-request/new-collection add button in the sidebar.

### Why

The issue reports missing hover labels on icon-only controls in the API client, which makes common actions harder to discover and reduces accessibility.

### How to test

- Run the API client UI and hover each affected icon:
  - Settings
  - Add new request or collection
  - Add new environment
  - Edit breadcrumb
  - More actions
  - Delete in the key-value table
  - Dock toggle in the response panel
  - New request tab add icon
- Verify the tooltip text matches the issue description.

### Scope

Small UI-only change across existing API client components.

### Demo video

Not applicable for this tooltip-only accessibility fix.

### Checklist

- [x] Kept the change limited to existing icon buttons
- [x] Preserved click handlers and behavior
- [x] Kept the change focused on tooltips only
- [x] Verified the diff with `git diff --check`

### Bounty

Open GitHub bounty issue: `https://github.com/requestly/requestly/issues/3868`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual tooltips to many interactive controls: docking toggle, tab add action, "More actions" menu button, environment/add buttons, delete action in key/value tables, and header settings.
  * Standardized breadcrumb edit tooltip to a fixed "Edit" label for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->