### PR TITLE
fix: keep request bot within viewport

### DIFF
--- a/app/src/features/requestBot/RequestBot.tsx
+++ b/app/src/features/requestBot/RequestBot.tsx
@@ -39,8 +39,8 @@ export const RequestBot: React.FC<RequestBotProps> = ({ isOpen, onClose, modelTy
   return (
     <>
       <m.div
-        initial={{ opacity: 0, right: -450 }}
-        animate={{ opacity: shouldShowBot ? 1 : 0, right: shouldShowBot ? 65 : -450 }}
+        initial={{ opacity: 0, right: "-450px" }}
+        animate={{ opacity: shouldShowBot ? 1 : 0, right: shouldShowBot ? "clamp(16px, 5vw, 65px)" : "-450px" }}
         transition={{ duration: 0.2 }}
         className="request-bot"
         style={{ pointerEvents: shouldShowBot ? "auto" : "none" }}

--- a/app/src/features/requestBot/requestBot.css
+++ b/app/src/features/requestBot/requestBot.css
@@ -5,10 +5,12 @@
 .request-bot {
   position: fixed;
   bottom: 30px;
-  right: 20px;
+  right: clamp(16px, 5vw, 65px);
   z-index: 100;
-  width: 424px;
-  height: 640px;
+  width: min(424px, calc(100vw - 32px));
+  height: min(640px, calc(100vh - 60px));
+  max-width: calc(100vw - 32px);
+  max-height: calc(100vh - 60px);
   background-color: var(--requestly-color-surface-2);
   padding: 8px;
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- keep the RequestBot panel inside the viewport on narrow or short screens
- replace the fixed opened `right: 65px` position with a responsive `clamp(...)` value
- cap the bot width and height with viewport-based `min(...)`/`max-*` constraints

## Validation
- `git diff --check`
- static inspection of the RequestBot open/closed positioning and viewport-bound CSS

Fixes #3846.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Improvements**
* RequestBot component now adapts responsively across different screen sizes with enhanced positioning and sizing behavior, improving visibility and usability on mobile and desktop devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->