### PR TITLE
fix: re-add "issue" label to bug/feature issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: "🐛 Bug Report"
 description: "Something isn't working as expected"
 title: "[BUG] "
-labels: ["type:bug"]
+labels: ["issue", "type:bug"]
 type: Bug
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 name: "💡 Feature Request"
 description: "Request a new feature 🎉"
 title: "[Feature] "
-labels: ["type:feature"]
+labels: ["issue", "type:feature"]
 type: Feature
 body:
   - type: markdown


### PR DESCRIPTION
## Problem
No Slack alerts were received for recent GitHub issues (#4769, #4771, #4772).

The Slack issue-notification subscription only fires on issues carrying the **`issue`** label (added to filter out noise from Pull Requests). When the issue forms were redesigned, the `issue` label was dropped from both templates' `labels:` lists — so every form-created issue since then got only `type:bug` / `type:feature` and never matched the subscription filter → **no alert**.

The affected issues had to have the `issue` label added manually after the fact.

## Fix
Re-add `issue` to both issue-form templates:
- `bug-report.yml`: `["type:bug"]` → `["issue", "type:bug"]`
- `feature-request.yml`: `["type:feature"]` → `["issue", "type:feature"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bug report and feature request issue forms to apply an additional `issue` label automatically.
  * Issue submissions now receive more consistent labeling for easier tracking and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->