### PR TITLE
feat: hide sensitive auth fields

### DIFF
--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/index.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/index.ts
@@ -12,7 +12,7 @@ export const AUTH_SELECTOR_LABELS = [
 const FORM_FIELDS_LAYOUT: Record<AuthConfigMeta.AuthWithConfig, AuthForm.FormField[]> = {
   [Authorization.Type.API_KEY]: [
     { id: "key", type: AuthForm.FIELD_TYPE.INPUT, label: "Key", placeholder: "Key" },
-    { id: "value", type: AuthForm.FIELD_TYPE.INPUT, label: "Value", placeholder: "Value" },
+    { id: "value", type: AuthForm.FIELD_TYPE.INPUT, label: "Value", placeholder: "Value", isSensitive: true },
     {
       id: "addTo",
       type: AuthForm.FIELD_TYPE.SELECT,
@@ -25,11 +25,11 @@ const FORM_FIELDS_LAYOUT: Record<AuthConfigMeta.AuthWithConfig, AuthForm.FormFie
     },
   ],
   [Authorization.Type.BEARER_TOKEN]: [
-    { id: "bearer", type: AuthForm.FIELD_TYPE.INPUT, label: "Token", placeholder: "Token" },
+    { id: "bearer", type: AuthForm.FIELD_TYPE.INPUT, label: "Token", placeholder: "Token", isSensitive: true },
   ],
   [Authorization.Type.BASIC_AUTH]: [
     { id: "username", type: AuthForm.FIELD_TYPE.INPUT, label: "Username", placeholder: "Username" },
-    { id: "password", type: AuthForm.FIELD_TYPE.INPUT, label: "Password", placeholder: "Password" },
+    { id: "password", type: AuthForm.FIELD_TYPE.INPUT, label: "Password", placeholder: "Password", isSensitive: true },
   ],
 };
 

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/types.ts
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/formStructure/types.ts
@@ -10,6 +10,7 @@ export namespace AuthForm {
     type: string;
     label: string;
     className?: string;
+    isSensitive?: boolean;
   }
   export enum FIELD_TYPE {
     INPUT = "RQ_SINGLE_LINE_EDITOR",

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/index.tsx
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/AuthorizationForm/index.tsx
@@ -1,5 +1,7 @@
 import { Select } from "antd";
 import React from "react";
+import { RiEyeLine } from "@react-icons/all-files/ri/RiEyeLine";
+import { RiEyeOffLine } from "@react-icons/all-files/ri/RiEyeOffLine";
 import { AuthForm } from "./formStructure/types";
 import { AuthConfig, AuthConfigMeta, Authorization } from "../types/AuthConfig";
 import { useAuthFormState } from "./hooks/useAuthFormState";
@@ -9,6 +11,7 @@ import InfoIcon from "components/misc/InfoIcon";
 import { Conditional } from "components/common/Conditional";
 import { INVALID_KEY_CHARACTERS } from "features/apiClient/constants";
 import { ScopedVariables, useScopedVariables } from "features/apiClient/helpers/variableResolver/variable-resolver";
+import { RQButton } from "lib/design-system-v2/components";
 
 interface AuthorizationFormProps<AuthType extends AuthConfigMeta.AuthWithConfig> {
   recordId: string;
@@ -31,15 +34,29 @@ const AuthorizationForm = <AuthType extends AuthConfigMeta.AuthWithConfig>({
   onChangeHandler,
 }: AuthorizationFormProps<AuthType>) => {
   const { formState, handleFormChange } = useAuthFormState(formType, onChangeHandler, defaultAuthValues);
+  const [revealedSensitiveFields, setRevealedSensitiveFields] = React.useState<Record<string, boolean>>({});
 
   const scopedVariables = useScopedVariables(recordId);
+  const toggleSensitiveFieldVisibility = (fieldKey: string) => {
+    setRevealedSensitiveFields((prev) => ({ ...prev, [fieldKey]: !prev[fieldKey] }));
+  };
+
   return (
     <div className="form">
       {formData.map((formField, index) => (
         <div className="field-group" key={formField.id || index}>
           <label>{formField.label}</label>
           <div className="field">
-            {generateFields(formField, index, scopedVariables, formType, handleFormChange, formState)}
+            {generateFields(
+              formField,
+              index,
+              scopedVariables,
+              formType,
+              handleFormChange,
+              formState,
+              revealedSensitiveFields,
+              toggleSensitiveFieldVisibility
+            )}
           </div>
         </div>
       ))}
@@ -53,11 +70,15 @@ function generateFields(
   variables: ScopedVariables,
   formType: Authorization.Type,
   onChangeHandler: (value: string, id: string) => void,
-  formState: Record<string, string>
+  formState: Record<string, string>,
+  revealedSensitiveFields: Record<string, boolean>,
+  toggleSensitiveFieldVisibility: (fieldKey: string) => void
 ) {
   const hasInvalidCharacter = INVALID_KEY_CHARACTERS.test(formState[field.id]);
   //this is used as on mount the formState is undefinded so added a fallback
   const isHeader = (formState.addTo || addToOptions.HEADER) === addToOptions.HEADER;
+  const sensitiveFieldKey = `${formType}-${field.id}`;
+  const isSensitiveFieldHidden = !!field.isSensitive && !revealedSensitiveFields[sensitiveFieldKey];
   /*
   TODO: Make a component for singleLineEditor error-state to avoid repetition
   */
@@ -69,16 +90,26 @@ function generateFields(
             hasInvalidCharacter && formType === Authorization.Type.API_KEY && field.id === "key" && isHeader
               ? "error-state"
               : ""
-          }`}
+          } ${field.isSensitive ? "has-visibility-toggle" : ""}`}
         >
           <SingleLineEditor
             key={`${formType}-${index}`}
-            className={field.className ?? ""}
+            className={`${field.className ?? ""} ${isSensitiveFieldHidden ? "sensitive-field-hidden" : ""}`}
             placeholder={field.placeholder}
             defaultValue={formState[field.id]}
             onChange={(value) => onChangeHandler(value, field.id)}
             variables={variables}
           />
+          <Conditional condition={!!field.isSensitive}>
+            <RQButton
+              type="transparent"
+              size="small"
+              className="sensitive-field-toggle"
+              icon={isSensitiveFieldHidden ? <RiEyeOffLine /> : <RiEyeLine />}
+              aria-label={isSensitiveFieldHidden ? "Show sensitive value" : "Hide sensitive value"}
+              onClick={() => toggleSensitiveFieldVisibility(sensitiveFieldKey)}
+            />
+          </Conditional>
           <Conditional
             condition={hasInvalidCharacter && formType === Authorization.Type.API_KEY && field.id === "key" && isHeader}
           >

--- a/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/authorizationView.scss
+++ b/app/src/features/apiClient/screens/apiClient/components/views/components/request/components/AuthorizationView/authorizationView.scss
@@ -57,6 +57,38 @@
               width: 100%;
             }
 
+            .input-container {
+              position: relative;
+              display: flex;
+              align-items: center;
+
+              .editor-popup-container {
+                width: 100%;
+              }
+
+              &.has-visibility-toggle {
+                .editor-popup-container {
+                  padding-right: var(--requestly-space-9, 32px);
+                }
+
+                .sensitive-field-hidden {
+                  .cm-line,
+                  .cm-content {
+                    -webkit-text-security: disc;
+                  }
+                }
+
+                .sensitive-field-toggle {
+                  position: absolute;
+                  right: var(--requestly-space-1, 2px);
+                  z-index: 1;
+                  height: var(--requestly-space-8, 24px);
+                  width: var(--requestly-space-8, 24px);
+                  color: var(--requestly-color-text-subtle);
+                }
+              }
+            }
+
             @media (max-width: var(--breakpoint-md)) {
               width: auto;
               flex-grow: 0;


### PR DESCRIPTION
## Summary
- mark API key values, bearer tokens, and basic auth passwords as sensitive in the API client auth form
- hide sensitive CodeMirror single-line fields by default with a show/hide toggle
- keep existing variable-aware editing behavior intact while masking only the visual text

Fixes #3725

## Validation
- Static review of the affected TypeScript/SCSS files; the requestly source tree is excluded from GitHub archives via `.gitattributes`, so this patch was prepared from upstream file contents fetched through the GitHub API.

Signed-off-by: sodalone <soda791401863@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added ability to toggle visibility of sensitive authorization credentials (API keys, bearer tokens, passwords) in the authorization form with eye icon controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/requestly/requestly/pull/4748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->